### PR TITLE
(DOCSP-23041): Functions find example wrongly shows insertMany

### DIFF
--- a/source/functions/mongodb/read.txt
+++ b/source/functions/mongodb/read.txt
@@ -58,7 +58,7 @@ The following :ref:`function <functions>` snippet finds all documents in
 the ``items`` collection that have at least one review and returns them
 sorted by ``name`` with the ``_id`` field omitted:
 
-.. include:: /functions/mongodb/api/snippets/insertMany.rst
+.. include:: /functions/mongodb/api/snippets/findMany.rst
 
 .. _mongodb-count-documents:
 


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-23041): Functions find example wrongly shows insertMany

### Staged Changes (Requires MongoDB Corp SSO)

- [Read Data > Find One or More Documents](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/fix-example/functions/mongodb/read/#find-one-or-more-documents--find---)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
