### PR TITLE
(DOCSP-23201): Flexible sync type-specific & field-level permissions

### DIFF
--- a/source/includes/tip-role-order-config-files.rst
+++ b/source/includes/tip-role-order-config-files.rst
@@ -1,0 +1,4 @@
+.. tip::
+   
+   Roles are evaluated in order starting from the beginning of the
+   array, so define the most specific roles first.

--- a/source/manage-apps/configure/config/sync.txt
+++ b/source/manage-apps/configure/config/sync.txt
@@ -155,9 +155,11 @@ Sync configuration:
              "read": <Expression>,
              "write": <Expression>,
              "fields": {
-               "read": <Boolean>,
-               "write": <Boolean>,
-               "fields": <Embedded Fields>,
+               "<Field Name>": {
+                 "read": <Boolean>,
+                 "write": <Boolean>,
+                 "fields": <Embedded Object Fields>
+               }
              }
              "additional_fields": {
                "read": <Boolean>,
@@ -341,7 +343,19 @@ For more information, see :ref:`Type-Specific Roles
        | Object
        | *Optional*
      
-     - todo
+     - An object that defines read and write permissions for specific
+       fields. A field-level permission definition has the following
+       form:
+
+       .. code-block:: json
+          
+          "fields": {
+            "<Field Name>": {
+              "read": <Boolean>,
+              "write": <Boolean>,
+              "fields": <Embedded Object Fields>
+            }
+          }
 
    * - | ``fields.<Field Name>.read``
        | Boolean
@@ -390,7 +404,17 @@ For more information, see :ref:`Type-Specific Roles
        | Object
        | *Optional*
      
-     - todo
+     - An object that defines read and write permissions for all fields
+       that do not have any permissions defined in ``fields``. A
+       field-level permission definition for generic fields has the
+       following form:
+
+       .. code-block:: json
+          
+          "additional_fields": {
+            "read": <Boolean>,
+            "write": <Boolean>
+          }
    
    * - | ``additional_fields.read``
        | Boolean

--- a/source/manage-apps/configure/config/sync.txt
+++ b/source/manage-apps/configure/config/sync.txt
@@ -41,8 +41,8 @@ app uses this Sync configuration:
        "key": "<Partition Key Field Name>",
        "type": "<Partition Key Type>",
        "permissions": {
-         "read": { <JSON Expression> },
-         "write": { <JSON Expression> }
+         "read": { <Expression> },
+         "write": { <Expression> }
        }
      },
      "last_disabled": <Number>,
@@ -103,14 +103,14 @@ app uses this Sync configuration:
        - ``"long"``
 
    * - | ``partition.permissions.read``
-       | JSON Expression
+       | Expression
      - An :ref:`expression <expressions>` that evaluates to ``true`` when a user
        has permission to read objects in a partition. If the expression
        evaluates to ``false``, {+service-short+} does not allow the user to read
        an object or its properties.
 
    * - | ``partition.permissions.write``
-       | JSON Expression
+       | Expression
      - An :ref:`expression <expressions>` that evaluates to ``true`` when a user
        has permission to write objects in a partition. If the expression
        evaluates to ``false``, {+service-short+} does not allow the user to
