### PR TITLE
(DOCSP-23435): Reserved File Names Warning

### DIFF
--- a/source/manage-apps/configure/config.txt
+++ b/source/manage-apps/configure/config.txt
@@ -44,7 +44,7 @@ using structured JSON configuration and JavaScript source code files.
    you to avoid using for your own purposes: ``stitch.json``, ``config.json``, 
    ``realm_config.json``, and ``app_config.json``. Files with these names
    conflict with pre-made files of the same name in their app structure's file
-   system. As such, using these names for files may raise CLI errors.
+   system. Using these file names throws an error when you import the app using the CLI.
    
 
 You'll work directly with configuration files if you prefer to develop and

--- a/source/manage-apps/configure/config.txt
+++ b/source/manage-apps/configure/config.txt
@@ -41,10 +41,12 @@ using structured JSON configuration and JavaScript source code files.
 .. important:: Reserved File Names
    
    You can include arbitrarily named files in your realm app config, with a few exceptions.
-   The following file names should not be used: ``stitch.json``, ``config.json``, 
-   ``realm_config.json``, and ``app_config.json``. Files with these names
-   conflict with pre-made files of the same name in their app structure's file
-   system. Using these file names throws an error when you import the app using the CLI.
+   Note the following names: ``stitch.json``, ``config.json``, 
+   ``realm_config.json``, and ``app_config.json``. These names are reserved specific 
+   files used to define and configure specific components in your app. As such, files 
+   of these names must conform to a specific schema for its component type. 
+   Using these file names when the file's content fails to conform to that schema
+   will throw an error when you import the app using the CLI.
    
 You'll work directly with configuration files if you prefer to develop and
 :ref:`deploy <application-deployment>` locally instead of through the {+ui+}.

--- a/source/manage-apps/configure/config.txt
+++ b/source/manage-apps/configure/config.txt
@@ -43,7 +43,7 @@ using structured JSON configuration and JavaScript source code files.
    You can include arbitrarily named files in your realm app config, with a few exceptions.
    Note the following names: ``stitch.json``, ``config.json``, 
    ``realm_config.json``, and ``app_config.json``. These names are reserved for specific 
-   files used to define and configure specific components in your app. As such, files 
+   files used to define and configure components in your App. Files 
    of these names must conform to a specific schema for its component type. 
    Using these file names when the file's content fails to conform to that schema
    will throw an error when you import the app using the CLI.

--- a/source/manage-apps/configure/config.txt
+++ b/source/manage-apps/configure/config.txt
@@ -46,7 +46,7 @@ using structured JSON configuration and JavaScript source code files.
    files used to define and configure components in your App. Files 
    with these names must conform to a specific schema for its component type. 
    Using these file names when the file's content fails to conform to that schema
-   will throw an error when you import the app using the CLI.
+  throws an error when you import the app using the CLI.
    
 You'll work directly with configuration files if you prefer to develop and
 :ref:`deploy <application-deployment>` locally instead of through the {+ui+}.

--- a/source/manage-apps/configure/config.txt
+++ b/source/manage-apps/configure/config.txt
@@ -41,10 +41,9 @@ using structured JSON configuration and JavaScript source code files.
 .. important:: Reserved File Names
    
    You can include arbitrarily named files in your realm app config, with a few exceptions.
-   Note the following names: ``stitch.json``, ``config.json``, 
-   ``realm_config.json``, and ``app_config.json``. These names are reserved for specific 
-   files used to define and configure components in your App. Files 
-   with these names must conform to a specific schema for its component type. 
+   The following filenames are used to define and configure components in your App:
+   ``stitch.json``, ``config.json``, ``realm_config.json``, and ``app_config.json``.
+   Files with these names must conform to a specific schema for its component type. 
    Using these file names when the file's content fails to conform to that schema
   throws an error when you import the app using the CLI.
    

--- a/source/manage-apps/configure/config.txt
+++ b/source/manage-apps/configure/config.txt
@@ -45,7 +45,7 @@ using structured JSON configuration and JavaScript source code files.
    ``stitch.json``, ``config.json``, ``realm_config.json``, and ``app_config.json``.
    Files with these names must conform to a specific schema for their component type. 
    Using these file names when the file's content fails to conform to that schema
-  throws an error when you import the app using the CLI.
+   throws an error when you import the app using the CLI.
    
    Refer to this section for reference information about configuring these files.
    

--- a/source/manage-apps/configure/config.txt
+++ b/source/manage-apps/configure/config.txt
@@ -46,7 +46,6 @@ using structured JSON configuration and JavaScript source code files.
    conflict with pre-made files of the same name in their app structure's file
    system. Using these file names throws an error when you import the app using the CLI.
    
-
 You'll work directly with configuration files if you prefer to develop and
 :ref:`deploy <application-deployment>` locally instead of through the {+ui+}.
 

