### PR TITLE
(DOCSP-23902): Global URL small fix on Facebook Authentication page

### DIFF
--- a/source/includes/deployment-region-auth-callback-urls.rst
+++ b/source/includes/deployment-region-auth-callback-urls.rst
@@ -8,7 +8,7 @@
    * - | **Global**
      - .. code-block:: text
 
-          https://stitch.mongodb.com/api/client/v2.0/auth/callback
+          https://realm.mongodb.com/api/client/v2.0/auth/callback 
 
    * - | **Virginia**
        | (``us-east-1``)

--- a/source/includes/deployment-region-auth-callback-urls.rst
+++ b/source/includes/deployment-region-auth-callback-urls.rst
@@ -14,40 +14,40 @@
        | (``us-east-1``)
      - .. code-block:: text
 
-          https://us-east-1.aws.stitch.mongodb.com/api/client/v2.0/auth/callback
+          https://us-east-1.aws.realm.mongodb.com/api/client/v2.0/auth/callback
 
    * - | **Oregon**
        | (``us-west-2``)
      - .. code-block:: text
 
-          https://us-west-2.aws.stitch.mongodb.com/api/client/v2.0/auth/callback
+          https://us-west-2.aws.realm.mongodb.com/api/client/v2.0/auth/callback
 
    * - | **Ireland**
        | (``eu-west-1``)
      - .. code-block:: text
 
-          https://eu-west-1.aws.stitch.mongodb.com/api/client/v2.0/auth/callback
+          https://eu-west-1.aws.realm.mongodb.com/api/client/v2.0/auth/callback
 
    * - | **Frankfurt**
        | (``eu-central-1``)
      - .. code-block:: text
 
-          https://eu-central-1.aws.stitch.mongodb.com/api/client/v2.0/auth/callback
+          https://eu-central-1.aws.realm.mongodb.com/api/client/v2.0/auth/callback
 
    * - | **Mumbai**
        | (``ap-south-1``)
      - .. code-block:: text
 
-          https://ap-south-1.aws.stitch.mongodb.com/api/client/v2.0/auth/callback
+          https://ap-south-1.aws.realm.mongodb.com/api/client/v2.0/auth/callback
 
    * - | **Singapore**
        | (``ap-southeast-1``)
      - .. code-block:: text
 
-          https://ap-southeast-1.aws.stitch.mongodb.com/api/client/v2.0/auth/callback
+          https://ap-southeast-1.aws.realm.mongodb.com/api/client/v2.0/auth/callback
 
    * - | **Sydney**
        | (``ap-southeast-2``)
      - .. code-block:: text
 
-          https://ap-southeast-2.aws.stitch.mongodb.com/api/client/v2.0/auth/callback
+          https://ap-southeast-2.aws.realm.mongodb.com/api/client/v2.0/auth/callback


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-23902

### Staged Changes (Requires MongoDB Corp SSO)

- [Facebook Authentication](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-23902-url-fix/authentication/facebook/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
