### PR TITLE
Recover custom collection rules

### DIFF
--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -548,10 +548,10 @@ information, see :ref:`{+sync+} Configuration Files <appconfig-sync>`.
 Custom Rules Per Collection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can combine custom rules per collection with default roles. The custom
-session role applies to the ``Employees`` collection. The ``Store`` 
-collection is not listed in the configuration, and has no custom session 
-role, so it also evaluates to the default role.
+You can combine custom rules per collection with default roles. This example 
+shows applying a custom rule to the ``Employees`` collection. This app also 
+links to a ``Store`` collection that is not listed in the configuration, 
+and has no custom collection rule, so it evaluates to the default role.
 
 Sync attempts to find a matching session role by traversing the session
 roles in descending order. List the most specific custom session roles

--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -345,21 +345,15 @@ objects regardless of their type. You use :ref:`expressions
 <expressions>` to determine when a role applies and to define dynamic
 field-level permissions for a specific role.
 
-.. _flexible-sync-collection-level-rules:
-
-Collection-Level Rules
-~~~~~~~~~~~~~~~~~~~~~~
-
-You can create rules that apply to an entire collection, and combine
-them with default roles. This example shows applying a custom rule to the 
-``Employees`` collection. This app also links to a ``Store`` collection 
-that is not listed in the configuration, and has no custom collection rule, 
-so it evaluates to the default role.
+You can use type-specific roles alongside default roles. This example shows 
+applying a custom rule to the ``Employees`` collection. This app also 
+links to a ``Store`` collection that is not listed in the configuration, 
+and has no custom type-specific rule, so it evaluates to the default role.
 
 Sync attempts to find a matching session role by traversing the session
 roles in descending order. List the most specific custom session roles
 first, getting gradually more general, so the user "falls through" to
-the correct session role. If no collection-specific role applies, and you 
+the correct session role. If no type-specific role applies, and you 
 have defined a default role that does apply, the user gets the default role 
 permissions.
 

--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -546,7 +546,7 @@ information, see :ref:`{+sync+} Configuration Files <appconfig-sync>`.
 .. _flexible-sync-custom-and-default-roles:
 
 Custom Rules Per Collection
