### PR TITLE
(DOCSP-20091): Add Apple requirements to user accounts, update include

### DIFF
--- a/source/authentication.txt
+++ b/source/authentication.txt
@@ -87,6 +87,8 @@ validates a unique identity. You can source user metadata, such as email
 or birthday, from authentication providers. You can associate each user 
 with :ref:`custom data <custom-user-data>`.
 
+.. include:: /includes/apple-account-deletion-requirements.rst
+
 .. _authentication-provider-identities:
 
 Authentication Provider Identities

--- a/source/includes/apple-account-deletion-requirements.rst
+++ b/source/includes/apple-account-deletion-requirements.rst
@@ -1,10 +1,9 @@
 .. tip:: Apple Account Deletion Requirements
 
-   If you distribute your app through the Apple App Store, 
-   Apple :apple:`requires that applications listed through the App Store 
+   Apple :apple:`requires that applications distributed through the App Store 
    <app-store/review/guidelines/#5.1.1>` must give any user who creates 
-   an account the option to delete the account. Whether you use an 
+   an account the option to delete the account. Whether that app uses an 
    authentication method where you must manually register a user, such as 
    email/password authentication, or one that that automatically creates a 
-   user, such as Sign-In with Apple, you must implement :ref:`user account 
-   deletion <delete-user>`.
+   user, such as Sign-In with Apple, an app distributed through the App Store 
+   must implement :ref:`user account deletion <delete-user>`.

--- a/source/includes/apple-account-deletion-requirements.rst
+++ b/source/includes/apple-account-deletion-requirements.rst
@@ -1,9 +1,10 @@
 .. tip:: Apple Account Deletion Requirements
 
-   Apple :apple:`requires that applications listed through its App Store 
+   If you distribute your app through the Apple App Store, 
+   Apple :apple:`requires that applications listed through the App Store 
    <app-store/review/guidelines/#5.1.1>` must give any user who creates 
    an account the option to delete the account. Whether you use an 
    authentication method where you must manually register a user, such as 
    email/password authentication, or one that that automatically creates a 
    user, such as Sign-In with Apple, you must implement :ref:`user account 
-   deletion <delete-user>` by June 30, 2022.
+   deletion <delete-user>`.


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-20091

### Staged Changes (Requires MongoDB Corp SSO)

- [Users & Authentication/User Accounts](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-20091/authentication/#user-accounts): Add the include that mentions folks distributing through the App Store must implement account deletion. Also, update include to remove the date because we are past the date and so now all apps must include it.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
