### PR TITLE
(DOCSP-23473): Updated Severless Limitations to Include Incompatibility with Watch-for-Changes

### DIFF
--- a/source/mongodb/limitations-serverless-instances.rst
+++ b/source/mongodb/limitations-serverless-instances.rst
@@ -7,4 +7,4 @@ currently support change streams, so the following features are limited:
 
 - You cannot use a serverless instance as your app's :ref:`synced <sync>` cluster.
 
-- You cannot watch collections for changes on a serverless instance.
+- You cannot watch collections for changes data sources that are serverless {+atlas+} instances.

--- a/source/mongodb/limitations-serverless-instances.rst
+++ b/source/mongodb/limitations-serverless-instances.rst
@@ -6,3 +6,5 @@ currently support change streams, so the following features are limited:
 - You cannot create a :ref:`database trigger <database-trigger>` on a serverless instance.
 
 - You cannot use a serverless instance as your app's :ref:`synced <sync>` cluster.
+
+- You cannot watch collections for changes on a serverless instance.


### PR DESCRIPTION
## Pull Request Info

Updated the section of "MongoDB Data Sources" which lists some limitations of using serverless as a data source because of the lack of change streams to also mention that watching collections is  unavailable.

### Jira

- https://jira.mongodb.org/browse/DOCSP-23473

### Staged Changes (Requires MongoDB Corp SSO)

- [MongoDB Data Sources](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-23473/mongodb/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
