### PR TITLE
(DOCSP-23087): Add Flex Sync Template Apps to Template Apps Page

### DIFF
--- a/source/template-apps.txt
+++ b/source/template-apps.txt
@@ -37,6 +37,10 @@ Template Apps Available
      - ``triggers``
      - Event-driven :ref:`Database Trigger <database-trigger>` template to update a view in a separate collection.
 
+   * - Flutter + Realm Flutter SDK
+     - ``flutter.todo.flex``
+     - Cross-platform applixation for Android, iOS, Windows and MacOS built with the :ref: `Realm Flutter SDK <flutter-intro>`.
+
    * - React.JS + {+realm-web+} Boilerplate
      - ``web.mql.todo``
      - Hosted Todo web app using the :ref:`{+realm-web+} SDK <web-intro>`.
@@ -45,25 +49,41 @@ Template Apps Available
      - ``web.graphql.todo``
      - Hosted Todo web app using the :ref:`GraphQL API <graphql-api>`
 
-   * - Kotlin + {+sync+} Starter
-     - ``android.kotlin.todo``
-     - Android app written in Kotlin using the :ref:`Realm Java SDK <java-intro>` to sync data to {+service-short+}'s server.
+   * - Kotlin + {+sync+} Starter (Flexible Sync)
+     - ``android.kotlin.todo.flex``
+     - Android app written in Kotlin using the :ref:`Realm Java SDK <java-intro>` to sync data to {+service-short+}'s server. Uses Flexible Sync.
 
-   * - SwiftUI + {+sync+} Starter
+   * - Kotlin + {+sync+} Starter (Partition-Based Sync)
+     - ``android.kotlin.todo``
+     - Android app written in Kotlin using the :ref:`Realm Java SDK <java-intro>` to sync data to {+service-short+}'s server. Uses Partition-Based-Sync.
+
+   * - SwiftUI + {+sync+} Starter (Flexible Sync)
+     - ``swiftui.todo.flex``
+     - iOS app using SwiftUI and the :ref:`Realm Swift SDK <ios-intro>` to sync data to {+service-short+}'s server. Uses Flexible Sync.
+
+   * - SwiftUI + {+sync+} Starter (Partition-Based-Sync)
      - ``swiftui.todo``
-     - iOS app using SwiftUI and the :ref:`Realm Swift SDK <ios-intro>` to sync data to {+service-short+}'s server.
+     - iOS app using SwiftUI and the :ref:`Realm Swift SDK <ios-intro>` to sync data to {+service-short+}'s server. Uses Partition-Based-Sync.
 
    * - Swift + {+sync+} Starter
      - ``ios.swift.todo``
      - iOS app using UIKit and the :ref:`Realm Swift SDK <ios-intro>` to sync data to {+service-short+}'s server.
 
-   * - React Native + {+sync+} Starter
-     - ``react-native.todo``
-     - Cross-platform mobile app using the :ref:`Realm JS SDK <react-native-intro>` to sync data to {+service-short+}'s server.
+   * - React Native + {+sync+} Starter (Flexible Sync)
+     - ``react-native.todo.flex``
+     - Cross-platform mobile app using the :ref:`Realm JS SDK <react-native-intro>` to sync data to {+service-short+}'s server. Uses Flexible Sync.
 
-   * - Xamarin + {+sync+} Starter
+   * - React Native + {+sync+} Starter (Partition-Based-Sync) 
+     - ``react-native.todo``
+     - Cross-platform mobile app using the :ref:`Realm JS SDK <react-native-intro>` to sync data to {+service-short+}'s server. Uses Partition-Based-Sync.
+
+   * - Xamarin + {+sync+} Starter (Flexible Sync)
+     - ``xamarin.todo.flex``
+     - Cross-platform mobile app using the :ref:`Realm C# SDK <dotnet-intro>` to sync data to {+service-short+}'s server. Uses Flexible Sync.
+
+   * - Xamarin + {+sync+} Starter (Partition-Based-Sync) 
      - ``xamarin.todo``
-     - Cross-platform mobile app using the :ref:`Realm C# SDK <dotnet-intro>` to sync data to {+service-short+}'s server.
+     - Cross-platform mobile app using the :ref:`Realm C# SDK <dotnet-intro>` to sync data to {+service-short+}'s server. Uses Partition-Based-Sync.
 
 Create a Template App
 ---------------------


### PR DESCRIPTION
## Pull Request Info

Added the new Flexible Sync template apps to the Template Apps page, and updated the details of the existing apps to specify that they work with PBS.

### Jira

- https://jira.mongodb.org/browse/DOCSP-23807

### Staged Changes (Requires MongoDB Corp SSO)

- [Template Apps](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-23087/template-apps/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
