### PR TITLE
(DOCSP-23641): Added Documentation for Endpoint Logs

### DIFF
--- a/source/logs.txt
+++ b/source/logs.txt
@@ -27,6 +27,7 @@ Application Logs
    Trigger Logs </logs/trigger>
    Schema Logs </logs/schema>
    Sync Logs </logs/sync>
+   Endpoint Logs </logs/endpoint>
 
 Introduction
 ------------

--- a/source/logs.txt
+++ b/source/logs.txt
@@ -197,3 +197,7 @@ Reference Documentation
    * - :doc:`Sync Logs </logs/sync>`
      - This page describes the form and content of sync logs as well
        as the events that lead to their creation.
+
+   * - :doc:`Endpoint Logs </logs/endpoint>`
+     - This page describes the form and content of endpoint logs as well
+       as the events that lead to their creation.

--- a/source/logs/endpoint.txt
+++ b/source/logs/endpoint.txt
@@ -1,0 +1,99 @@
+=============
+Function Logs
+=============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+Endpoint logs are created whenever a user calls an 
+:ref:`HTTPS Endpoint <data-api>`.
+
+Log Format
+----------
+
+Endpoint log entries have the following form:
+
+.. code-block:: javascript
+
+   Logs:
+   [
+      <log line>,
+      <log line>,
+      ...
+   ]
+
+   {
+      "arguments": [
+         <arg1>,
+         <arg2>
+      ],
+      "name": <function name>,
+   }
+
+   Function Call Location: <location>
+
+   Endpoint Query Arguments: <arguments>
+
+   Endpoint Headers: <headers>
+
+   Compute Used: <number> bytes•ms
+
+   Remote IP Address: <ip address>
+
+Fields
+------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 50
+
+   * - Field
+     - Description
+
+   * - Logs
+     - Information about the Endpoint Call. Includes the name of the function, as well as the arguments passed to it. Among those are a list of headers
+     
+   * - Function Call Location
+     - The data center in which the function was executed.
+
+   * - Compute Used
+     - The computational load of the operation.
+
+   * - Remote IP Address
+     - ??
+   
+   * - Platform Version
+     - The version of the platform that sent the request.
+
+   * - Endpoint Query Arguments
+     - The parameters passed to the endpoint function.”
+
+   * - Endpoint Headers
+     -
+
+Error Fields
+------------
+
+Log entries created by unsuccessful operations may feature additional
+fields for debugging purposes. These include the following:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 50
+
+   * - Field
+     - Description
+
+   * - Error
+     - A brief description of an error.
+
+   * - Remote IP Address
+     - ??

--- a/source/logs/endpoint.txt
+++ b/source/logs/endpoint.txt
@@ -68,7 +68,7 @@ Fields
      - The computational load of the operation.
 
    * - Remote IP Address
-     - ??
+     - The IP Address that sent the request to the endpoint. (e.g. 52.21.89.200)
    
    * - Platform Version
      - The version of the platform that sent the request.
@@ -96,4 +96,4 @@ fields for debugging purposes. These include the following:
      - A brief description of an error.
 
    * - Remote IP Address
-     - ??
+     - The IP Address that sent the request to the endpoint. (e.g. 52.21.89.200)


### PR DESCRIPTION
## Pull Request Info

Added page documenting endpoint logs, in the style of other logs docs (ex: [authentication logs](https://www.mongodb.com/docs/atlas/app-services/logs/authentication/)).

### Jira

- https://jira.mongodb.org/browse/DOCSP-23641

### Staged Changes (Requires MongoDB Corp SSO)

- [Endpoint Logs](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-23641/logs/endpoint)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