@@ -148,21 +148,25 @@ Sync configuration:
      "state": <"enabled" | "disabled">,
      "permissions": {
        "rules": {
-         "<Collection Name>": [
+         "<Type Name>": [
            {
              "name": <String>,
-             "applyWhen": { <JSON Expression> },
-             "read": { <JSON Expression> },
-             "write": { <JSON Expression> }
+             "applyWhen": { <Expression> },
+             "read": <Expression>,
+             "write": <Expression>,
+             "additional_fields": {
+               "read": <Boolean>,
+               "write": <Boolean>
+             }
            }
          ]
        },
        "defaultRoles": [
          {
            "name": <String>,
-           "applyWhen": { <JSON Expression> },
-           "read": <JSON Expression>,
-           "write": <JSON Expression>
+           "applyWhen": { <Expression> },
+           "read": <Expression>,
+           "write": <Expression>
          }
        ]       
      },
@@ -215,65 +219,132 @@ Sync configuration:
        - ``"enabled"``
        - ``"disabled"``
 
-   * - | ``permissions.rules.<Coll>``
+   * - | ``permissions.rules.<Type Name>``
+       | Array<Role>
+     
+     - You can define a set of roles that apply to a specific object
+       type. These roles apply in order from the beginning of the array,
+       so define the most specific rules first.
+
+   * - | ``rules.<Type Name>.[].name``
        | String
-     - You can define rules that apply to a single collection by specifying
-       the collection name. App Services apps apply rules in order from the beginning
-       of the array, so start with the most specific rules first.
 
-   * - | ``rules.<Coll>.name``
-       | String
-     - The name of the specific rule in the rules array. You might use a 
-       descriptive name to make it easier to parse the rules, such as 
-       "adminReadWrite" or "employeeReadOnly".
+     - The name of the role. You might use a descriptive name, such as
+       ``"adminReadWrite"`` or ``"employeeReadOnly"``, to make it easier
+       to understand the rules.
 
-   * - | ``rules.<Coll>.applyWhen``
-       | JSON Expression
-     - An :ref:`expression <expressions>` that evaluates to ``true`` when 
-       the rule should be applied. An example might be 
-       ``{"%%user.custom_data.isGlobalAdmin": true}``. This reads the 
-       value of the ``isGlobalAdmin`` bool from the :ref:`user's custom data 
-       <custom-user-data>`, and applies the rule when the value of this 
-       bool is ``true``.
+   * - | ``rules.<Type Name>.[].applyWhen``
+       | Expression
+     
+     - An :ref:`expression <expressions>` that evaluates to ``true``
+       when the role applies to the user. 
+       
+       .. example::
+          
+          The following expression defines a role that applies when a
+          :ref:`user's custom data <custom-user-data>` contains a field
+          named ``isGlobalAdmin`` with the value set to ``true``:
 
-   * - | ``rules.<Coll>.read``
-       | JSON Expression
-     - An :ref:`expression <expressions>` that evaluates to ``true`` when a 
-       user has permission to read objects in the collection. If the 
-       expression evaluates to ``false``, {+service-short+} does not allow 
-       the user to read an object or its properties.
+          .. code-block:: json
+             
+             {
+               "%%user.custom_data.isGlobalAdmin": true
+             }
 
-   * - | ``rules.<Coll>.write``
-       | JSON Expression
-     - An :ref:`expression <expressions>` that evaluates to ``true`` when a 
-       user has permission to write objects in the collection. If the 
-       expression evaluates to ``false``, {+service-short+} does not allow 
-       the user to modify an object or its properties. Write permission
-       requires read permission. A user cannot write to a document that
-       they cannot read.
+   * - | ``rules.<Type Name>.[].read``
+       | Expression
+     
+     - An :ref:`expression <expressions>` that determines whether or not
+       the user can read data. If the expression evaluates to ``true``,
+       the user has permission to read objects of this type. If
+       ``false``, the user cannot read an object or any of its
+       properties.
+
+   * - | ``rules.<Type Name>.[].write``
+       | Expression
+     
+     - An :ref:`expression <expressions>` that determines whether or not
+       the user can write data. If the expression evaluates to ``true``,
+       the user has permission to write objects of this type. If
+       ``false``, the user cannot write an object or any of its
+       properties.
+       
+       Write permission requires read permission. A user cannot write to
+       a document that they cannot read.
+
+   * - | ``rules.<Type Name>.[].fields.<Field Name>.read``
+       | Boolean
+     
+     - If ``true``, the role has permission to read this field. If
+       ``false``, the user cannot read the field.
+
+   * - | ``rules.<Type Name>.[].fields.<Field Name>.write``
+       | Boolean
+     
+     - If ``true``, the role has permission to write this field. If
+       ``false``, the user cannot write the field.
+       
+       Write permission requires read permission. A user cannot write to
+       a field that they cannot read.
+
+   * - | ``rules.<Type Name>.[].fields.<Field Name>.fields``
+       | Object
+     
+     - Nested field-level permissions for an embedded object.
+       
+       .. example::
+          
+          The following role defines read and write permissions for the
+          embedded field ``address.street``:
+
+          .. code-block:: json
+             
+             {
+               "fields": {
+                 "address": {
+                   "fields": {
+                     "street": {
+                       "read": true,
+                       "write": true
+                     }
+                   }
+                 }
+               }
+             }
+   
+   * - | ``rules.<Type Name>.[].additional_fields.read``
+       | Boolean
+     
+     - If ``true``, the role has permission to read any field that
+       isn't defined in ``fields``. If ``false``, the user can only
+       read a field with specific permissions.
+
+   * - | ``rules.<Type Name>.[].additional_fields.write``
+       | Boolean
+     
+     - If ``true``, the role has permission to write any field that
+       isn't defined in ``fields``. If ``false``, the user can only
+       write a field with specific permissions.
+       
+       Write permission requires read permission. A user cannot write to
+       a field that they cannot read.
 
    * - | ``permissions.defaultRoles``
-       | String
-     - Your {+app+} evaluates ``defaultRoles`` after ``rules``. If no 
-       collection-specific rule applies to a user's attempt to access 
-       data through an {+app+}, {+service-short+} proceeds to evaluate ``defaultRoles`` 
-       until it finds a set of permissions that apply to the user. This 
-       may occur when a collection does not have a specific set of rules 
-       defined, or when none of the rules defined for a collection apply
-       to a user. 
-       
-       You can have more than one ``defaultRole``, and they apply
-       across all the collections that your {+app+} can access, even 
-       when you have more specific collection rules defined.
+       | Array<Object>
+     
+     - Any array of generic roles that apply to all object types.
+       Type-specific roles defined in the ``rules`` property always take
+       precedence over default roles. A user may be assigned a default
+       role when type-specific roles do not apply or are not defined.
 
-   * - | ``defaultRoles.name``
+   * - | ``defaultRoles.[].name``
        | String
      - The name of the specific role in the defaultRoles array. You might 
        use a descriptive name to make it easier to parse the roles, such as 
        "adminReadWrite" or "employeeReadOnly".
 
-   * - | ``defaultRoles.applyWhen``
-       | JSON Expression
+   * - | ``defaultRoles.[].applyWhen``
+       | Expression
      - An :ref:`expression <expressions>` that evaluates to ``true`` when 
        the role should be applied. An example might be 
        ``{"%%user.custom_data.isGlobalAdmin": true}``. This reads the 
@@ -281,22 +352,27 @@ Sync configuration:
        <custom-user-data>`, and applies the role when the value of this 
        bool is ``true``.
 
-   * - | ``defaultRoles.read``
-       | JSON Expression
-     - An :ref:`expression <expressions>` that evaluates to ``true`` when a 
-       user has permission to read objects in the collection. If the 
-       expression evaluates to ``false``, {+service-short+} does not allow 
-       the user to read an object or its properties.
+   * - | ``defaultRoles.[].read``
+       | Expression
+     
+     - An :ref:`expression <expressions>` that determines whether or not
+       the user can read data. If the expression evaluates to ``true``,
+       the user has permission to read objects. If ``false``, the user
+       cannot read an object or any of its properties.
 
-   * - | ``defaultRoles.write``
-       | JSON Expression
-     - An :ref:`expression <expressions>` that evaluates to ``true`` when a 
-       user has permission to write objects in the collection. If the 
-       expression evaluates to ``false``, {+service-short+} does not allow 
-       the user to modify an object or its properties. 
+   * - | ``defaultRoles.[].write``
+       | Expression
+     
+     - An :ref:`expression <expressions>` that determines whether or not
+       the user can write data. If the expression evaluates to ``true``,
+       the user has permission to write objects. If ``false``, the user
+       cannot write an object or any of its properties.
+       
+       Write permission requires read permission. A user cannot write to
+       a document that they cannot read. 
 
    * - | ``queryable_fields_names``
-       | Array of Strings
+       | Array<String>
      - The :ref:`names of the fields <queryable-fields>` that your client 
        application can query to determine which data to synchronize.
 

--- a/source/manage-apps/configure/config/sync.txt
+++ b/source/manage-apps/configure/config/sync.txt
@@ -51,7 +51,7 @@ app uses this Sync configuration:
 
 .. list-table::
    :header-rows: 1
-   :widths: 10 30
+   :widths: 10 40
 
    * - Field
      - Description
@@ -154,6 +154,11 @@ Sync configuration:
              "applyWhen": { <Expression> },
              "read": <Expression>,
              "write": <Expression>,
+             "fields": {
+               "read": <Boolean>,
+               "write": <Boolean>,
+               "fields": <Embedded Fields>,
+             }
              "additional_fields": {
                "read": <Boolean>,
                "write": <Boolean>
@@ -177,13 +182,14 @@ Sync configuration:
 
 .. list-table::
    :header-rows: 1
-   :widths: 10 30
+   :widths: 10 40
 
    * - Field
      - Description
 
    * - | ``type``
        | String
+     
      - The :ref:`Sync Mode <sync-modes>` for the application.
        
        Valid Options:
@@ -192,6 +198,7 @@ Sync configuration:
 
    * - | ``development_mode_enabled``
        | Boolean
+     
      - If ``true``, :ref:`Development Mode <enable-development-mode>` is enabled
        for the application. While enabled, {+service-short+} automatically stores synced
        objects in a specific database (specified in ``database_name``) and
@@ -199,12 +206,14 @@ Sync configuration:
 
    * - | ``service_name``
        | String
+     
      - The name of the Atlas cluster :ref:`data source <appconfig-data_sources>`
        to sync. You cannot use sync with a :ref:`serverless instance
        <serverless-caveats>`.
 
    * - | ``database_name``
        | String
+     
      - The name of a database in the synced cluster where {+service-short+} stores data in
        :ref:`Development Mode <enable-development-mode>`. {+service-short+} automatically
        generates a schema for each synced type and maps each object type to a
@@ -212,29 +221,83 @@ Sync configuration:
 
    * - | ``state``
        | String
-     - The current state of the :doc:`Sync </sync>` protocol for the application.
+     
+     - The current state of the sync protocol for the application.
        
        Valid Options:
 
        - ``"enabled"``
        - ``"disabled"``
 
-   * - | ``permissions.rules.<Type Name>``
-       | Array<Role>
+   * - | ``permissions.rules``
+       | Object
      
-     - You can define a set of roles that apply to a specific object
-       type. These roles apply in order from the beginning of the array,
-       so define the most specific rules first.
+     - An object that maps object type names to :ref:`Type-Specific
+       Roles <appconfig-sync-type-specific-roles>`.
 
-   * - | ``rules.<Type Name>.[].name``
+       .. code-block:: json
+          
+          {
+            "<Type Name>": [ <Role>, ... ]
+          }
+
+   * - | ``permissions.defaultRoles``
+       | Array<Object>
+     
+     - An array of :ref:`Default Roles <appconfig-sync-default-roles>`.
+
+       .. code-block:: json
+          
+          [ <Role>, ... ]
+
+   * - | ``queryable_fields_names``
+       | Array<String>
+     
+     - The :ref:`names of the fields <queryable-fields>` that your client 
+       application can query to determine which data to synchronize.
+
+   * - | ``last_disabled``
+       | Number
+     
+     - The date and time that sync was last paused or disabled, represented by
+       the number of seconds since the Unix epoch (January 1, 1970, 00:00:00
+       UTC).
+
+   * - | ``client_max_offline_days``
+       | Number
+     
+     - Controls how long the :ref:`backend compaction <optimize-sync-atlas-usage>`
+       process waits before aggressively pruning metadata that some clients
+       require to synchronize from an old version of a {+realm+}.
+
+.. _appconfig-sync-type-specific-roles:
+
+Type-Specific Roles
+~~~~~~~~~~~~~~~~~~~
+
+The ``permissions.rules`` field maps object type names to sets of roles
+that apply specifically to each object type.
+
+For more information, see :ref:`Type-Specific Roles
+<type-specific-roles>`.
+
+.. include:: /includes/tip-role-order-config-files.rst
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 40
+
+   * - | ``name``
        | String
+       | *Required*
 
      - The name of the role. You might use a descriptive name, such as
        ``"adminReadWrite"`` or ``"employeeReadOnly"``, to make it easier
        to understand the rules.
 
-   * - | ``rules.<Type Name>.[].applyWhen``
+   * - | ``applyWhen``
        | Expression
+       | *Required*
      
      - An :ref:`expression <expressions>` that evaluates to ``true``
        when the role applies to the user. 
@@ -251,8 +314,9 @@ Sync configuration:
                "%%user.custom_data.isGlobalAdmin": true
              }
 
-   * - | ``rules.<Type Name>.[].read``
+   * - | ``read``
        | Expression
+       | *Optional*
      
      - An :ref:`expression <expressions>` that determines whether or not
        the user can read data. If the expression evaluates to ``true``,
@@ -260,8 +324,9 @@ Sync configuration:
        ``false``, the user cannot read an object or any of its
        properties.
 
-   * - | ``rules.<Type Name>.[].write``
+   * - | ``write``
        | Expression
+       | *Optional*
      
      - An :ref:`expression <expressions>` that determines whether or not
        the user can write data. If the expression evaluates to ``true``,
@@ -271,15 +336,23 @@ Sync configuration:
        
        Write permission requires read permission. A user cannot write to
        a document that they cannot read.
+   
+   * - | ``fields``
+       | Object
+       | *Optional*
+     
+     - todo
 
-   * - | ``rules.<Type Name>.[].fields.<Field Name>.read``
+   * - | ``fields.<Field Name>.read``
        | Boolean
+       | *Required*
      
      - If ``true``, the role has permission to read this field. If
        ``false``, the user cannot read the field.
 
-   * - | ``rules.<Type Name>.[].fields.<Field Name>.write``
+   * - | ``fields.<Field Name>.write``
        | Boolean
+       | *Required*
      
      - If ``true``, the role has permission to write this field. If
        ``false``, the user cannot write the field.
@@ -287,8 +360,9 @@ Sync configuration:
        Write permission requires read permission. A user cannot write to
        a field that they cannot read.
 
-   * - | ``rules.<Type Name>.[].fields.<Field Name>.fields``
+   * - | ``fields.<Field Name>.fields``
        | Object
+       | *Optional*
      
      - Nested field-level permissions for an embedded object.
        
@@ -312,15 +386,23 @@ Sync configuration:
                }
              }
    
-   * - | ``rules.<Type Name>.[].additional_fields.read``
+   * - | ``additional_fields``
+       | Object
+       | *Optional*
+     
+     - todo
+   
+   * - | ``additional_fields.read``
        | Boolean
+       | *Required*
      
      - If ``true``, the role has permission to read any field that
        isn't defined in ``fields``. If ``false``, the user can only
        read a field with specific permissions.
 
-   * - | ``rules.<Type Name>.[].additional_fields.write``
+   * - | ``additional_fields.write``
        | Boolean
+       | *Required*
      
      - If ``true``, the role has permission to write any field that
        isn't defined in ``fields``. If ``false``, the user can only
@@ -329,22 +411,37 @@ Sync configuration:
        Write permission requires read permission. A user cannot write to
        a field that they cannot read.
 
-   * - | ``permissions.defaultRoles``
-       | Array<Object>
-     
-     - Any array of generic roles that apply to all object types.
-       Type-specific roles defined in the ``rules`` property always take
-       precedence over default roles. A user may be assigned a default
-       role when type-specific roles do not apply or are not defined.
+.. _appconfig-sync-default-roles:
 
-   * - | ``defaultRoles.[].name``
+Default Roles
+~~~~~~~~~~~~~
+
+The ``permissions.defaultRoles`` field contains an array of generic
+roles that apply to all object types. Type-specific roles defined in the
+``rules`` property always take precedence over default roles. A user may
+be assigned a default role when type-specific roles do not apply or are
+not defined.
+       
+For more information, see :ref:`Default Roles <default-roles>`.
+
+.. include:: /includes/tip-role-order-config-files.rst
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 40
+
+   * - | ``name``
        | String
-     - The name of the specific role in the defaultRoles array. You might 
+       | *Required*
+
+     - The name of the role in the ``defaultRoles`` array. You might 
        use a descriptive name to make it easier to parse the roles, such as 
        "adminReadWrite" or "employeeReadOnly".
 
-   * - | ``defaultRoles.[].applyWhen``
+   * - | ``applyWhen``
        | Expression
+       | *Required*
+
      - An :ref:`expression <expressions>` that evaluates to ``true`` when 
        the role should be applied. An example might be 
        ``{"%%user.custom_data.isGlobalAdmin": true}``. This reads the 
@@ -352,16 +449,18 @@ Sync configuration:
        <custom-user-data>`, and applies the role when the value of this 
        bool is ``true``.
 
-   * - | ``defaultRoles.[].read``
+   * - | ``read``
        | Expression
+       | *Optional*
      
      - An :ref:`expression <expressions>` that determines whether or not
        the user can read data. If the expression evaluates to ``true``,
        the user has permission to read objects. If ``false``, the user
        cannot read an object or any of its properties.
 
-   * - | ``defaultRoles.[].write``
+   * - | ``write``
        | Expression
+       | *Optional*
      
      - An :ref:`expression <expressions>` that determines whether or not
        the user can write data. If the expression evaluates to ``true``,
@@ -369,21 +468,4 @@ Sync configuration:
        cannot write an object or any of its properties.
        
        Write permission requires read permission. A user cannot write to
-       a document that they cannot read. 
-
-   * - | ``queryable_fields_names``
-       | Array<String>
-     - The :ref:`names of the fields <queryable-fields>` that your client 
-       application can query to determine which data to synchronize.
-
-   * - | ``last_disabled``
-       | Number
-     - The date and time that sync was last paused or disabled, represented by
-       the number of seconds since the Unix epoch (January 1, 1970, 00:00:00
-       UTC).
-
-   * - | ``client_max_offline_days``
-       | Number
-     - Controls how long the :ref:`backend compaction <optimize-sync-atlas-usage>`
-       process waits before aggressively pruning metadata that some clients
-       require to synchronize from an old version of a {+realm+}.
+       a document that they cannot read.

--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -302,39 +302,137 @@ cannot express solely in JSON expressions.
 .. _flexible-sync-rules-and-permissions:
 .. _flexible-sync-roles:
 
-Flexible Sync Session Roles and Rules
--------------------------------------
+Session Roles
+-------------
 
-In flexible sync, a **session role** determines which permissions apply for the
-duration of a sync session.
+A **session role** determines which permissions apply for the duration
+of a flexible sync session.
 
-You define Flexible Sync session roles on a per-collection basis. Each
-"collection" when using {+sync+} corresponds to a Realm Object type.
+.. seealso::
 
-When a user begins a session by opening a synced realm, {+service-short+} determines which
-session role applies for the user for each collection in play. {+service-short+} considers
-session roles in the order that you defined them in the configuration. It
-evaluates each session role's "apply when" expression until one evaluates to
-true. If no session role applies, the user has no permissions for that
-collection.
+   For a guide to setting up flexible sync with common permissions
+   models, see :ref:`flexible-sync-permissions-guide`.
+
+When a user begins a session by opening a synced realm, session roles
+are evaluated and applied to the user for each synced object type. A
+user may only have one role for each type, so session roles apply in a
+priority order. If no session role applies for an object type, the user
+cannot read or write any objects of that type.
+
+A session role stays assigned for the duration of the session. If
+something relevant to a user's session roles changes in the middle of
+the user's session, the user is not assigned an updated role until they
+start a new session. For example, if the user's metadata or the role's
+"apply when" expression changes, the user continues to use their
+existing session role until the next time they start the app.
 
 .. tip::
+   
+   You can think of session roles as a way to group read and write
+   expressions to organize your code. Most apps only need one (default)
+   session role with per-document logic defined in the session role's
+   read and write expressions.
 
-   Your session role "apply when" expressions can use :ref:`JSON expansions
-   <expansions>` to refer to :ref:`user metadata
-   <configure-user-metadata-on-the-backend>` and :ref:`custom user data
-   <custom-user-data>` and even call functions to determine the given user's
-   role. However, because {+service-short+} only evaluates session roles at the start of a
-   session -- that is, before any query for specific documents -- you can't
-   refer to a document or its field values to determine whether the session role
-   applies.
+.. _default-roles:
 
-The session role stays assigned for the duration of the session. If you make
-changes to an applied session role while a user is in the middle of a session,
-{+service-short+} does not evaluate the updated session role until the next time
-the user starts a session. Likewise, if something changes that would qualify the
-user for a different session role, the user's current session role does not
-change until the next session.
+Type-Specific and Default Roles
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Roles may be either *type-specific roles* that apply to a single object
+type that you identify by name or *default roles* that apply to all
+objects regardless of their type. You use :ref:`expressions
+<expressions>` to determine when a role applies and to define dynamic
+field-level permissions for a specific role.
+
+Document-Level Permissions
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can define read and write permissions for a role that apply to an
+entire object. A user with document-level read permission for an object
+type can access all fields in an object of that type. Similarly,
+document-level write permissions allow a user to modify all fields.
+
+If a user does not have read permission for an object type, no objects
+of that type are included in sync query results.
+
+Field-Level Permissions
+~~~~~~~~~~~~~~~~~~~~~~~
+
+When you need more granularity than document-level permissions, you can
+configure field-level permissions that determine whether a user can read
+or write individual fields of an object type. You can define permissions
+for specific fields as well as a set of permissions that apply to fields
+without specific permissions.
+
+Expressions
+~~~~~~~~~~~
+
+Expressions in a role can only refer to the :ref:`queryable fields
+<queryable-fields>` of your data model.
+
+You can use :ref:`expansions <expansions>` to define dynamic "apply
+when" expressions and field-level permissions. Expansions let you refer
+to :ref:`user metadata <configure-user-metadata-on-the-backend>`,
+including :ref:`custom user data <custom-user-data>`, and can call
+functions to handle complex logic. However, because session roles are
+determined at the start of a session -- that is, before any query for
+specific documents -- you can't refer to a document or its field values
+to determine whether a session role applies.
+
+The following table describes support for expression expansions in
+flexible sync roles:
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - Expansion
+     - Can Use in "Apply When"?
+     - Can Use in Read & Write Rules?
+   
+   * - :json-expansion:`%%true`, :json-expansion:`%%false`
+     - Yes
+     - Yes
+   
+   * - :json-expansion:`%%values`, :json-expansion:`%%environment`
+     - Yes
+     - Yes with an :ref:`important caveat <flex-sync-expansions-caveat>`
+   
+   * - :json-expansion:`%%request`
+     - No
+     - No
+   
+   * - :json-expansion:`%%user`
+     - Yes
+     - Yes with an :ref:`important caveat <flex-sync-expansions-caveat>`
+   
+   * - :json-expansion:`%%this`, :json-expansion:`%%prev`, :json-expansion:`%%root`,  :json-expansion:`%%prevRoot`
+     - No. These expansions refer to the document. {+service-short+} evaluates "apply when" expressions at session start, so there's no document to evaluate.
+     - No. These expansions might access non-queryable fields of the document, which is not possible.
+   
+   * - :json-expansion:`%%partition`
+     - No
+     - No
+   
+   * - :json-operator:`%stringToOid`, :json-operator:`%oidToString`
+     - Yes
+     - No
+   
+   * - :json-operator:`%function`
+     - Yes
+     - No. {+service-short+} expands the expansions at the start of the session, so the function would not operate on a per-document basis.
+   
+   * - :json-operator:`$exists`
+     - Yes
+     - Yes
+   
+   * - :json-operator:`$in`, :json-operator:`$nin`
+     - Yes
+     - Yes. However, note that you cannot currently have an array field as a queryable field on a document.
+   
+   * - :json-operator:`$eq`, :json-operator:`$ne`, :json-operator:`$gt`, :json-operator:`$gte`, :json-operator:`$lt`, :json-operator:`$lte`  
+     - Yes
+     - Yes
 
 .. _flex-sync-expansions-caveat:
 
@@ -343,163 +441,32 @@ change until the next session.
    {+service-short+} triggers a :ref:`client reset <client-resets>` if anything about the
    session role changed since the previous session.
 
-   At the start of a session, {+service-short+} expands all JSON expansions in the "apply
-   when", read, and write expressions and stores the result. This has the following
-   implications:
+   At the start of a session, {+service-short+} expands all expansions
+   in the "apply when", read, and write expressions and stores the
+   result. This has the following implications:
 
-   - If the value changes during a session, {+service-short+} continues to use the value as it was at the time of session start.
-   - On the next session, if the value is different from what it was at the start of this session, {+service-short+} triggers a client reset.
+   - If the value changes during a session, {+service-short+} continues
+     to use the value as it was at the time of session start.
+
+   - On the next session, if the value is different from what it was at
+     the start of this session, {+service-short+} triggers a client
+     reset.
+   
    - You cannot use the :json-operator:`%function` operator in read and
      write rules. Functions would not operate on a per-document basis.
-   - You cannot store permissions information (such as "which document IDs may this user access?") in the user object.
+   
+   - You cannot store permissions information (such as "which document
+     IDs may this user access?") in the user object.
 
+Role Configuration Files
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. _flexible-sync-roles-json-reference:
-
-Flexible Sync Roles JSON Reference
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A **Role** object can specify a role for a specific collection or the default
-role applied to all collections. You define field-level permissions with a
-**Fields** object in the Role.
-
-A **Role** object has the following properties:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 20 20 10 50
-
-   * - Key
-     - Value Type
-     - Required
-     - Notes
-
-   * - name
-     - string
-     - Yes
-     - The name of the role.
-
-   * - applyWhen
-     - JSON expression
-     - Yes
-     - The rules system evaluates the expression at session start time
-       and assigns the first role whose ``applyWhen`` expression evaluates to
-       true.
-
-   * - write
-     - JSON expression
-     - No
-     - The rules system evaluates the expression for each document to
-       determine if the user may write to the given document. If true, the
-       system implicitly grants read access. The expression may only refer to
-       the pre-specified **queryable fields** of the document.
-
-   * - read
-     - JSON expression
-     - No
-     - The rules system evaluates the expression for each document to
-       determine if the user may write to the given document. If ``write``
-       evaluates to true, the system implicitly grants read access regardless of
-       the result of ``read``. The expression may only refer to the
-       pre-specified **queryable fields** of the document.
-
-   * - fields
-     - Fields object
-     - No
-     - Specifies field-level permissions in addition to document-level
-       permission. If omitted, document-level rules apply.
-
-   * - additional_fields
-     - Object
-     - No
-     - Specifies permissions for fields not explicitly listed in the
-       ``fields`` object.
-
-   * - additional_fields.read
-     - boolean
-     - No
-     - Specifies whether read access should be granted for fields not
-       explicitly listed in the ``fields`` object.
-       
-   * - additional_fields.write
-     - boolean
-     - No
-     - Specifies whether write access should be granted for fields not
-       explicitly listed in the ``fields`` object.
-
-The **Fields** object defines permissions for specific fields. The keys of the
-fields object are names of the field:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 20 20 10 50
-
-   * - Key
-     - Value Type
-     - Required
-     - Notes
-
-   * - *arbitrary field name*
-     - **Permissions** object
-     - No
-     - Specifies the field-level permissions for the given field.
-
-The **Permissions** object has the following properties:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 20 20 10 50
-
-   * - Key
-     - Value Type
-     - Required
-     - Notes
-
-   * - write
-     - boolean
-     - No
-     - If the user has write permission at the document level:
-
-       - When ``write`` is ``true`` or undefined, the system grants read and write access.
-       - When ``write`` is ``false``, the system revokes write access.
-
-   * - read
-     - boolean
-     - No
-     - First, if the user has write access, the user always has read access. If
-       the user does not have write access but does have document-level read
-       permission:
-       
-       - When ``read`` is ``true`` or undefined, the system grants read access.
-       - When ``read`` is ``false``, the system revokes read access.
-
-   * - fields
-     - Fields object
-     - No
-     - For embedded object fields. Specifies field-level permissions.
-
-   * - additional_fields
-     - Object
-     - No
-     - For embedded object fields. Specifies permissions for fields not
-       explicitly listed in the ``fields`` object.
-
-   * - additional_fields.read
-     - boolean
-     - No
-     - For embedded object fields. Specifies whether read access should be
-       granted for fields not explicitly listed in the ``fields`` object.
-       
-   * - additional_fields.write
-     - boolean
-     - No
-     - For embedded object fields. Specifies whether write access should be
-       granted for fields not explicitly listed in the ``fields`` object.
-
+You use JSON configuration files to define session roles. For more
+information, see :ref:`{+sync+} Configuration Files <appconfig-sync>`.
 
 .. example::
 
-   The following JSON object describes a **Role** for a team admin:
+   The following role configuration describes a team administrator:
 
    .. code-block:: json
 
@@ -574,163 +541,3 @@ The **Permissions** object has the following properties:
 
         - May not read or write any other fields despite having document-level
           access to the document.
-          
-
-
-Available Expansions in Flexible Sync Rules Quick Reference
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. list-table::
-   :header-rows: 1
-   :stub-columns: 1
-
-   * - Expansion
-     - Can Use in "Apply When"?
-     - Can Use in Read & Write Rules?
-   
-   * - :json-expansion:`%%true`, :json-expansion:`%%false`
-     - Yes
-     - Yes
-   
-   * - :json-expansion:`%%values`, :json-expansion:`%%environment`
-     - Yes
-     - Yes with an :ref:`important caveat <flex-sync-expansions-caveat>`
-   
-   * - :json-expansion:`%%request`
-     - No
-     - No
-   
-   * - :json-expansion:`%%user`
-     - Yes
-     - Yes with an :ref:`important caveat <flex-sync-expansions-caveat>`
-   
-   * - :json-expansion:`%%this`, :json-expansion:`%%prev`, :json-expansion:`%%root`,  :json-expansion:`%%prevRoot`
-     - No. These expansions refer to the document. {+service-short+} evaluates "apply when" expressions at session start, so there's no document to evaluate.
-     - No. These expansions might access non-queryable fields of the document, which is not possible.
-   
-   * - :json-expansion:`%%partition`
-     - No
-     - No
-   
-   * - :json-operator:`%stringToOid`, :json-operator:`%oidToString`
-     - Yes
-     - No
-   
-   * - :json-operator:`%function`
-     - Yes
-     - No. {+service-short+} expands the expansions at the start of the session, so the function would not operate on a per-document basis.
-   
-   * - :json-operator:`$exists`
-     - Yes
-     - Yes
-   
-   * - :json-operator:`$in`, :json-operator:`$nin`
-     - Yes
-     - Yes. However, note that you cannot currently have an array field as a queryable field on a document.
-   
-   * - :json-operator:`$eq`, :json-operator:`$ne`, :json-operator:`$gt`, :json-operator:`$gte`, :json-operator:`$lt`, :json-operator:`$lte`  
-     - Yes
-     - Yes
-
-.. _default-roles:
-
-Default Roles
-~~~~~~~~~~~~~
-
-You can create one or more default session roles that apply across all
-collections. If a collection does not have any custom session roles
-defined, session role resolution reverts to default session roles. 
-
-.. tip::
-
-   Because session roles apply only at the session level and not on a
-   per-document level, most apps only need one (default) session role
-   with per-document logic in that session role's read
-   and write rules. With Flexible Sync, session roles can be thought of
-   as a way to group read and write rule expressions to organize
-   your code.
-
-
-Flexible Sync Rules
-~~~~~~~~~~~~~~~~~~~
-
-You define a read and write rule expression pair for every session role.
-
-Rule expressions can refer to the :ref:`queryable fields
-<queryable-fields>` of your data model.
-
-In response to a Flexible Sync subscription query, {+service-short+} evaluates the
-read and write rule expressions for each document that matches the query.
-The client only receives documents where the rule expression evaluates to "true".
-
-Consider the following behavior when designing your schemas 
-to ensure that you have appropriate data access granularity and don't 
-accidentally leak sensitive information.
-
-- Sync rules apply dynamically based on the value of the queryable field or 
-  user metadata. One user may have full read & write access to a document 
-  while another user has only read permissions or is unable to access the 
-  document. You control these permissions by defining 
-  :ref:`JSON expressions <expressions>`.
-
-- Write permissions require read permissions, so a user with write access to a
-  collection also has read access regardless of the defined (or undefined) read
-  permission rule.
-
-.. seealso::
-
-   For a guide to setting up flexible sync with common permissions models, see
-   :ref:`flexible-sync-permissions-guide`.
-
-.. _flexible-sync-read-permissions:
-
-Read Permissions
-^^^^^^^^^^^^^^^^
-
-A user with read permissions for a given collection can view all fields of any
-object matching the client-side query. Read permissions do not permit a user
-to modify data.
-
-.. _flexible-sync-write-permissions:
-
-Write Permissions
-^^^^^^^^^^^^^^^^^
-
-A user with write permissions for a given collection can modify the value of any
-field of any object matching the client-side query. Write permissions require
-read permissions, so any user that can modify data can also view that data
-before and after it's modified.
-
-.. _flexible-sync-field-level-permissions:
-
-Field-Level Permissions
-^^^^^^^^^^^^^^^^^^^^^^^
-
-You can refine document-level permissions on a per-field basis with the
-``fields`` and ``additional_fields`` properties of the **Role** configuration
-object.
-
-If the user does not have document-level permissions to a document, field-level
-permissions cannot grant access to that document. Field-level permissions can
-only refine the permissions on documents that a user can access. For example,
-you can use field-level permissions to forbid writes on a specific field of a
-document that a user may otherwise write to.
-
-The ``additional_fields`` property defines the field-level permissions for
-fields that you don't explicitly define in the ``fields`` object. If you don't
-define ``additional_fields`` or its read/write properties, the system uses the
-corresponding document-level permission for any field not mentioned in
-``fields``.
-
-In practice, you can use ``additional_fields`` to start with all fields
-**restricted** and use ``fields`` to grant access to a few specific fields.
-Conversely, you can omit ``additional_fields`` to start with all fields
-**unrestricted** and use ``fields`` to restrict a few specific fields.
-
-In addition to ``read`` and ``write``, you can specify ``fields`` and
-``additional_fields`` rules for embedded object fields. In this case, ``read``
-and ``write`` are "document-level" to the embedded object field, while
-``fields`` and ``additional_fields`` are "field-level". In other words, ``read``
-and ``write`` determine permissions on the embedded object as a whole, while
-``fields`` and ``additional_fields`` refine those permissions on a per-field
-basis. 

--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -333,6 +333,7 @@ existing session role until the next time they start the app.
    session role with per-document logic defined in the session role's
    read and write expressions.
 
+.. _type-specific-roles:
 .. _default-roles:
 
 Type-Specific and Default Roles


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-23201): Flexible sync type-specific & field-level permissions

### Staged Changes (Requires MongoDB Corp SSO)


- [Flexible Sync Configuration](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/sync-rules/manage-apps/configure/config/sync/#flexible-sync-configuration)
- [Session Roles](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/sync-rules/sync/data-access-patterns/permissions/#session-roles)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
