### PR TITLE
Move Admin API up in sidebar

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -26,7 +26,7 @@
    Logs </logs>
    Activity Feed & Alerts </alerts>
    {+cli+} </cli>
-   {+service-short+} Administration API </admin/api/v3>
+   {+service-short+} Admin API </admin/api/v3>
    Reference </reference>
    Release Notes </release-notes>
    {+client-sdks+} <https://mongodb.com/docs/realm>

--- a/source/index.txt
+++ b/source/index.txt
@@ -26,6 +26,7 @@
    Logs </logs>
    Activity Feed & Alerts </alerts>
    {+cli+} </cli>
+   {+service-short+} Administration API </admin/api/v3>
    Reference </reference>
    Release Notes </release-notes>
    {+client-sdks+} <https://mongodb.com/docs/realm>

--- a/source/reference.txt
+++ b/source/reference.txt
@@ -8,7 +8,6 @@ Reference
    
    Billing </billing>
    Find Your Project or App ID </reference/find-your-project-or-app-id>
-   {+service-short+} Administration API </admin/api/v3>
    Authenticate HTTP Client Requests </reference/authenticate-http-client-requests>
    Known Issues & Workarounds </reference/issues-and-workarounds>
    Third-Party Licenses </reference/third-party-licenses>


### PR DESCRIPTION
move admin api from reference folder in sidebar to top level. i think this is an important and well document feature worth not hiding in the reference folder

## Pull Request Info

### Jira

- n/a

### Staged Changes (Requires MongoDB Corp SSO)

- [see sidebar, toward bottom](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/admin_api_up_in_sidebar/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
