### PR TITLE
(DOCSP-25418) Add Data API & GraphQL to TLS Security

### DIFF
--- a/source/manage-apps/secure.txt
+++ b/source/manage-apps/secure.txt
@@ -190,9 +190,10 @@ Transport Layer Security (TLS)
 App Services uses `TLS 1.3 <https://datatracker.ietf.org/doc/html/rfc8446>`__
 to secure all network requests to and from your application, including:
 
-- Apps that connect from a {+client-sdk+} 
-- Queries and operations on a linked {+atlas+} data source. 
-  
+- Apps that connect from a {+client-sdk+}.
+- Data API and GraphQL requests sent over HTTPS.
+- Queries and operations on a linked {+atlas+} data source.
+
 The TLS certificate is pre-defined and cannot be customized or disabled.
 
 .. _realm-public-ips:


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-25418) Add Data API & GraphQL to TLS Security

### Staged Changes (Requires MongoDB Corp SSO)

- [Security > Transport Layer Security (TLS)](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/api-tls/manage-apps/secure/#transport-layer-security--tls-)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
