### PR TITLE
(DOCSP-24152): No GraphQL relationships for object array fields (pt 2)

### DIFF
--- a/source/schemas/relationships.txt
+++ b/source/schemas/relationships.txt
@@ -293,9 +293,10 @@ with a foreign collection.
 
 .. important::
 
-   {+sync-short+} does not support embedded object relationships.
+   The GraphQL API does not currently support embedded object relationships.
 
-   You can query embedded object relationships with the GraphQL API.
+   You can resolve embedded object relationships with {+sync-short+} and
+   in the Realm SDKs.
 
 .. code-block:: json
 

--- a/source/schemas/relationships.txt
+++ b/source/schemas/relationships.txt
@@ -291,6 +291,12 @@ Embedded Object Within a List
 An embedded object that is within a list property can have a relationship
 with a foreign collection.
 
+.. important::
+
+   {+sync-short+} does not support embedded object relationships.
+
+   You can query embedded object relationships with the GraphQL API.
+
 .. code-block:: json
 
    {


### PR DESCRIPTION
## Pull Request Info

Adds a note in addition to https://github.com/mongodb/docs-app-services/pull/117

### Jira

(DOCSP-24152): No GraphQL relationships for object array fields

### Staged Changes (Requires MongoDB Corp SSO)

- [Relationships > Embedded Object Within a List](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/gql-relationship/schemas/relationships/#embedded-object-within-a-list)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
