### PR TITLE
(DOCS-15429): Fixed typo on Database Triggers page

### DIFF
--- a/source/triggers/database-triggers.txt
+++ b/source/triggers/database-triggers.txt
@@ -457,7 +457,7 @@ limit the number of fields that the Trigger processes by using a
   When using Triggers, a projection expression is inclusive *only*. 
   Project does not support mixing inclusions and exclusions.
   The project expression must be inclusive because Triggers require you 
-  to include ``operation_type``. 
+  to include ``operationType``. 
   
   If you want to exclude a single field, the projection expression must 
   include every field *except* the one you want to exclude.


### PR DESCRIPTION
## Pull Request Info

Updated note in the section "Use Project Expressions to Reduce Input Data Size", so that what was previously written as "operation_type" is updated to read as operationType, matching the example right below it where the field has to be in camel case.

### Jira

- https://jira.mongodb.org/browse/DOCS-15429

### Staged Changes (Requires MongoDB Corp SSO)

- [Database Triggers](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCS-15429/triggers/database-triggers/#use-project-expressions-to-reduce-input-data-size/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
