### PR TITLE
Add Makefile to enable pushless staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ stagel:
 	@ rm -rf build_scripts
  
 commit:
-		@:
+	@:
  
 local:
-		@:
+	@:
  
 clean:
 	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+#!make
+MAKEFLAGS += --silent
+ 
+# This allows us to accept extra arguments (by doing nothing when we get a job that doesn't match,
+# rather than throwing an error).
+%:
+	@:
+ 
+# $(MAKECMDGOALS) is the list of "targets" spelled out on the command line
+stagel:
+	git clone --quiet https://github.com/mongodb/snooty-scripts.git build_scripts
+	@ cd build_scripts && npm install
+	@ source ~/.config/.snootyenv && node build_scripts/app.js $(filter-out $@,$(MAKECMDGOALS))
+	@ rm -rf build_scripts
+ 
+commit:
+		@:
+ 
+local:
+		@:
+ 
+clean:
+	rm -rf build


### PR DESCRIPTION
Per the instructions on [how to set up Pushless Staging](https://wiki.corp.mongodb.com/x/EZipBg), this Makefile will enable us to use pushless staging with the app-services repo.