### PR TITLE
GraphQL Updates

### DIFF
--- a/source/graphql.txt
+++ b/source/graphql.txt
@@ -106,6 +106,13 @@ collection name instead.
 For more information on how to expose a collection and name its data
 type, see :ref:`Expose Data in a Collection <graphql-expose-data>`.
 
+.. note::
+   
+   GraphQL mutation and custom resolver requests use MongoDB
+   transactions to ensure correctness across multiple database
+   operations. If any operation in a request fails, then the entire
+   transaction fails and no operations are committed to the database.
+
 Queries
 ~~~~~~~
 

--- a/source/graphql/types-and-resolvers.txt
+++ b/source/graphql/types-and-resolvers.txt
@@ -703,12 +703,9 @@ accepts the following parameters:
    
    * - ``limit``
      - Int
-     - Optional. The maximum number of documents to include in the query
-       result set. If the query matches more than the set limit then it
-       only returns a subset of matched documents.
-       
-       If you do not specify a ``limit`` argument then the query
-       operation returns all matching documents.
+     - Optional. Default ``100``. The maximum number of documents to
+       include in the query result set. If the query matches more than
+       the set limit then it only returns a subset of matched documents.
    
    * - ``sortBy``
      - :ref:`SortByInput <input-type-sortby>`

--- a/source/graphql/types-and-resolvers.txt
+++ b/source/graphql/types-and-resolvers.txt
@@ -156,6 +156,19 @@ GraphQL types that they map to:
    * - ``timestamp``
      - ``DateTime``
 
+.. note:: 
+   
+   JSON supports two types that represent "no value": ``undefined`` and
+   ``null``. The GraphQL spec supports ``null`` but not ``undefined``,
+   so your app converts ``undefined`` values in the following way:
+   
+   - If a document field is explicitly set to ``undefined`` then the
+     corresponding GraphQL type is an empty object, i.e. ``{}``.
+   
+   - If the field name is not defined for the document at all, or if the
+     value is explicitly set to ``null``, then the corresponding GraphQL
+     type is ``null``.
+
 .. _graphql-input-types:
 
 Input Types

--- a/source/graphql/types-and-resolvers.txt
+++ b/source/graphql/types-and-resolvers.txt
@@ -557,8 +557,12 @@ RelationInput
 
 A ``RelationInput`` defines a new set of related documents for a relationship
 field in the mutated document. You can reference documents that already exist in
-the related collection with the ``link`` field and insert new documents into the
+the related collection with the ``link`` field or insert new documents into the
 related collection with the ``create`` field.
+
+You cannot use both ``link`` and ``create`` at the same time. If both
+are specified, the ``create`` operation takes precedence and the
+``link`` is ignored.
 
 .. code-block:: graphql
    


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-11203): GraphQL RelationInput cannot simultaneously create and link
- (DOCSP-19374): GraphQL FindMany limit has a default of 100
- (DOCSP-22884): GraphQL mutations and custom resolvers use transactions
- (DOCSP-21985): GraphQL represents undefined as an empty object

### Staged Changes (Requires MongoDB Corp SSO)

- [GraphQL API](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/graphql/graphql)
- [GraphQL Types, Resolvers, & Operators](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/graphql/graphql/types-and-resolvers/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
