### PR TITLE
(DOCSP-23637): GraphQL naming/IA refresh

### DIFF
--- a/source/graphql.txt
+++ b/source/graphql.txt
@@ -14,31 +14,19 @@ GraphQL API
 
 .. toctree::
    :titlesonly:
-   :caption: Configure GraphQL
    :hidden:
-   
+
    Expose Data in a Collection </graphql/expose-data>
-   Define a Custom Resolver </graphql/custom-resolvers>
-
-.. toctree::
-   :titlesonly:
-   :caption: Use GraphQL
-   :hidden:
-   
    Authenticate GraphQL Requests </graphql/authenticate>
-   Run GraphQL Operations from a CLI </graphql/cli>
-
-.. toctree::
-   :titlesonly:
-   :caption: Reference
-   :hidden:
-   
    GraphQL Types, Resolvers, and Operators </graphql/types-and-resolvers>
+   Define a Custom Resolver </graphql/custom-resolvers>
+   Connect with Apollo Client (React) <https://www.mongodb.com/docs/realm/web/graphql-apollo-react/>
+   Run GraphQL Operations from a CLI </graphql/cli>
 
 Overview
 --------
 
-The {+service+} :graphql:`GraphQL <>` API allows client applications to access
+The Atlas :graphql:`GraphQL <>` API allows client applications to access
 data stored in a linked {+atlas+} cluster using any standard GraphQL client.
 
 {+service-short+} automatically creates GraphQL types for every linked
@@ -47,7 +35,7 @@ collection that has a defined :ref:`schema <schemas>` and evaluates
 To learn how to make data available through the GraphQL API,
 see :ref:`Expose Data in a Collection <graphql-expose-data>`.
 
-To learn about the generated types and operations that you can use with the {+service-short+}
+To learn about the generated types and operations that you can use with the Atlas
 GraphQL API, see :ref:`GraphQL Types & Resolvers <graphql-types-and-resolvers>`.
 
 To extend the generated GraphQL API's functionality with custom queries and mutations,

--- a/source/graphql/authenticate.txt
+++ b/source/graphql/authenticate.txt
@@ -13,7 +13,7 @@ Authenticate GraphQL Requests
 Overview
 --------
 
-The GraphQL API operates over HTTP, which means that you can access your
+The Atlas GraphQL API operates over HTTP, which means that you can access your
 :ref:`exposed data <graphql-expose-data>` using any HTTP or GraphQL client.
 {+service-short+} enforces rules for all GraphQL operations, so any GraphQL HTTP request
 must include an application user's login credentials or a valid access token.

--- a/source/graphql/cli.txt
+++ b/source/graphql/cli.txt
@@ -15,7 +15,7 @@ Run GraphQL Operations from a CLI
 Overview
 --------
 
-You can access your app's :doc:`exposed GraphQL API </graphql/expose-data>`
+You can access your App's :doc:`Atlas GraphQL API </graphql/expose-data>`
 through a terminal or command line interface. GraphQL operates over HTTP, so the
 CLI can be a standard HTTP client, like ``curl``, or a specialized GraphQL CLI,
 like :github:`graphqurl <hasura/graphqurl>`.

--- a/source/graphql/expose-data.txt
+++ b/source/graphql/expose-data.txt
@@ -16,7 +16,7 @@ Overview
 --------
 
 You can expose data from a MongoDB collection to client applications through the
-GraphQL API. {+service-short+} automatically generates GraphQL types and resolvers based on
+Atlas GraphQL API. {+service-short+} automatically generates GraphQL types and resolvers based on
 the :ref:`collection schema <schemas>` and enforces :ref:`collection rules
 <rules>` for all GraphQL operations.
 


### PR DESCRIPTION
## Pull Request Info

- fix naming to be 'Atlas GraphQL API' on first mention on page, to be consistent w the [naming guidance](https://docs.google.com/document/d/196sHKMtqpXQCdTF7AG_b989_osmmgbs9fu3KGyGgBEU/edit)
- shift IA to put pages in order of use/relevance. added link to Apollo GraphQL guide

### Jira

- https://jira.mongodb.org/browse/DOCSP-23637

### Staged Changes (Requires MongoDB Corp SSO)

- [GraphQL](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-23637/graphql)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