-```````````````````````````
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can combine custom rules per collection with default roles. The custom
 session role applies to the ``Employees`` collection. The ``Store`` 

--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -348,7 +348,7 @@ field-level permissions for a specific role.
 .. _flexible-sync-collection-level-rules:
 
 Collection-Level Rules
-^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~
 
 You can create rules that apply to an entire collection, and combine
 them with default roles. This example shows applying a custom rule to the 

--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -345,6 +345,73 @@ objects regardless of their type. You use :ref:`expressions
 <expressions>` to determine when a role applies and to define dynamic
 field-level permissions for a specific role.
 
+.. _flexible-sync-collection-level-rules:
+
+Collection-Level Rules
+^^^^^^^^^^^^^^^^^^^^^^
+
+You can create rules that apply to an entire collection, and combine
+them with default roles. This example shows applying a custom rule to the 
+``Employees`` collection. This app also links to a ``Store`` collection 
+that is not listed in the configuration, and has no custom collection rule, 
+so it evaluates to the default role.
+
+Sync attempts to find a matching session role by traversing the session
+roles in descending order. List the most specific custom session roles
+first, getting gradually more general, so the user "falls through" to
+the correct session role. If no role applies, and you have defined a
+default role, the user gets the default role permissions.
+
+.. code-block:: json
+
+   {
+    "rules": {
+      "Employees": [
+        {
+          "name": "employeeWriteSelf",
+          "applyWhen": {},
+          "read": {},
+          "write": {
+            "employee_id": "%%user.id"
+          }
+        }
+      ]
+    },
+    "defaultRoles": [
+      {
+        "name": "admin",
+        "applyWhen": {
+          "%%user.custom_data.isGlobalAdmin": true
+        },
+        "read": {},
+        "write": {}
+      },
+      {
+        "name": "owner",
+        "applyWhen": {
+          "%%true": {
+            "%function": {
+              "name": "isOwner",
+              "arguments": [
+                "%%user.id"
+              ]
+            }
+          }
+        },
+        "read": {},
+        "write": {
+          "owner_id": "%%user.custom_data.ownerId"
+        }
+      },
+      {
+        "name": "shoppers",
+        "applyWhen": {},
+        "read": {},
+        "write": false
+      }
+    ]
+  }
+
 Document-Level Permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -542,69 +609,3 @@ information, see :ref:`{+sync+} Configuration Files <appconfig-sync>`.
 
         - May not read or write any other fields despite having document-level
           access to the document.
-
-.. _flexible-sync-custom-and-default-roles:
-
-Custom Rules Per Collection
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-You can combine custom rules per collection with default roles. This example 
-shows applying a custom rule to the ``Employees`` collection. This app also 
-links to a ``Store`` collection that is not listed in the configuration, 
-and has no custom collection rule, so it evaluates to the default role.
-
-Sync attempts to find a matching session role by traversing the session
-roles in descending order. List the most specific custom session roles
-first, getting gradually more general, so the user "falls through" to
-the correct session role. If no role applies, and you have defined a
-default role, the user gets the default role permissions.
-
-.. code-block:: json
-
-   {
-    "rules": {
-      "Employees": [
-        {
-          "name": "employeeWriteSelf",
-          "applyWhen": {},
-          "read": {},
-          "write": {
-            "employee_id": "%%user.id"
-          }
-        }
-      ]
-    },
-    "defaultRoles": [
-      {
-        "name": "admin",
-        "applyWhen": {
-          "%%user.custom_data.isGlobalAdmin": true
-        },
-        "read": {},
-        "write": {}
-      },
-      {
-        "name": "owner",
-        "applyWhen": {
-          "%%true": {
-            "%function": {
-              "name": "isOwner",
-              "arguments": [
-                "%%user.id"
-              ]
-            }
-          }
-        },
-        "read": {},
-        "write": {
-          "owner_id": "%%user.custom_data.ownerId"
-        }
-      },
-      {
-        "name": "shoppers",
-        "applyWhen": {},
-        "read": {},
-        "write": false
-      }
-    ]
-  }

--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -359,8 +359,9 @@ so it evaluates to the default role.
 Sync attempts to find a matching session role by traversing the session
 roles in descending order. List the most specific custom session roles
 first, getting gradually more general, so the user "falls through" to
-the correct session role. If no role applies, and you have defined a
-default role, the user gets the default role permissions.
+the correct session role. If no collection-specific role applies, and you 
+have defined a default role that does apply, the user gets the default role 
+permissions.
 
 .. code-block:: json
 

--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -542,3 +542,69 @@ information, see :ref:`{+sync+} Configuration Files <appconfig-sync>`.
 
         - May not read or write any other fields despite having document-level
           access to the document.
+
+.. _flexible-sync-custom-and-default-roles:
+
+Custom Rules Per Collection
+```````````````````````````
+
+You can combine custom rules per collection with default roles. The custom
+session role applies to the ``Employees`` collection. The ``Store`` 
+collection is not listed in the configuration, and has no custom session 
+role, so it also evaluates to the default role.
+
+Sync attempts to find a matching session role by traversing the session
+roles in descending order. List the most specific custom session roles
+first, getting gradually more general, so the user "falls through" to
+the correct session role. If no role applies, and you have defined a
+default role, the user gets the default role permissions.
+
+.. code-block:: json
+
+   {
+    "rules": {
+      "Employees": [
+        {
+          "name": "employeeWriteSelf",
+          "applyWhen": {},
+          "read": {},
+          "write": {
+            "employee_id": "%%user.id"
+          }
+        }
+      ]
+    },
+    "defaultRoles": [
+      {
+        "name": "admin",
+        "applyWhen": {
+          "%%user.custom_data.isGlobalAdmin": true
+        },
+        "read": {},
+        "write": {}
+      },
+      {
+        "name": "owner",
+        "applyWhen": {
+          "%%true": {
+            "%function": {
+              "name": "isOwner",
+              "arguments": [
+                "%%user.id"
+              ]
+            }
+          }
+        },
+        "read": {},
+        "write": {
+          "owner_id": "%%user.custom_data.ownerId"
+        }
+      },
+      {
+        "name": "shoppers",
+        "applyWhen": {},
+        "read": {},
+        "write": false
+      }
+    ]
+  }


### PR DESCRIPTION
## Pull Request Info

Based on a Slack request.

### Staged Changes (Requires MongoDB Corp SSO)

- [Sync Rules and Permissions -> Collection-Level Rules](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/recover-collection-based-permissions/sync/data-access-patterns/permissions/#collection-level-rules): Recovered section pertaining to Collection-Level Rules, with some tweaks based on how the page has changed between when we lost the section and now.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
