### PR TITLE
(DOCSP-24152): No GraphQL relationships for object array fields

### DIFF
--- a/source/graphql.txt
+++ b/source/graphql.txt
@@ -215,3 +215,8 @@ Limitations
   or mutation. If an operation specifies a relationship deeper than
   {+max-graphql-relationship-depth+} resolvers, the entire operation
   fails with the error message ``"max relationship depth exceeded"``.
+
+- The GraphQL API does not currently support relationships for fields
+  inside arrays of embedded objects. You can use a :ref:`custom resolver
+  <graphql-custom-resolvers>` to manually look up and resolve embedded
+  object array relationships.


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-24152): No GraphQL relationships for object array fields

### Staged Changes (Requires MongoDB Corp SSO)

- [PAGE_NAME](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/graphql-relationship-limitations/graphql/#limitations)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
