### PR TITLE
(DOCSP-23964): Clarify that the Realm Web SDK doesn't support Atlas Device Sync

### DIFF
--- a/source/sync/learn/overview.txt
+++ b/source/sync/learn/overview.txt
@@ -149,8 +149,10 @@ To sync data across devices, you :ref:`enable {+sync+} <enable-sync>` for your
 
 .. tip:: Check out the tutorial
    
-   If you prefer to learn by example, check out the {+service-short+} `tutorial <https://www.mongodb.com/docs/realm/tutorial/>`_, which describes how to build a synced Task Tracker application
-   with clients for common platforms that {+service-short+} supports.
+   If you prefer to learn by example, check out the {+service-short+} 
+   `tutorial <https://www.mongodb.com/docs/realm/tutorial/>`_, which describes
+   how to build a synced Task Tracker application with clients for common 
+   platforms that {+service-short+} supports.
 
 Before You Start
 ----------------
@@ -192,7 +194,7 @@ check out the SDK docs:
 
 .. note::
 
-   The Realm Web SDK does not currently support {+client-database+} or {+sync+}.
+   The Realm Web SDK does not currently support Realm Database or Atlas Device Sync.
    However, you can query the same data in an Atlas cluster using either 
    the MongoDB query interface or the GraphQL API for Web SDK.
 

--- a/source/sync/learn/overview.txt
+++ b/source/sync/learn/overview.txt
@@ -192,8 +192,8 @@ check out the SDK docs:
 
 .. note::
 
-   The Realm Web SDK does not currently support Realm Database or Atlas Device 
-   Sync. However, you can query the same data in an Atlas cluster using either 
+   The Realm Web SDK does not currently support {+client-database+} or {+sync+}.
+   However, you can query the same data in an Atlas cluster using either 
    the MongoDB query interface or the GraphQL API for Web SDK.
 
 Define Data Model

--- a/source/sync/learn/overview.txt
+++ b/source/sync/learn/overview.txt
@@ -196,7 +196,8 @@ check out the SDK docs:
 
    The Realm Web SDK does not currently support Realm Database or Atlas Device Sync.
    However, you can query the same data in an Atlas cluster using either 
-   MongoDB Data Access or the GraphQL API.
+   :ref:`MongoDB Data Access <web-mongodb-data-access>`
+   or the :ref:`GraphQL API <graphql-apollo-react>`.
 
 Define Data Model
 ~~~~~~~~~~~~~~~~~

--- a/source/sync/learn/overview.txt
+++ b/source/sync/learn/overview.txt
@@ -192,9 +192,9 @@ check out the SDK docs:
 
 .. note::
 
-   The Web SDK does not currently support {+client-database+} or {+sync+} directly.
-   However, it is compatible with apps that use sync through the MongoDB and
-   GraphQL APIs.
+   The Realm Web SDK does not currently support Realm Database or Atlas Device 
+   Sync. However, you can query the same data in an Atlas cluster using either 
+   the MongoDB query interface or the GraphQL API for Web SDK.
 
 Define Data Model
 ~~~~~~~~~~~~~~~~~

--- a/source/sync/learn/overview.txt
+++ b/source/sync/learn/overview.txt
@@ -196,7 +196,7 @@ check out the SDK docs:
 
    The Realm Web SDK does not currently support Realm Database or Atlas Device Sync.
    However, you can query the same data in an Atlas cluster using either 
-   the MongoDB query interface or the GraphQL API for Web SDK.
+   MongoDB Data Access or the GraphQL API.
 
 Define Data Model
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

Clarified in a note on the Overview Device Sync overview page that the Realm Web SDK doesn't support Atlas Device Sync.

### Jira

- https://jira.mongodb.org/browse/DOCSP-23964

### Staged Changes (Requires MongoDB Corp SSO)

- [PAGE_NAME](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-23964/sync/learn/overview/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
