### PR TITLE
(DOCSP-20113): Remove out-of-date, inaccurate note

### DIFF
--- a/source/manage-apps/deploy/automated/deploy-automatically-with-github.txt
+++ b/source/manage-apps/deploy/automated/deploy-automatically-with-github.txt
@@ -120,23 +120,6 @@ Enable Automatic Deployment with GitHub
       application. You can create the application directory manually or :doc:`export
       the application directory </manage-apps/configure/export-app>` of an existing app.
 
-      .. important::
-
-         In order to deploy successfully, your git repository *must not* contain
-         some fields that are present in your application export.
-
-         If you are using :ref:`realm-cli v1.x <realm-cli-v1>` for the v1 app
-         structure, use the ``--for-source-control`` flag when you export an app.
-         This flag omits the ``name``, ``app_id``, ``location``, and ``deployment_model``
-         fields in the ``config.json`` file, and the ``config.clusterName`` field of
-         the ``config.json`` of any Atlas :ref:`data sources <link-a-data-source>`
-         connected to the application.
-
-         If you are using the :ref:`realm-cli v2.x <realm-cli>` for the v2 app
-         structure, ``--for-source-control`` is no longer an available flag. The
-         v2 app structure no longer contains most of those references. The only
-         field you must remove is the ``app_id`` from the ``realm_config.json`` file.
-
       Add the application directory to the repository and then commit the changes:
 
       .. code-block:: shell


### PR DESCRIPTION
## Pull Request Info

remove note that is:

- out of date with realm-cli v1 related guidance
- inaccurate about realm-cli v2
- generally confusing

### Jira

- https://jira.mongodb.org/browse/DOCSP-20113

### Staged Changes (Requires MongoDB Corp SSO)

- [Deploy Automatically with Github](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-20113/manage-apps/deploy/automated/deploy-automatically-with-github/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
