### PR TITLE
(DOCSP-22534): Add information about refresh token expiration

### DIFF
--- a/source/authentication.txt
+++ b/source/authentication.txt
@@ -176,7 +176,9 @@ SDKs supply the logic to manage tokens, and provide them with requests.
 
 The access token for a session expires after thirty minutes. Clients can 
 use the refresh token to retrieve a new access token and start a new 
-session. Realm SDKs manage refresh access tokens for you. You don't need 
+session. Refresh tokens expire after thirty days.
+
+Realm SDKs manage refresh access tokens for you. You don't need 
 to manage this process yourself when implementing client applications.
 
 You can invalidate a refresh token by calling the ``logout()`` method on the 

--- a/source/reference/authenticate-http-client-requests.txt
+++ b/source/reference/authenticate-http-client-requests.txt
@@ -151,7 +151,8 @@ Refresh a Client API Access Token
 Access tokens expire 30 minutes after {+service+} grants them. When an access
 token expires, you can either request another access token using the
 user's credentials or use the refresh token to request a new access
-token with including the user's credentials.
+token with including the user's credentials. Refresh tokens expire after 
+30 days.
 
 The Client API session refresh endpoint accepts a ``POST`` request that
 includes the refresh token in the ``Authorization`` header and uses the


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-22534

### Staged Changes (Requires MongoDB Corp SSO)

- [Authenticate HTTP Client Requests/Refresh a Client API Access Token](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-22534/reference/authenticate-http-client-requests/#refresh-a-client-api-access-token)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)