--- a/source/manage-apps/configure/config.txt
+++ b/source/manage-apps/configure/config.txt
@@ -42,7 +42,7 @@ using structured JSON configuration and JavaScript source code files.
    
    From a CLI perspective, there are a few special/reserved file names we advise
    you to avoid using for your own purposes: ``stitch.json``, ``config.json``, 
-   ``realm_config.json``, and ``app_config.json``. Files with these names may
+   ``realm_config.json``, and ``app_config.json``. Files with these names
    conflict with pre-made files of the same name in their app structure's file
    system. As such, using these names for files may raise CLI errors.
    

--- a/source/manage-apps/configure/config.txt
+++ b/source/manage-apps/configure/config.txt
@@ -38,6 +38,15 @@ using structured JSON configuration and JavaScript source code files.
 - ``.js`` files define serverless application logic used in functions, triggers,
   HTTPS endpoints, and custom resolvers.
 
+.. important:: Reserved File Names
+   
+   From a CLI perspective, there are a few special/reserved file names we advise
+   you to avoid using for your own purposes: ``stitch.json``, ``config.json``, 
+   ``realm_config.json``, and ``app_config.json``. Files with these names may
+   conflict with pre-made files of the same name in their app structure's file
+   system. As such, using these names for files may raise CLI errors.
+   
+
 You'll work directly with configuration files if you prefer to develop and
 :ref:`deploy <application-deployment>` locally instead of through the {+ui+}.
 

--- a/source/manage-apps/configure/config.txt
+++ b/source/manage-apps/configure/config.txt
@@ -42,7 +42,7 @@ using structured JSON configuration and JavaScript source code files.
    
    You can include arbitrarily named files in your realm app config, with a few exceptions.
    Note the following names: ``stitch.json``, ``config.json``, 
-   ``realm_config.json``, and ``app_config.json``. These names are reserved specific 
+   ``realm_config.json``, and ``app_config.json``. These names are reserved for specific 
    files used to define and configure specific components in your app. As such, files 
    of these names must conform to a specific schema for its component type. 
    Using these file names when the file's content fails to conform to that schema

--- a/source/manage-apps/configure/config.txt
+++ b/source/manage-apps/configure/config.txt
@@ -43,7 +43,7 @@ using structured JSON configuration and JavaScript source code files.
    You can include arbitrarily named files in your realm app config, with a few exceptions.
    The following filenames are used to define and configure components in your App:
    ``stitch.json``, ``config.json``, ``realm_config.json``, and ``app_config.json``.
-   Files with these names must conform to a specific schema for its component type. 
+   Files with these names must conform to a specific schema for their component type. 
    Using these file names when the file's content fails to conform to that schema
   throws an error when you import the app using the CLI.
    

--- a/source/manage-apps/configure/config.txt
+++ b/source/manage-apps/configure/config.txt
@@ -47,6 +47,8 @@ using structured JSON configuration and JavaScript source code files.
    Using these file names when the file's content fails to conform to that schema
   throws an error when you import the app using the CLI.
    
+   Refer to this section for reference information about configuring these files.
+   
 You'll work directly with configuration files if you prefer to develop and
 :ref:`deploy <application-deployment>` locally instead of through the {+ui+}.
 

--- a/source/manage-apps/configure/config.txt
+++ b/source/manage-apps/configure/config.txt
@@ -44,7 +44,7 @@ using structured JSON configuration and JavaScript source code files.
    Note the following names: ``stitch.json``, ``config.json``, 
    ``realm_config.json``, and ``app_config.json``. These names are reserved for specific 
    files used to define and configure components in your App. Files 
-   of these names must conform to a specific schema for its component type. 
+   with these names must conform to a specific schema for its component type. 
    Using these file names when the file's content fails to conform to that schema
    will throw an error when you import the app using the CLI.
    

--- a/source/manage-apps/configure/config.txt
+++ b/source/manage-apps/configure/config.txt
@@ -40,8 +40,8 @@ using structured JSON configuration and JavaScript source code files.
 
 .. important:: Reserved File Names
    
-   From a CLI perspective, there are a few special/reserved file names we advise
-   you to avoid using for your own purposes: ``stitch.json``, ``config.json``, 
+   You can include arbitrarily named files in your realm app config, with a few exceptions.
+   The following file names should not be used: ``stitch.json``, ``config.json``, 
    ``realm_config.json``, and ``app_config.json``. Files with these names
    conflict with pre-made files of the same name in their app structure's file
    system. Using these file names throws an error when you import the app using the CLI.


### PR DESCRIPTION
## Pull Request Info

Added a note/section to the CLI docs landing page to warn for reserved file names users shouldn't use. DRAFT.

### Jira

- https://jira.mongodb.org/browse/DOCSP-23435

### Staged Changes (Requires MongoDB Corp SSO)

- [App Configuration](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-23435/manage-apps/configure/config/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
