### PR TITLE
Fix monospace method titles in MongoDB API spec

### DIFF
--- a/source/functions/javascript-support.txt
+++ b/source/functions/javascript-support.txt
@@ -218,8 +218,8 @@ Partially Supported Modules
 
 .. _partially-supported-module-dgram:
 
-dgram``
-^^^^^^^
+``dgram``
+^^^^^^^^^
 
 {+service-short+} supports the following ``dgram`` APIs:
 
@@ -242,8 +242,8 @@ dgram``
 
 .. _partially-supported-module-dns:
 
-dns
-^^^
+``dns``
+^^^^^^^
 
 {+service-short+} supports the :nodejs:`dns
 <docs/v10.18.1/api/dns.html>` module with the following **exceptions**:
@@ -253,8 +253,8 @@ dns
 
 .. _partially-supported-module-fs:
 
-fs
-^^
+``fs``
+^^^^^^
 
 {+service-short+} supports the following ``fs`` APIs:
 
@@ -266,8 +266,8 @@ fs
 
 .. _partially-supported-module-http:
 
-http``, ``http/2`` and ``https``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``http``, ``http/2`` and ``https``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 {+service-short+} supports all of the :nodejs:`http <docs/v10.18.1/api/http.html>` 
 and :nodejs:`https <docs/v10.18.1/api/https.html>` APIs **except** 
@@ -279,8 +279,8 @@ Similarly, {+service-short+} supports only the client-side APIs of
 
 .. _partially-supported-module-process:
 
-process``
-^^^^^^^^^
+``process``
+^^^^^^^^^^^
 
 {+service-short+} supports the following ``process`` APIs:
 
@@ -291,8 +291,8 @@ process``
 
 .. _partially-supported-module-util:
 
-util``
-^^^^^^
+``util``
+^^^^^^^^
 
 {+service-short+} supports the :nodejs:`util <docs/v10.18.1/api/util.html>` module with the following **exceptions**:
 
@@ -300,8 +300,8 @@ util``
 - {+service-short+} does **not** support :nodejs:`util.TextDecoder <docs/v10.18.1/api/util.html#util_class_util_textdecoder>` 
 
 
-crypto``
-^^^^^^^^
+``crypto``
+^^^^^^^^^^
 
 {+service-short+} supports the :nodejs:`crypto <api/crypto.html>` module with
 the following **exceptions**:

--- a/source/functions/mongodb/api.txt
+++ b/source/functions/mongodb/api.txt
@@ -14,8 +14,8 @@ MongoDB API Reference
 
 .. _mongodb-db:
 
-mongodb.db()``
---------------
+``mongodb.db()``
+----------------
 
 .. class:: hidden
    
@@ -58,8 +58,8 @@ See :method:`database.collection()`
 
 .. _mongodb-db-collection:
 
-database.collection()``
------------------------
+``database.collection()``
+-------------------------
 
 .. class:: hidden
    
@@ -102,8 +102,8 @@ allows you to query the specified collection.
 
 .. _mongodb-collection-find:
 
-collection.find()``
--------------------
+``collection.find()``
+---------------------
 
 .. class:: hidden
    
@@ -250,8 +250,8 @@ methods:
 
 .. _mongodb-collection-findOne:
 
-collection.findOne()``
-----------------------
+``collection.findOne()``
+------------------------
 
 .. class:: hidden
    
@@ -316,8 +316,8 @@ match the specified query, the promise resolves to ``null``.
 
 .. _mongodb-collection-findOneAndUpdate:
 
-collection.findOneAndUpdate()``
--------------------------------
+``collection.findOneAndUpdate()``
+---------------------------------
 
 .. class:: hidden
    
@@ -397,8 +397,8 @@ specified query, the promise resolves to ``null``.
 
 .. _mongodb-collection-findOneAndReplace:
 
-collection.findOneAndReplace()``
---------------------------------
+``collection.findOneAndReplace()``
+----------------------------------
 
 .. class:: hidden
    
@@ -478,8 +478,8 @@ specified query, the promise resolves to ``null``.
 
 .. _mongodb-collection-findOneAndDelete:
 
-collection.findOneAndDelete()``
--------------------------------
+``collection.findOneAndDelete()``
+---------------------------------
 
 .. class:: hidden
    
@@ -544,8 +544,8 @@ specified query, the promise resolves to ``null``.
 
 .. _mongodb-collection-insertOne:
 
