### PR TITLE
Add configuration details for repo

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,19 @@
+## Is there something wrong with existing docs content, or is something missing from the docs?
+<!-- something is wrong with existing content OR something is missing from the docs -->
+
+## If this is related to existing docs content, what page or pages are affected?
+<!-- links to pages -->
+
+## Is this related to the MongoDB Realm backend, or an SDK? If it is an issue with an SDK, which one?
+<!-- backend OR iOS and/or Web and/or React Native and/or Node.js and/or Android and/or .NET -->
+
+## What would you like to see in the docs that isn't already there?
+<!-- ex. example of how to do X, warning about Y, official guidance on how to deal with Z -->
+
+## If the content is technical, can you link to an example implementation?
+<!-- link to a repo, or copy/pasted code that demonstrates the issue/solution -->
+
+## Where do you feel this content belongs?
+<!-- links to pages -->
+
+## Other Comments

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Pull Request Info
+
+### Jira
+
+- https://jira.mongodb.org/browse/DOCSP-NNNNN
+
+### Staged Changes (Requires MongoDB Corp SSO)
+
+- [PAGE_NAME](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/BRANCH_NAME/)
+
+### Review Guidelines
+
+[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # docs-app-services
 
-[Your words here].
+This repository contains documentation for MongoDB App Services.
+
+## Contribute
+
+The MongoDB Documentation Project is governed by the terms of the
+`MongoDB Contributor Agreement
+<https://www.mongodb.com/legal/contributor-agreement>`_.
+
+To contribute to the documentation,
+
+- If you have not done so already, please sign the `MongoDB Contributor Agreement <https://www.mongodb.com/legal/contributor-agreement>`_.
+
+- Fork this repository on GitHub and issue a pull request.
 
 ## Report Issues
 

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -1,0 +1,59 @@
+# Reviewing Guidelines for the MongoDB Realm Documentation
+
+Realm Docs contributions typically go through two sets of reviewers:
+
+1. A **copy edit**, which focuses on structure and wording
+2. A **technical review**, which addresses code snippets and the
+   technical correctness of prose.
+
+## Technical Review
+
+Review the technical accuracy and completeness of a docs PR
+(Pull Request) and correct it if necessary.
+
+### What to Review
+
+- Code snippets
+- Technical claims, e.g. ("To create a `Foo`, use the `Bar.createFoo()` method")
+- Missing "footguns", i.e. potential pitfalls that could trip up users
+  who try to follow the documentation.
+
+### What Not to Review
+
+- Wording of sentences: while suggestions are appreciated, PRs
+  that have reached the technical review stage have already passed copy
+  editing. Copy edits are out of scope of technical reviews, unless they
+  directly relate to a technical claim.
+- Structure of the page: as with wording, structural changes are out of
+  scope and should never block approval of a technical review.
+- Any lines of the page that have not been touched in the PR,
+  unless they refer to content that has changed as a result of the PR or
+  fall within the scope of the PR's related JIRA ticket. If you do notice
+  an issue with content that's outside of the JIRA ticket's scope,
+  please mention it in the #docs-realm Slack channel or file a JIRA
+  ticket with the `DOCSP` project.
+
+## Copy Edits
+
+Review the structure, wording and flow of a docs PR and correct it if
+necessary.
+
+### What to Review
+
+- Wording
+- Page structure
+- Snooty Autobuilder build errors and warnings
+- Altered or added example app tests (if any have changed, CI should
+  automatically run)
+- Technical content from a "looks correct" perspective, since technical
+  review should address deeper concerns
+- Whether or not the PR fulfills the Acceptance Criteria described in the
+  linked JIRA ticket.
+
+### What Not to Review
+
+Very little is completely off-limits to a copy edit of a PR -- if you
+notice a technical issue, it's best to call it out early.
+However,
+copy editors should constrain their reviews to only content within the
+scope of the JIRA ticket.

--- a/snooty.toml
+++ b/snooty.toml
@@ -7,7 +7,41 @@ intersphinx = [
   "https://www.mongodb.com/docs/realm/objects.inv"
 ]
 
-# toc_landing_pages = ["/paths/to/pages/that/have/nested/content"]
+# These are the pages that open when you click on them (instead of just being containers)
+toc_landing_pages = [
+  # Cloud
+  "/cloud",
+  "/authentication",
+  "/authentication/providers",
+  "/mongodb",
+  "/graphql",
+  "/functions",
+  "/functions/mongodb",
+  "/services",
+  "/services/http",
+  "/services/twilio",
+  "/hosting",
+  "/values-and-secrets",
+  "/manage-apps/deploy",
+  "/logs",
+  "/manage-apps/configure/config",
+  "/manage-apps/configure/export-realm-app",
+  "/manage-apps/secure",
+  "/schemas",
+  "/rules",
+  "/endpoints",
+  # CLI
+  "/cli",
+  "/cli/realm-cli-accessList",
+  "/cli/realm-cli-apps",
+  "/cli/realm-cli-function",
+  "/cli/realm-cli-logs",
+  "/cli/realm-cli-schema",
+  "/cli/realm-cli-secrets",
+  "/cli/realm-cli-users",
+  # Other
+  "/studio"
+]
 
 [substitutions]
 atlas = "Atlas"


### PR DESCRIPTION
Add a handful of stuff to set up the repo like we had it for docs-realm, including:

- Issue template
- Pull request template
- REVIEWING.md
- Applicable info from the README.md
- Update the "container pages" to expand via snooty.toml