### PR TITLE
(DOCSP-23592): Fixed "Defaut" Typo

### DIFF
--- a/source/manage-apps/configure/config/data_sources.txt
+++ b/source/manage-apps/configure/config/data_sources.txt
@@ -231,11 +231,11 @@ You can define default rules that apply to all collections in a data
 source that don't have more specific :ref:`collection-level rules
 <config-collection-rules>` defined.
 
-You define default rules in the data source's ``defaut_rule.json``
+You define default rules in the data source's ``default_rule.json``
 configuration file.
 
 .. code-block:: json
-   :caption: /data_sources/<data source>/defaut_rule.json
+   :caption: /data_sources/<data source>/default_rule.json
    
    {
      "roles": [<Role>],

--- a/source/rules/roles.txt
+++ b/source/rules/roles.txt
@@ -342,7 +342,7 @@ deploying configuration files with {+cli+}:
                :tabid: default-rules
                
                .. code-block:: json
-                  :caption: /data_sources/<data source>/defaut_rule.json
+                  :caption: /data_sources/<data source>/default_rule.json
                   
                   {
                     "roles": [


### PR DESCRIPTION
## Pull Request Info

"Default" is misspelled "defaut" twice on the MongoDB Data Source Configuration Files page. I also found another page (roles.txt) with this same error and also corrected that one. If that should be on another ticket/PR let me know!

### Jira

- https://jira.mongodb.org/browse/DOCSP-23592

### Staged Changes (Requires MongoDB Corp SSO)

- [MongoDB Data Source Configuration Files
](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-23592/manage-apps/configure/config/data_sources/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
