### PR TITLE
Remove beta/preview from Flutter and Kotlin SDK names

### DIFF
--- a/source/sync/learn/overview.txt
+++ b/source/sync/learn/overview.txt
@@ -187,8 +187,8 @@ check out the SDK docs:
 - :ref:`.NET SDK <dotnet-intro>`
 - :ref:`Node.js SDK <node-intro>`
 - :ref:`React Native SDK <react-native-intro>`
-- :ref:`Kotlin SDK (Alpha) <kotlin-intro>`
-- :ref:`Flutter SDK (Preview) <flutter-intro>`
+- :ref:`Kotlin SDK <kotlin-intro>`
+- :ref:`Flutter SDK <flutter-intro>`
 
 .. note::
 


### PR DESCRIPTION
## Pull Request Info

Remove beta/preview from Flutter and Kotlin SDK names. not necessary here and prone to get out of date, as the labels for both Flutter and Kotlin currently are. 

### Jira

n/a

### Staged Changes (Requires MongoDB Corp SSO)



### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
