### PR TITLE
Update refresh token expiration length based on backend auth code

### DIFF
--- a/source/authentication.txt
+++ b/source/authentication.txt
@@ -176,10 +176,12 @@ SDKs supply the logic to manage tokens, and provide them with requests.
 
 The access token for a session expires after thirty minutes. Clients can 
 use the refresh token to retrieve a new access token and start a new 
-session. Refresh tokens expire after thirty days.
+session.
 
 Realm SDKs manage refresh access tokens for you. You don't need 
 to manage this process yourself when implementing client applications.
+
+.. include:: /includes/refresh-token-expiration.rst
 
 You can invalidate a refresh token by calling the ``logout()`` method on the 
 client, which does two things:

--- a/source/includes/refresh-token-expiration.rst
+++ b/source/includes/refresh-token-expiration.rst
@@ -1,0 +1,5 @@
+The default expiration for refresh tokens is 60 days. :ref:`Anonymous user 
+<anonymous-authentication>` refresh tokens effectively do not expire, 
+although inactive users may be deleted after a period of inactivity. 
+Custom JWT refresh tokens expire based on the expiration date provided 
+in the :ref:`JWT payload <custom-jwt-authentication-jwt-payload>`.

--- a/source/reference/authenticate-http-client-requests.txt
+++ b/source/reference/authenticate-http-client-requests.txt
@@ -151,8 +151,9 @@ Refresh a Client API Access Token
 Access tokens expire 30 minutes after {+service+} grants them. When an access
 token expires, you can either request another access token using the
 user's credentials or use the refresh token to request a new access
-token with including the user's credentials. Refresh tokens expire after 
-30 days.
+token with including the user's credentials.
+
+.. include:: /includes/refresh-token-expiration.rst
 
 The Client API session refresh endpoint accepts a ``POST`` request that
 includes the refresh token in the ``Authorization`` header and uses the


### PR DESCRIPTION
## Pull Request Info

A few weeks ago, I added refresh token expiration length to the docs based on this Jira ticket: https://jira.mongodb.org/browse/DOCSP-22534

This ticket has been re-opened, because the expiration length (30 days) I previously added to the docs was incorrect. After some spelunking in the backend auth code, I've updated the docs based on what I found.

### Staged Changes (Requires MongoDB Corp SSO)

- [Authentication/User Sessions](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/update-inaccurate-refresh-token-length/authentication/#user-sessions)
- [Authenticate HTTP Client Requests/Refresh a Client API Access Token](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/update-inaccurate-refresh-token-length/reference/authenticate-http-client-requests/#refresh-a-client-api-access-token)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