-collection.insertOne()``
-------------------------
+``collection.insertOne()``
+--------------------------
 
 .. class:: hidden
    
@@ -601,8 +601,8 @@ resolves to a document that describes the insert operation.
 
 .. _mongodb-collection-insertMany:
 
-collection.insertMany()``
--------------------------
+``collection.insertMany()``
+---------------------------
 
 .. class:: hidden
    
@@ -659,8 +659,8 @@ resolves to a document that describes the insert operation.
 
 .. _mongodb-collection-updateOne:
 
-collection.updateOne()``
-------------------------
+``collection.updateOne()``
+--------------------------
 
 .. class:: hidden
    
@@ -747,8 +747,8 @@ resolves to a document that describes the update operation.
 
 .. _mongodb-collection-updateMany:
 
-collection.updateMany()``
--------------------------
+``collection.updateMany()``
+---------------------------
 
 .. class:: hidden
    
@@ -835,8 +835,8 @@ resolves to a document that describes the update operation.
 
 .. _mongodb-collection-deleteOne:
 
-collection.deleteOne()``
-------------------------
+``collection.deleteOne()``
+--------------------------
 
 .. class:: hidden
    
@@ -902,8 +902,8 @@ resolves to a document that describes the delete operation.
 
 .. _mongodb-collection-deleteMany:
 
-collection.deleteMany()``
--------------------------
+``collection.deleteMany()``
+---------------------------
 
 .. class:: hidden
    
@@ -969,8 +969,8 @@ resolves to a document that describes the delete operation.
 
 .. _mongodb-collection-aggregate:
 
-collection.aggregate()``
-------------------------
+``collection.aggregate()``
+--------------------------
 
 .. class:: hidden
    
@@ -1072,8 +1072,8 @@ in the aggregation result set with the following methods:
 
 .. _mongodb-collection-count:
 
-collection.count()``
---------------------
+``collection.count()``
+----------------------
 
 .. class:: hidden
    
@@ -1146,8 +1146,8 @@ that match the query.
 
 .. _mongodb-collection-distinct:
 
-collection.distinct()``
------------------------
+``collection.distinct()``
+-------------------------
 
 .. class:: hidden
    
@@ -1219,8 +1219,8 @@ array of distinct values.
 
 .. _mongodb-collection-bulkWrite:
 
-collection.bulkWrite()``
-------------------------
+``collection.bulkWrite()``
+--------------------------
 
 .. class:: hidden
    

--- a/source/services/aws.txt
+++ b/source/services/aws.txt
@@ -158,8 +158,8 @@ properties.
 Example
 ~~~~~~~
 
-S3 PutObject``
-^^^^^^^^^^^^^^
+``S3 PutObject``
+^^^^^^^^^^^^^^^^
 
 The ``S3`` service includes the :aws-go:`PutObject <s3/#S3.PutObject>`
 action, which takes an input object of type of :aws-go:`PutObjectInput
@@ -194,8 +194,8 @@ This can also be expressed as the following JSON:
    }
 
 
-S3 GetObject``
-^^^^^^^^^^^^^^
+``S3 GetObject``
+^^^^^^^^^^^^^^^^
 
 The ``S3`` service includes the :aws-go:`GetObject <s3/#S3.GetObject>`
 action, which takes an input object of type of :aws-go:`GetObjectInput
@@ -244,8 +244,8 @@ service has already been created.
 S3 Service
 ^^^^^^^^^^
 
-S3 PutObject``
-``````````````
+``S3 PutObject``
+````````````````
 
 .. code-block:: javascript
 
@@ -260,8 +260,8 @@ S3 PutObject``
      return result;
    };
 
-S3 GetObject``
-``````````````
+``S3 GetObject``
+````````````````
 
 .. code-block:: javascript
 
@@ -276,8 +276,8 @@ S3 GetObject``
       return result;
    };
 
-S3 PresignURL``
-```````````````
+``S3 PresignURL``
+`````````````````
 
 .. code-block:: javascript
    


### PR DESCRIPTION
## Pull Request Info

### Jira

- Noticed this issue in a separate PR. Looks like these got butchered in https://github.com/mongodb/docs-app-services/commit/c2a0cbe4396ae4f5fb858d5686fc6700b8480abe
- Guess [which jerk](https://github.com/mongodb/docs-app-services/pull/54#pullrequestreview-1001880870) approved THAT PR?

### Staged Changes (Requires MongoDB Corp SSO)

- [MongoDB API](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/fix-monospace-method-titles/functions/mongodb/api/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
