### PR TITLE
(DOCSP-25395): Update App Services docs for Client Reset with Recovery

### DIFF
--- a/source/includes/destructive-schema-change-app-update.rst
+++ b/source/includes/destructive-schema-change-app-update.rst
@@ -2,7 +2,8 @@
 
    After a breaking schema change:
 
-   - All clients must perform a client reset.
+   - All clients must perform a :ref:`manual client reset 
+     <manually-recover-unsynced-changes>`.
    - You must update client models affected by the breaking schema change.
 
 

--- a/source/manage-apps/configure/config/sync.txt
+++ b/source/manage-apps/configure/config/sync.txt
@@ -33,6 +33,7 @@ app uses this Sync configuration:
    :caption: sync/config.json
    
    {
+     "type": "partition",
      "state": <"enabled" | "disabled">,
      "development_mode_enabled": <Boolean>,
      "service_name": "<Data Source Name>",
@@ -46,7 +47,8 @@ app uses this Sync configuration:
        }
      },
      "last_disabled": <Number>,
-     "client_max_offline_days": <Number>
+     "client_max_offline_days": <Number>,
+     "is_recovery_mode_disabled": <Boolean>
    }
 
 .. list-table::
@@ -55,6 +57,15 @@ app uses this Sync configuration:
 
    * - Field
      - Description
+
+   * - | ``type``
+       | String
+     - The :ref:`Sync Mode <sync-modes>` that determines how users can access
+       data in client applications.
+
+       Valid Options:
+
+       - ``"partition"``
 
    * - | ``state``
        | String
@@ -129,6 +140,13 @@ app uses this Sync configuration:
        process waits before aggressively pruning metadata that some clients
        require to synchronize from an old version of a {+realm+}.
 
+   * - | ``is_recovery_mode_disabled``
+       | Boolean
+     - If ``false``, :ref:`Recovery Mode <recover-unsynced-changes>` is enabled
+       for the application. While enabled, Realm SDKs that support this feature 
+       attempt to recover unsynced changes upon performing a client reset.
+       Recovery mode is enabled by default.
+
 .. _flexible-sync-config-object:
 
 Flexible Sync Configuration
@@ -146,6 +164,8 @@ Sync configuration:
      "service_name": "<Data Source Name>",
      "database_name": "<Development Mode Database Name>",
      "state": <"enabled" | "disabled">,
+     "client_max_offline_days": <Number>,
+     "is_recovery_mode_disabled": <Boolean>,
      "permissions": {
        "rules": {
          "<Type Name>": [
@@ -192,7 +212,8 @@ Sync configuration:
    * - | ``type``
        | String
      
-     - The :ref:`Sync Mode <sync-modes>` for the application.
+     - The :ref:`Sync Mode <sync-modes>` that determines how users can access
+       data in client applications.
        
        Valid Options:
 
@@ -231,6 +252,20 @@ Sync configuration:
        - ``"enabled"``
        - ``"disabled"``
 
+   * - | ``client_max_offline_days``
+       | Number
+     
+     - Controls how long the :ref:`backend compaction <optimize-sync-atlas-usage>`
+       process waits before aggressively pruning metadata that some clients
+       require to synchronize from an old version of a {+realm+}.
+
+   * - | ``is_recovery_mode_disabled``
+       | Boolean
+     - If ``false``, :ref:`Recovery Mode <recover-unsynced-changes>` is enabled
+       for the application. While enabled, Realm SDKs that support this feature 
+       attempt to recover unsynced changes upon performing a client reset.
+       Recovery mode is enabled by default.
+
    * - | ``permissions.rules``
        | Object
      
@@ -264,13 +299,6 @@ Sync configuration:
      - The date and time that sync was last paused or disabled, represented by
        the number of seconds since the Unix epoch (January 1, 1970, 00:00:00
        UTC).
-
-   * - | ``client_max_offline_days``
-       | Number
-     
-     - Controls how long the :ref:`backend compaction <optimize-sync-atlas-usage>`
-       process waits before aggressively pruning metadata that some clients
-       require to synchronize from an old version of a {+realm+}.
 
 .. _appconfig-sync-type-specific-roles:
 

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -280,8 +280,8 @@ Enable Partition-Based Sync
          .. step:: Specify Values for Sync Optimization
 
             Sync provides features that enable you to optimize Sync 
-            performance and improve the client data recovery process. These 
-            features are represented by additional settings:
+            performance and improve the data recovery process on the client. 
+            These features are represented by additional settings:
 
             - ``client_max_offline_days``
             - ``is_recovery_mode_disabled``
@@ -292,12 +292,12 @@ Enable Partition-Based Sync
             
             For more information, see: :ref:`client-maximum-offline-time`.
 
-            Recovery Mode enables Sync to attempt to recover unsynced data 
-            when a client reset occurs. When you enable Sync via the App 
-            Services UI, Recovery Mode is enabled by default. We recommend
-            enabling Recovery Mode for automatic client reset handling.
-            To enable Recovery Mode, set ``is_recovery_mode_disabled`` to 
-            ``false``.
+            Recovery Mode enables Sync to attempt to recover data that 
+            has not yet been synced when a client reset occurs. When you 
+            enable Sync via the App Services UI, Recovery Mode is enabled 
+            by default. We recommend enabling Recovery Mode for automatic 
+            client reset handling. If you have disabled recovery mode and 
+            want to re-enable it, set ``is_recovery_mode_disabled`` to ``false``.
             
             For more information, see: :ref:`recover-unsynced-changes`.
 

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -75,7 +75,7 @@ Enable Partition-Based Sync
 
             You can enable Device Sync for a single linked cluster in your application.
             Determine which cluster you want to use and then select it from the
-            :guilabel:`Select Cluster To Device Sync` dropdown menu.
+            :guilabel:`Select a Cluster To Sync` dropdown menu.
 
             .. figure:: /images/define-sync-rules-select-cluster.png
                :width: 750px
@@ -1046,7 +1046,7 @@ Enable Flexible Sync
             Specify the values for these settings:
 
             .. code-block:: json
-               :emphasize-lines: 9-10
+               :emphasize-lines: 10-11
 
                {
                  ...

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -552,7 +552,7 @@ Enable Partition-Based Sync
                curl https://realm.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services/{MongoDB_Service_ID}/config \
                  -X PATCH \
                  -h 'Authorization: Bearer <Valid Access Token>' \
-                 -d '"sync": {"type": "partition", "state": "enabled", "development_mode_enabled": <Boolean>, "database_name": "<Database Name>", "partition": { "key": "owner_id", "type": "string", "permissions": { "read": { "$or": [{ "%%user.id": "%%partition" }, { "%%user.custom_data.shared": "%%partition" }]}, "write": { "%%user.id": "%%partition"}}}, "client_max_offline_days": <Number>, "is_recovery_mode_disabled": <Boolean>}'
+                 -d @/sync/config.json
 
 .. _enable-flexible-sync:
 
@@ -1086,4 +1086,4 @@ Enable Flexible Sync
                  -X PATCH \
                  -h 'Authorization: Bearer <Valid Access Token>' \
                  -h "Content-Type: application/json"
-                 -d @/some-directory/config.json
+                 -d @/sync/config.json

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -42,8 +42,8 @@ configure your data model and access Device Sync, see:
    unless you are using :ref:`Development Mode <enable-development-mode>`.
    
    At a minimum, the schema must define ``_id`` and the field that you intend to
-   use as your partition key. A partition key field may be a ``string``,
-   ``integer``, or ``objectId``.
+   use as your :ref:`partition key <partition-key>` or :ref:`queryable field 
+   <queryable-fields>`.
    
    For more details on how to define a schema, see :ref:`enforce-a-schema`.
 
@@ -122,6 +122,19 @@ Enable Partition-Based Sync
                :width: 750px
                :alt: The partition read and write expression inputs
 
+         .. step:: Check Default Advanced Configuration Behaviors
+
+            Expand the :guilabel:`Advanced Configuration` section.
+
+            App Services Apps provide advanced optimization features 
+            that are enabled by default:
+
+            - :ref:`Client Max Offline Time <client-maximum-offline-time>`
+            - :ref:`Client Recovery <recover-unsynced-changes>`
+
+            If you want to change the length of time that a client can be 
+            offline, or disable either of these features, you can do so 
+            in the :guilabel:`Advanced Configuration` section.
 
          .. step:: Turn On Sync
 
@@ -132,6 +145,13 @@ Enable Partition-Based Sync
      
    .. tab::
       :tabid: cli
+
+      This procedure assumes you have :ref:`created an App Services App 
+      <create-app-cli>` and have linked a data source.
+
+      If you have not yet linked the cluster to your application, follow the
+      :ref:`link-a-data-source` guide to link it before
+      you continue.
       
       .. procedure::
 
@@ -146,36 +166,38 @@ Enable Partition-Based Sync
                realm-cli pull --remote="<Your App ID>"
 
 
-         .. step:: Select a Cluster to Sync
+         .. step:: Add a Sync Configuration
 
             You can enable sync for a single linked cluster in your application.
             If you have not yet linked the cluster to your application, follow the
             :ref:`link-a-data-source` guide to link it before
             you continue.
 
-            Determine which cluster you want to use and then open its configuration file.
-            Add the ``config.sync`` field with the following value:
+            The App Services App has a ``sync`` directory where you can find 
+            the :ref:`sync configuration file <appconfig-sync>`. If you have not 
+            yet enabled Sync, this directory is empty.
+
+            Add a ``config.json`` similar to:
 
             .. code-block:: json
 
                {
-                 "config": {
-                   "sync": {
-                     "state": "enabled",
-                     "partition": {
-                       "key": "<Partition Key Field>",
-                       "type": "<Partition Key Type>",
-                       "permissions": {
-                         "read": {},
-                         "write": {}
-                       }
-                     }
-                   },
-                   ...
+                 "type": "partition",
+                 "state": <"enabled" | "disabled">,
+                 "development_mode_enabled": <Boolean>,
+                 "service_name": "<Data Source Name>",
+                 "database_name": "<Database Name>",
+                 "partition": {
+                   "key": "<Partition Key Field Name>",
+                   "type": "<Partition Key Type>",
+                   "permissions": {
+                     "read": { <Expression> },
+                     "write": { <Expression> }
+                   }
                  },
-                 ...
+                 "client_max_offline_days": <Number>,
+                 "is_recovery_mode_disabled": <Boolean>
                }
-
 
          .. step:: Choose a Partition Key
 
@@ -196,31 +218,25 @@ Enable Partition-Based Sync
               pre-existing data with invalid or missing partition values from a
               MongoDB collection.
 
-            Once you have decided which field to use, update ``config.sync.partition``
+            Once you have decided which field to use, update ``sync.partition``
             with the partition key field name in the ``key`` field and the partition key
-            type in the ``type`` field.
+            type in the ``type`` field, similar to:
 
             .. code-block:: json
-               :emphasize-lines: 6, 7
+               :emphasize-lines: 4, 5
 
                {
-                 "config": {
-                   "sync": {
-                     "state": "enabled",
-                     "partition": {
-                       "key": "owner_id",
-                       "type": "string",
-                       "permissions": {
-                         "read": {},
-                         "write": {}
-                       }
-                     }
-                   },
-                   ...
-                 },
+                 ...
+                 "partition": {
+                   "key": "owner_id",
+                   "type": "string",
+                   "permissions": {
+                     "read": {},
+                     "write": {}
+                   }
+                 }
                  ...
                }
-
 
          .. step:: Define Read & Write Permissions
 
@@ -236,36 +252,70 @@ Enable Partition-Based Sync
 
             Once you've determined how to decide a user's read and write permissions for a
             given partition, define the corresponding JSON expressions in the
-            ``read`` and ``write`` fields of ``config.sync.partition.permissions``.
+            ``read`` and ``write`` fields of ``partition.permissions``, similar to:
 
             .. code-block:: json
-               :emphasize-lines: 9-14, 15-17
+               :emphasize-lines: 7-15
 
                {
-                 "config": {
-                   "sync": {
-                     "state": "enabled",
-                     "partition": {
-                       "key": "owner_id",
-                       "type": "string",
-                       "permissions": {
-                         "read": {
-                           "$or": [
-                             { "%%user.id": "%%partition" },
-                             { "%%user.custom_data.shared": "%%partition" }
-                           ]
-                         },
-                         "write": {
-                           "%%user.id": "%%partition"
-                         }
-                       }
+                 ...
+                 "partition": {
+                   "key": "owner_id",
+                   "type": "string",
+                   "permissions": {
+                     "read": {
+                       "$or": [
+                         { "%%user.id": "%%partition" },
+                         { "%%user.custom_data.shared": "%%partition" }
+                       ]
+                     },
+                     "write": {
+                       "%%user.id": "%%partition"
                      }
-                   },
-                   ...
-                 },
+                   }
+                 }
                  ...
                }
 
+         .. step:: Specify Values for Sync Optimization
+
+            Sync provides features that enable you to optimize Sync 
+            performance and improve the client data recovery process. These 
+            features are represented by additional settings:
+
+            - ``client_max_offline_days``
+            - ``is_recovery_mode_disabled``
+
+            You can set a numerical value for ``client_max_offline_days``.
+            When you enable Sync via the App Services UI, the default 
+            value is ``30``, which represents 30 days. 
+            
+            For more information, see: :ref:`client-maximum-offline-time`.
+
+            Recovery Mode enables Sync to attempt to recover unsynced data 
+            when a client reset occurs. When you enable Sync via the App 
+            Services UI, Recovery Mode is enabled by default. We recommend
+            enabling Recovery Mode for automatic client reset handling.
+            To enable Recovery Mode, set ``is_recovery_mode_disabled`` to 
+            ``false``.
+            
+            For more information, see: :ref:`recover-unsynced-changes`.
+
+            .. code-block:: json
+               :emphasize-lines: 10-11
+
+               {
+                 "type": "partition",
+                 "state": "enabled",
+                 "development_mode_enabled": true,
+                 "service_name": "mongodb-atlas",
+                 "database_name": "my-test-database",
+                 "partition": {
+                   ...
+                 },
+                 "client_max_offline_days": 30,
+                 "is_recovery_mode_disabled": false
+               }
 
          .. step:: Deploy the Sync Configuration
 
@@ -273,12 +323,11 @@ Enable Partition-Based Sync
             permissions, you can deploy your changes to start syncing data and enforcing
             sync rules.
 
-            To deploy your changes, import your app configuration:
+            To deploy your changes, import your app configuration to your App Services App:
 
             .. code-block:: shell
 
                realm-cli push --remote="<Your App ID>"
-
      
    .. tab::
       :tabid: api
@@ -287,13 +336,14 @@ Enable Partition-Based Sync
 
          .. step:: Select a Cluster to Sync
 
-            You can enable sync for a single linked cluster in your application.
+            You can enable Sync for a single linked cluster in your application.
             If you have not yet linked the cluster to your application, follow the
             :ref:`link-a-data-source` guide to link it before
             you continue.
 
             You'll need the cluster's service configuration file to configure sync. You
-            can find the configuration file by listing all services through the Admin API:
+            can find the configuration file by :admin-api-endpoint:`listing all services 
+            through the Admin API <operation/adminListServices>`:
 
             .. code-block:: shell
 
@@ -301,33 +351,45 @@ Enable Partition-Based Sync
                  -X GET \
                  -h 'Authorization: Bearer <Valid Access Token>'
 
-            Once you have the configuration, add the ``config.sync`` field with the
+            Identify the service whose configuration you need to update to enable
+            Sync. If you have accepted the default names when configuring 
+            your App, this should be a service whose ``name`` is ``mongodb-atlas``
+            and ``type`` is ``mongodb-atlas``. You need this service's ``_id``.
+
+            Now you can :admin-api-endpoint:`get the configuration file for 
+            this service <operation/adminGetServiceConfig>`:
+
+            .. code-block:: shell
+
+               curl https://realm.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services/{MongoDB_Service_ID}/config \
+                 -X GET \
+                 -h 'Authorization: Bearer <Valid Access Token>'
+
+            Once you have the configuration, add the ``sync`` object with the
             following template configuration:
 
             .. code-block:: json
 
                {
-                 "config": {
-                   "sync": {
-                     "state": "enabled",
-                     "partition": {
-                       "key": "<Partition Key Field>",
-                       "type": "<Partition Key Type>",
-                       "permissions": {
-                         "read": {},
-                         "write": {}
-                       }
+                 ...
+                 "sync": {
+                   "type": "partition",
+                   "state": "enabled",
+                   "development_mode_enabled": <Boolean>,
+                   "database_name": "<Database Name>",
+                   "partition": {
+                     "key": "<Partition Key Field Name>",
+                     "type": "<Partition Key Type>",
+                     "permissions": {
+                       "read": { <Expression> },
+                       "write": { <Expression> }
                      }
                    },
-                   ...
-                 },
+                   "client_max_offline_days": <Number>,
+                   "is_recovery_mode_disabled": <Boolean>
+                 }
                  ...
                }
-
-            .. seealso::
-
-               :admin-api-endpoint:`Admin API: List All Services <operation/adminListServices>`
-
 
          .. step:: Choose a Partition Key
 
@@ -337,7 +399,8 @@ Enable Partition-Based Sync
             patterns. For more information on partition keys and how to choose one, see
             :ref:`Partitions <sync-partitions>`.
 
-            You can get a list of all valid partition keys and their corresponding types
+            You can :admin-api-endpoint:`get a list of all valid partition 
+            keys <operation/adminGetSync>` and their corresponding types 
             through the Admin API:
 
             .. code-block:: shell
@@ -357,35 +420,33 @@ Enable Partition-Based Sync
               pre-existing data with invalid or missing partition values from a
               MongoDB collection.
 
-            Once you have decided which field to use, update ``config.sync.partition``
+            Once you have decided which field to use, update ``sync.partition``
             with the partition key field name in the ``key`` field and the partition key
             type in the ``type`` field.
 
             .. code-block:: json
-               :emphasize-lines: 6, 7
+               :emphasize-lines: 9-10
 
                {
-                 "config": {
-                   "sync": {
-                     "state": "enabled",
-                     "partition": {
-                       "key": "owner_id",
-                       "type": "string",
-                       "permissions": {
-                         "read": {},
-                         "write": {}
-                       }
+                 ...
+                 "sync": {
+                   "type": "partition",
+                   "state": "enabled",
+                   "development_mode_enabled": <Boolean>,
+                   "database_name": "<Database Name>",
+                   "partition": {
+                     "key": "owner_id",
+                     "type": "string",
+                     "permissions": {
+                       "read": { <Expression> },
+                       "write": { <Expression> }
                      }
                    },
-                   ...
-                 },
+                   "client_max_offline_days": <Number>,
+                   "is_recovery_mode_disabled": <Boolean>
+                 }
                  ...
                }
-
-            .. seealso::
-
-               :admin-api-endpoint:`Admin API: List Valid Partition Keys <operation/adminGetSync>`
-
 
          .. step:: Define Read & Write Permissions
 
@@ -401,36 +462,81 @@ Enable Partition-Based Sync
 
             Once you've determined how to decide a user's read and write permissions for a
             given partition, define the corresponding JSON expressions in the
-            ``read`` and ``write`` fields of ``config.sync.partition.permissions``.
+            ``read`` and ``write`` fields of ``sync.partition.permissions``.
 
             .. code-block:: json
-               :emphasize-lines: 9-14, 15-17
+               :emphasize-lines: 12-20
 
                {
-                 "config": {
-                   "sync": {
-                     "state": "enabled",
-                     "partition": {
-                       "key": "owner_id",
-                       "type": "string",
-                       "permissions": {
-                         "read": {
-                           "$or": [
-                             { "%%user.id": "%%partition" },
-                             { "%%user.custom_data.shared": "%%partition" }
-                           ]
-                         },
-                         "write": {
-                           "%%user.id": "%%partition"
-                         }
+                 ...
+                 "sync": {
+                   "type": "partition",
+                   "state": "enabled",
+                   "development_mode_enabled": <Boolean>,
+                   "database_name": "<Database Name>",
+                   "partition": {
+                     "key": "owner_id",
+                     "type": "string",
+                     "permissions": {
+                       "read": {
+                         "$or": [
+                           { "%%user.id": "%%partition" },
+                           { "%%user.custom_data.shared": "%%partition" }
+                         ]
+                       },
+                       "write": {
+                         "%%user.id": "%%partition"
                        }
                      }
                    },
-                   ...
-                 },
+                   "client_max_offline_days": <Number>,
+                   "is_recovery_mode_disabled": <Boolean>
+                 }
                  ...
                }
 
+         .. step:: Specify Values for Sync Optimization
+
+            Sync provides features that enable you to optimize Sync 
+            performance and improve the client data recovery process. These 
+            features are represented by additional settings:
+
+            - ``client_max_offline_days``
+            - ``is_recovery_mode_disabled``
+
+            You can set a numerical value for ``client_max_offline_days``.
+            When you enable Sync via the App Services UI, the default 
+            value is ``30``, which represents 30 days. 
+            
+            For more information, see: :ref:`client-maximum-offline-time`.
+
+            Recovery Mode enables Sync to attempt to recover unsynced data 
+            when a client reset occurs. When you enable Sync via the App 
+            Services UI, Recovery Mode is enabled by default. We recommend
+            enabling Recovery Mode for automatic client reset handling.
+            To enable Recovery Mode, set ``is_recovery_mode_disabled`` to 
+            ``false``.
+            
+            For more information, see: :ref:`recover-unsynced-changes`.
+
+            .. code-block:: json
+               :emphasize-lines: 11-12
+
+               {
+                 ...
+                 "sync": {
+                   "type": "partition",
+                   "state": "enabled",
+                   "development_mode_enabled": true,
+                   "database_name": "my-test-database",
+                   "partition": {
+                     ...
+                   },
+                   "client_max_offline_days": 30,
+                   "is_recovery_mode_disabled": false
+                 }
+                 ...
+               }
 
          .. step:: Deploy the Sync Configuration
 
@@ -438,20 +544,15 @@ Enable Partition-Based Sync
             permissions, you can deploy your changes to start syncing data and enforcing
             sync rules.
 
-            To deploy your changes, send an Admin API request that updates the cluster
-            configuration with your sync configuration:
+            To deploy your changes, send an :admin-api-endpoint:`Admin API request that updates the cluster
+            configuration with your sync configuration <operation/adminGetServiceConfig>`:
 
             .. code-block:: shell
 
                curl https://realm.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services/{MongoDB_Service_ID}/config \
                  -X PATCH \
                  -h 'Authorization: Bearer <Valid Access Token>' \
-                 -d '{"sync":{"state":"enabled","database_name":"","partition":{"key":"_partition","type":"string","permissions":{"read":{"$or":[{"%%user.id":"%%partition"},{"%%user.custom_data.shared":"%%partition"}]},"write": {"%%user.id": "%%partition"}}}}'
-
-            .. seealso::
-
-               :admin-api-endpoint:`Admin API: Update a Service Configuration <operation/adminGetServiceConfig>`
-
+                 -d '"sync": {"type": "partition", "state": "enabled", "development_mode_enabled": <Boolean>, "database_name": "<Database Name>", "partition": { "key": "owner_id", "type": "string", "permissions": { "read": { "$or": [{ "%%user.id": "%%partition" }, { "%%user.custom_data.shared": "%%partition" }]}, "write": { "%%user.id": "%%partition"}}}, "client_max_offline_days": <Number>, "is_recovery_mode_disabled": <Boolean>}'
 
 .. _enable-flexible-sync:
 
@@ -567,81 +668,92 @@ Enable Flexible Sync
 
                realm-cli pull --remote="<Your App ID>"
 
+         .. step:: Add a Sync Configuration
 
-         .. step:: Select a Cluster to Sync
-
-            You can enable Device Sync for a single linked cluster in your application.
+            You can enable sync for a single linked cluster in your application.
             If you have not yet linked the cluster to your application, follow the
             :ref:`link-a-data-source` guide to link it before
             you continue.
 
-            Determine which cluster you want to use and then open its configuration file.
-            Add the ``config.flexible_sync`` field with the following template:
+            The App Services App has a ``sync`` directory where you can find 
+            the :ref:`sync configuration file <appconfig-sync>`. If you have not 
+            yet enabled Sync, this directory is empty.
+
+            Add a ``config.json`` similar to:
 
             .. code-block:: json
 
                {
-                   "config": {
-                       "flexible_sync": {
-                           "state": "enabled",
-                           "database_name": "",
-                           "permissions": {
-                               "defaultRoles": [
-                                   {
-                                       "applyWhen": {},
-                                       "name": "all",
-                                       "read": true,
-                                       "write": true
-                                   }
-                               ],
-                               "rules": {}
-                           },
-                           "queryable_fields_names": []
+                 "type": "flexible",
+                 "development_mode_enabled": <Boolean>,
+                 "service_name": "<Data Source Name>",
+                 "database_name": "<Development Mode Database Name>",
+                 "state": <"enabled" | "disabled">,
+                 "client_max_offline_days": <Number>,
+                 "is_recovery_mode_disabled": <Boolean>,
+                 "permissions": {
+                   "rules": {
+                     "<Type Name>": [
+                       {
+                         "name": <String>,
+                         "applyWhen": { <Expression> },
+                         "read": <Expression>,
+                         "write": <Expression>,
+                         "fields": {
+                           "<Field Name>": {
+                             "read": <Boolean>,
+                             "write": <Boolean>,
+                             "fields": <Embedded Object Fields>
+                           }
+                         }
+                         "additional_fields": {
+                           "read": <Boolean>,
+                           "write": <Boolean>
+                         }
                        }
-                   }
+                     ]
+                   },
+                   "defaultRoles": [
+                     {
+                       "name": <String>,
+                       "applyWhen": { <Expression> },
+                       "read": <Expression>,
+                       "write": <Expression>
+                     }
+                   ]       
+                 },
+                 "queryable_fields_names": [
+                   <Array of String Field Names>
+                 ]
                }
-
-            Replace the ``database_name`` field's value with the name of your database.
-
-            .. note::
-
-              The default role applies to any collection where you do not define custom roles.
-              Since there is no custom roles defined in the above example, the default role
-              applies to all collections.
-
 
          .. step:: Choose Queryable Fields
 
             The ``queryable_fields_names`` property allows you to define a set of
-            queryable fields for the device should query on. A queryable field can be any
-            top-level primitive field with a scalar type, this excludes embedded objects or arrays.
+            queryable fields for the device should query on.
 
-            To learn more about queryable fields, read the :ref:`queryable fields
-            <queryable-fields>` documentation.
+            To learn more about queryable fields, such as eligible field types, 
+            reserved field names, and performance implications, see the 
+            :ref:`queryable fields <queryable-fields>` documentation.
 
             .. code-block:: json
+               :emphasize-lines: 12-14
 
                {
-                   "config": {
-                       "flexible_sync": {
-                           "state": "enabled",
-                           "database_name": "",
-                           "permissions": {
-                               "defaultRoles": [
-                                   {
-                                       "applyWhen": {},
-                                       "name": "all",
-                                       "read": true,
-                                       "write": true
-                                   }
-                               ],
-                               "rules": {}
-                           },
-                           "queryable_fields_names": ["age", "name"]
-                       }
-                   }
+                 "type": "flexible",
+                 "development_mode_enabled": <Boolean>,
+                 "service_name": "<Data Source Name>",
+                 "database_name": "<Development Mode Database Name>",
+                 "state": <"enabled" | "disabled">,
+                 "client_max_offline_days": <Number>,
+                 "is_recovery_mode_disabled": <Boolean>,
+                 "permissions": {
+                   ... 
+                 },
+                 "queryable_fields_names": [
+                   ["age", "name"]
+                 ]
                }
-
 
          .. step:: Define Read & Write Permissions
 
@@ -656,44 +768,82 @@ Enable Flexible Sync
             specify a value, App Services will apply the default role to the ``Items`` collection.
 
             .. code-block:: json
+               :emphasize-lines: 5-24
 
                {
-                 "config": {
-                   "flexible_sync": {
-                     "state": "enabled",
-                     "database_name": "test-database",
-                     "permissions": {
-                       "Employees": {
-                         "roles": [
-                           {
-                             "name": "everyone",
-                             "applyWhen": {},
-                             "read": { "owner_id": "%%user.id" },
-                             "write": false
-                           }
-                         ]
-                       },
-                       "Items": {},
-                       "defaultRoles": [
-                         {
-                           "applyWhen": {},
-                           "name": "all",
-                           "read": true,
-                           "write": true
+                 "type": "flexible",
+                 ...
+                 "permissions": {
+                   "Employees": {
+                     "roles": [
+                       {
+                         "name": "everyone",
+                         "applyWhen": {},
+                         "read": { "owner_id": "%%user.id" },
+                           "write": false
                          }
-                       ],
-                       "rules": {}
-                     },
-                     "queryable_fields_names": ["age", "name"]
-                   }
-                 }
+                     ]
+                   },
+                   "Items": {},
+                   "defaultRoles": [
+                     {
+                       "applyWhen": {},
+                       "name": "all",
+                       "read": true,
+                       "write": true
+                     }
+                    ],
+                   "rules": {}
+                 },
+                 "queryable_fields_names": ["age", "name"]
                }
 
+         .. step:: Specify Values for Sync Optimization
+
+            Sync provides features that enable you to optimize Sync 
+            performance and improve the client data recovery process. These 
+            features are represented by additional settings:
+
+            - ``client_max_offline_days``
+            - ``is_recovery_mode_disabled``
+
+            You can set a numerical value for ``client_max_offline_days``.
+            When you enable Sync via the App Services UI, the default 
+            value is ``30``, which represents 30 days. 
+            
+            For more information, see: :ref:`client-maximum-offline-time`.
+
+            Recovery Mode enables Sync to attempt to recover unsynced data 
+            when a client reset occurs. When you enable Sync via the App 
+            Services UI, Recovery Mode is enabled by default. We recommend
+            enabling Recovery Mode for automatic client reset handling.
+            To enable Recovery Mode, set ``is_recovery_mode_disabled`` to 
+            ``false``.
+            
+            For more information, see: :ref:`recover-unsynced-changes`.
+
+            Specify the values for these settings:
+
+            .. code-block:: json
+               :emphasize-lines: 4-5
+
+               {
+                 "type": "flexible",
+                 ...
+                 "client_max_offline_days": 30,
+                 "is_recovery_mode_disabled": false,
+                 "permissions": {
+                   ... 
+                 },
+                 "queryable_fields_names": [
+                   ["age", "name"]
+                 ]
+               }
 
          .. step:: Deploy the Sync Configuration
 
-            Now that you've defined the Device Sync configuration, including read and write
-            permissions, you can deploy your changes to start syncing data and enforcing
+            Now that you've defined the Device Sync configuration, you can 
+            deploy your changes to start syncing data and enforcing
             Device Sync rules.
 
             To deploy your changes, import your app configuration:
@@ -714,9 +864,6 @@ Enable Flexible Sync
             :ref:`link-a-data-source` guide to link it before
             you continue.
 
-            You'll need the cluster's service configuration file to configure Device Sync. You
-            can find the configuration file by listing all services through the Admin API:
-
             .. note:: Authenticating Your Request with an Access Token
 
               To authenticate your request to the App Services Admin API, you need a valid and
@@ -724,36 +871,56 @@ Enable Flexible Sync
               :admin-api-endpoint:`API Authentication <section/Get-Authentication-Tokens>`
               documentation to learn how to acquire a valid access token.
 
+            You'll need the cluster's service configuration file to configure sync. You
+            can find the configuration file by :admin-api-endpoint:`listing all services 
+            through the Admin API <operation/adminListServices>`:
+
             .. code-block:: shell
 
                curl https://realm.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services \
                  -X GET \
                  -h 'Authorization: Bearer <Valid Access Token>'
 
-            Once you have the configuration, add the ``config.flexible_sync`` field with the
+            Identify the service whose configuration you need to update to enable
+            Sync. If you have accepted the default names when configuring 
+            your App, this should be a service whose ``name`` is ``mongodb-atlas``
+            and ``type`` is ``mongodb-atlas``. You need this service's ``_id``.
+
+            Now you can :admin-api-endpoint:`get the configuration file for 
+            this service <operation/adminGetServiceConfig>`:
+
+            .. code-block:: shell
+
+               curl https://realm.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services/{MongoDB_Service_ID}/config \
+                 -X GET \
+                 -h 'Authorization: Bearer <Valid Access Token>'
+
+            Once you have the configuration, add the ``flexible_sync`` object with the
             following template configuration:
 
             .. code-block:: json
 
                {
-                   "config": {
-                       "flexible_sync": {
-                           "state": "enabled",
-                           "database_name": "",
-                           "permissions": {
-                               "defaultRoles": [
-                                   {
-                                       "applyWhen": {},
-                                       "name": "all",
-                                       "read": true,
-                                       "write": true
-                                   }
-                               ],
-                               "rules": {}
-                           },
-                           "queryable_fields_names": []
+                 ...
+                 "flexible_sync": {
+                   "state": "enabled",
+                   "database_name": "",
+                   "permissions": {
+                     "defaultRoles": [
+                       {
+                         "applyWhen": {},
+                         "name": "all",
+                         "read": true,
+                         "write": true
                        }
-                   }
+                     ],
+                     "rules": {}
+                   },
+                   "queryable_fields_names": [],
+                   "client_max_offline_days": <Number>,
+                   "is_recovery_mode_disabled": <Boolean>
+                 }
+                 ...
                }
 
             Replace the ``database_name`` field's value with the name of your database.
@@ -762,48 +929,46 @@ Enable Flexible Sync
 
               The default role applies to any collection where you do not define custom roles.
               Since no custom roles are defined in the above example, the default role
-              applies to all collections.
-
-            .. seealso::
-
-              :ref:`Default Roles <default-roles>`
-
+              applies to all collections. For more information, see: 
+              :ref:`Default Roles <default-roles>`.
 
          .. step:: Choose Queryable Fields
 
-            The ``queryable_fields_names`` property defines a set of queryable fields that
-            the device may query on. A queryable field can be any top-level primitive
-            field with a scalar type. A queryable field cannot be an embedded object or
-            array.
+            The ``queryable_fields_names`` property defines a set of queryable 
+            fields that the device may query on. 
+            
+            To learn more about queryable fields, such as eligible field types, 
+            reserved field names, and performance implications, see the 
+            :ref:`queryable fields <queryable-fields>` documentation.
 
-            To learn more about queryable fields, read the :ref:`queryable fields
-            <queryable-fields>` documentation.
-
-            Add the fields you would like your application to query on to the ``config.flexible_sync.queryable_fields_names``:
+            Add the fields you would like your application to query on to 
+            the ``flexible_sync.queryable_fields_names``:
 
             .. code-block:: json
+               :emphasize-lines: 17
 
                {
-                   "config": {
-                       "flexible_sync": {
-                           "state": "enabled",
-                           "database_name": "",
-                           "permissions": {
-                               "defaultRoles": [
-                                   {
-                                       "applyWhen": {},
-                                       "name": "all",
-                                       "read": true,
-                                       "write": true
-                                   }
-                               ],
-                               "rules": {}
-                           },
-                           "queryable_fields_names": ["age", "name"]
+                ...
+                 "flexible_sync": {
+                   "state": "enabled",
+                   "database_name": "",
+                   "permissions": {
+                     "defaultRoles": [
+                       {
+                         "applyWhen": {},
+                         "name": "all",
+                         "read": true,
+                         "write": true
                        }
-                   }
+                     ],
+                     "rules": {}
+                   },
+                   "queryable_fields_names": ["age", "name"],
+                   "client_max_offline_days": <Number>,
+                   "is_recovery_mode_disabled": <Boolean>
+                 }
+                 ...
                }
-
 
          .. step:: Define Read & Write Permissions
 
@@ -818,39 +983,85 @@ Enable Flexible Sync
             specify a value, App Services will apply the default role to the ``Items`` collection.
 
             .. code-block:: json
+               :emphasize-lines: 7-26
 
                {
-                 "config": {
-                   "flexible_sync": {
-                     "state": "enabled",
-                     "database_name": "test-database",
-                     "permissions": {
-                       "Employees": {
-                         "roles": [
-                           {
-                             "name": "everyone",
-                             "applyWhen": {},
-                             "read": { "owner_id": "%%user.id" },
-                             "write": false
-                           }
-                         ]
-                       },
-                       "Items": {},
-                       "defaultRoles": [
+                 ...
+                 "flexible_sync": {
+                   "state": "enabled",
+                   "database_name": "test-database",
+                   "permissions": {
+                     "Employees": {
+                       "roles": [
                          {
+                           "name": "everyone",
                            "applyWhen": {},
-                           "name": "all",
-                           "read": true,
-                           "write": true
+                           "read": { "owner_id": "%%user.id" },
+                           "write": false
                          }
-                       ],
-                       "rules": {}
+                       ]
                      },
-                     "queryable_fields_names": ["age", "name"]
-                   }
+                     "Items": {},
+                     "defaultRoles": [
+                       {
+                         "applyWhen": {},
+                         "name": "all",
+                         "read": true,
+                         "write": true
+                       }
+                     ],
+                     "rules": {}
+                   },
+                   "queryable_fields_names": ["age", "name"],
+                   "client_max_offline_days": <Number>,
+                   "is_recovery_mode_disabled": <Boolean>
                  }
+                 ...
                }
 
+         .. step:: Specify Values for Sync Optimization
+
+            Sync provides features that enable you to optimize Sync 
+            performance and improve the client data recovery process. These 
+            features are represented by additional settings:
+
+            - ``client_max_offline_days``
+            - ``is_recovery_mode_disabled``
+
+            You can set a numerical value for ``client_max_offline_days``.
+            When you enable Sync via the App Services UI, the default 
+            value is ``30``, which represents 30 days. 
+            
+            For more information, see: :ref:`client-maximum-offline-time`.
+
+            Recovery Mode enables Sync to attempt to recover unsynced data 
+            when a client reset occurs. When you enable Sync via the App 
+            Services UI, Recovery Mode is enabled by default. We recommend
+            enabling Recovery Mode for automatic client reset handling.
+            To enable Recovery Mode, set ``is_recovery_mode_disabled`` to 
+            ``false``.
+            
+            For more information, see: :ref:`recover-unsynced-changes`.
+
+            Specify the values for these settings:
+
+            .. code-block:: json
+               :emphasize-lines: 9-10
+
+               {
+                 ...
+                 "flexible_sync": {
+                   "state": "enabled",
+                   "database_name": "test-database",
+                   "permissions": {
+                     ...
+                   },
+                   "queryable_fields_names": ["age", "name"],
+                   "client_max_offline_days": 30,
+                   "is_recovery_mode_disabled": false
+                 }
+                 ...
+               }
 
          .. step:: Deploy the Sync Configuration
 
@@ -858,8 +1069,9 @@ Enable Flexible Sync
             permissions, you can deploy your changes to start syncing data and enforcing
             Device Sync rules.
 
-            To deploy your changes, send an Admin API request that updates the cluster
-            configuration with your Device Sync configuration.
+            To deploy your changes, send an :admin-api-endpoint:`Admin API 
+            request <operation/adminGetServiceConfig>` that updates the 
+            cluster configuration with your sync configuration:
 
             .. note:: Authenticating Your Request with an Access Token
 

--- a/source/sync/configure/pause-or-terminate-sync.txt
+++ b/source/sync/configure/pause-or-terminate-sync.txt
@@ -239,7 +239,7 @@ After you have terminated Device Sync, you can re-enable it. Re-enabling
 Device Sync enables your App to begin syncing changes to Atlas again. 
 After you re-enable Device Sync, your App begins accepting incoming
 client connections again. However, if a client had previously connected to
-your App before you terminated Device Sync, you must perform a manual client
+your App before you terminated Device Sync, you must perform a client
 reset for that client to enable it to connect to App Services again.
 
 Procedure
@@ -254,7 +254,7 @@ you must specify the configuration settings again.
 To re-enable Device Sync, follow the steps in the :ref:`enable-sync` guide.
 
 If you are re-enabling Device Sync after you have terminated it, you must 
-perform a manual client reset in your client applications:
+perform a client reset in your client applications:
 
 .. tabs-realm-sdks::
 
@@ -272,6 +272,11 @@ perform a manual client reset in your client applications:
       :tabid: node
       
       Learn how to perform a :ref:`Client Reset using the Node SDK <node-client-resets>`.
+
+   .. tab::
+      :tabid: react-native
+
+      Learn how to perform a :ref:`Client Reset using the React Native SDK <react-native-client-resets>`.
 
    .. tab::
       :tabid: dotnet

--- a/source/sync/data-access-patterns/flexible-sync.txt
+++ b/source/sync/data-access-patterns/flexible-sync.txt
@@ -67,6 +67,7 @@ control on individual collections.
 
 Eligible Field Types
 ~~~~~~~~~~~~~~~~~~~~
+
 Flexible Sync only supports top-level primitive fields with a scalar type as 
 queryable fields. You can also include arrays of these primitives as queryable 
 fields. Flexible Sync does not support embedded objects or arrays of 

--- a/source/sync/data-model/update-schema.txt
+++ b/source/sync/data-model/update-schema.txt
@@ -46,6 +46,8 @@ work with the new schema changes.
    deploy with GitHub. Instead, you should make breaking changes in 
    the App Services UI.
 
+.. _breaking-change-quick-reference:
+
 Breaking vs. Non-Breaking Change Quick Reference
 ------------------------------------------------
 
@@ -270,9 +272,9 @@ How to Remove an Object Type
 
 A breaking server-side schema change requires you to :ref:`terminate sync 
 <terminating-realm-sync>` in the backend, and then :ref:`re-enable 
-<enable-sync>` sync. This triggers a :ref:`client reset <client-resets>`, 
-which can result in client-side data loss. As a result, we do not recommend
-making breaking server-side schema changes.
+<enable-sync>` sync. Breaking schema changes prevent applications from 
+automatically recovering from a :ref:`client reset <handle-a-client-reset>`.
+As a result, we do not recommend making breaking server-side schema changes.
 
 Instead, you can remove the object type from the client-side object model and 
 leave it in place on the server-side schema. 
@@ -369,9 +371,9 @@ How to Change an Object Type Name
 
 A breaking server-side schema change requires you to :ref:`terminate sync 
 <terminating-realm-sync>` in the backend, and then :ref:`re-enable 
-<enable-sync>` sync. This triggers a :ref:`client reset <client-resets>`, 
-which can result in client-side data loss. As a result, we do not recommend
-making breaking server-side schema changes.
+<enable-sync>` sync. Breaking schema changes prevent applications from 
+automatically recovering from a :ref:`client reset <handle-a-client-reset>`.
+As a result, we do not recommend making breaking server-side schema changes.
 
 Instead, you can let the existing collection remain in place with the 
 existing schema, and create a partner collection with the new schema. 
@@ -400,7 +402,7 @@ preferred SDK's migration page.
 
 If you choose to terminate and re-enable sync instead of using the partner
 collection strategy to resolve this type of breaking change, your client 
-application must perform a :ref:`client reset <client-resets>`.
+application must perform a :ref:`manual client reset <manual-client-reset>`.
 
 .. _schema-update-change-property-name:
 
@@ -436,9 +438,9 @@ How to Change a Property Name
 
 A breaking server-side schema change requires you to :ref:`terminate sync 
 <terminating-realm-sync>` in the backend, and then :ref:`re-enable 
-<enable-sync>` sync. This triggers a :ref:`client reset <client-resets>`, 
-which can result in client-side data loss. As a result, we do not recommend
-making breaking server-side schema changes.
+<enable-sync>` sync. Breaking schema changes prevent applications from 
+automatically recovering from a :ref:`client reset <handle-a-client-reset>`.
+As a result, we do not recommend making breaking server-side schema changes.
 
 Instead, you can let the existing collection remain in place with the 
 existing schema, and create a partner collection with the new schema. 
@@ -486,7 +488,7 @@ preferred SDK's migration page.
 
 If you choose to terminate and re-enable sync instead of using the partner
 collection strategy to resolve this type of breaking change, your client 
-application must perform a :ref:`client reset <client-resets>`.
+application must perform a :ref:`manual client reset <manual-client-reset>`.
 
 .. _schema-update-change-property-type-but-keep-name:
 
@@ -509,9 +511,9 @@ How to Change a Property Type but Keep the Name
 
 A breaking server-side schema change requires you to :ref:`terminate sync 
 <terminating-realm-sync>` in the backend, and then :ref:`re-enable 
-<enable-sync>` sync. This triggers a :ref:`client reset <client-resets>`, 
-which can result in client-side data loss. As a result, we do not recommend
-making breaking server-side schema changes.
+<enable-sync>` sync. Breaking schema changes prevent applications from 
+automatically recovering from a :ref:`client reset <handle-a-client-reset>`.
+As a result, we do not recommend making breaking server-side schema changes.
 
 Instead, you can let the existing collection remain in place with the 
 existing schema, and create a partner collection with the new schema. 
@@ -559,7 +561,7 @@ preferred SDK's migration page.
 
 If you choose to terminate and re-enable sync instead of using the partner
 collection strategy to resolve this type of breaking change, your client 
-application must perform a :ref:`client reset <client-resets>`.
+application must perform a :ref:`manual client reset <manual-client-reset>`.
 
 .. _schema-update-change-property-from-optional-to-required:
 
@@ -575,9 +577,9 @@ How to Change a Property from Optional to Required
 
 A breaking server-side schema change requires you to :ref:`terminate sync 
 <terminating-realm-sync>` in the backend, and then :ref:`re-enable 
-<enable-sync>` sync. This triggers a :ref:`client reset <client-resets>`, 
-which can result in client-side data loss. As a result, we do not recommend
-making breaking server-side schema changes.
+<enable-sync>` sync. Breaking schema changes prevent applications from 
+automatically recovering from a :ref:`client reset <handle-a-client-reset>`.
+As a result, we do not recommend making breaking server-side schema changes.
 
 Instead, you can let the existing collection remain in place with the 
 existing schema, and create a partner collection with the new schema. 
@@ -606,7 +608,7 @@ preferred SDK's migration page.
 
 If you choose to terminate and re-enable sync instead of using the partner
 collection strategy to resolve this type of breaking change, your client 
-application must perform a :ref:`client reset <client-resets>`.
+application must perform a :ref:`manual client reset <manual-client-reset>`.
 
 .. _schema-update-change-property-from-required-to-optional:
 
@@ -622,9 +624,9 @@ How to Change a Property from Required to Optional
 
 A breaking server-side schema change requires you to :ref:`terminate sync 
 <terminating-realm-sync>` in the backend, and then :ref:`re-enable 
-<enable-sync>` sync. This triggers a :ref:`client reset <client-resets>`, 
-which can result in client-side data loss. As a result, we do not recommend
-making breaking server-side schema changes.
+<enable-sync>` sync. Breaking schema changes prevent applications from 
+automatically recovering from a :ref:`client reset <handle-a-client-reset>`.
+As a result, we do not recommend making breaking server-side schema changes.
 
 Instead, you can let the existing collection remain in place with the 
 existing schema, and create a partner collection with the new schema. 
@@ -653,7 +655,7 @@ preferred SDK's migration page.
 
 If you choose to terminate and re-enable sync instead of using the partner
 collection strategy to resolve this type of breaking change, your client 
-application must perform a :ref:`client reset <client-resets>`.
+application must perform a :ref:`manual client reset <manual-client-reset>`.
 
 Summary
 -------
@@ -663,4 +665,4 @@ Summary
 - Breaking changes are modifications to existing properties of a schema.
 - To perform breaking schema changes to a synced {+realm+}, create a partner collection with the necessary schema changes and manually copy the data from the first collection to the second collection.
 - To keep partner collections up-to-date with each other, set up database triggers to copy changed data from one collection to its partner.
-- You can implement a breaking change by terminating and re-enabling sync and performing a client reset, but it is not recommended.
+- You can implement a breaking change by terminating and re-enabling sync and performing a manual client reset, but it is not recommended.

--- a/source/sync/data-model/update-schema.txt
+++ b/source/sync/data-model/update-schema.txt
@@ -403,6 +403,8 @@ preferred SDK's migration page.
 If you choose to terminate and re-enable sync instead of using the partner
 collection strategy to resolve this type of breaking change, your client 
 application must perform a :ref:`manual client reset <manual-client-reset>`.
+You can define an error handler in your client application code to execute
+some custom logic in this scenario.
 
 .. _schema-update-change-property-name:
 
@@ -489,6 +491,8 @@ preferred SDK's migration page.
 If you choose to terminate and re-enable sync instead of using the partner
 collection strategy to resolve this type of breaking change, your client 
 application must perform a :ref:`manual client reset <manual-client-reset>`.
+You can define an error handler in your client application code to execute
+some custom logic in this scenario.
 
 .. _schema-update-change-property-type-but-keep-name:
 
@@ -562,6 +566,8 @@ preferred SDK's migration page.
 If you choose to terminate and re-enable sync instead of using the partner
 collection strategy to resolve this type of breaking change, your client 
 application must perform a :ref:`manual client reset <manual-client-reset>`.
+You can define an error handler in your client application code to execute
+some custom logic in this scenario.
 
 .. _schema-update-change-property-from-optional-to-required:
 
@@ -609,6 +615,8 @@ preferred SDK's migration page.
 If you choose to terminate and re-enable sync instead of using the partner
 collection strategy to resolve this type of breaking change, your client 
 application must perform a :ref:`manual client reset <manual-client-reset>`.
+You can define an error handler in your client application code to execute
+some custom logic in this scenario.
 
 .. _schema-update-change-property-from-required-to-optional:
 
@@ -656,6 +664,8 @@ preferred SDK's migration page.
 If you choose to terminate and re-enable sync instead of using the partner
 collection strategy to resolve this type of breaking change, your client 
 application must perform a :ref:`manual client reset <manual-client-reset>`.
+You can define an error handler in your client application code to execute
+some custom logic in this scenario.
 
 Summary
 -------

--- a/source/sync/error-handling/client-resets.txt
+++ b/source/sync/error-handling/client-resets.txt
@@ -25,7 +25,7 @@ automatically handle client resets under most scenarios.
    
    By default, the client reset process attempts to recover unsynced changes
    that were successfully saved locally. When your client application 
-   has schema changes, or if :ref:`Recovery Mode <recover-unsynced-changes>` 
+   has breaking schema changes, or if :ref:`Recovery Mode <recover-unsynced-changes>` 
    is disabled on the server, the client reset process cannot recover unsynced
    data that may be persisted locally on the device.
 
@@ -97,16 +97,16 @@ During an automatic client reset, the client:
 #. Applies that set of steps to transform the local realm into a state
    where it can sync with the backend. 
    
-   If there are no schema changes, the SDK attempts to recover all local 
-   changes that have not yet synced to the backend. It also applies 
-   any inserts, updates, and deletes from the backend that haven't yet 
-   synced to the client.
+   If there are no schema changes, or only non-breaking schema changes, 
+   the SDK attempts to recover all local changes that have not yet synced 
+   to the backend. It also applies any inserts, updates, and deletes 
+   from the backend that haven't yet synced to the client.
 
-   If there are non-breaking schema changes, or if Recovery Mode cannot 
-   recover unsynced changes, the SDK can discard local changes that have 
-   not yet synced to the backend. Then it can apply any inserts, updates, 
-   and deletes from the backend that haven't yet synced to the client.
-   To fall back to discard local changes, choose your preferred SDK's 
+   If you have chosen to discard unsynced changes in the SDK, or if Recovery 
+   Mode cannot recover unsynced changes, the SDK can discard local changes 
+   that have not yet synced to the backend. Then it can apply any inserts, 
+   updates, and deletes from the backend that haven't yet synced to the 
+   client. To fall back to discard local changes, choose your preferred SDK's 
    version of the ``recoverOrDiscard`` client reset mode.
 
 #. Discards the fresh copy. The app continues to use
@@ -116,6 +116,17 @@ In a breaking schema change, or if automatic client reset fails, the client
 reset falls back to a :ref:`manual client reset handler <manual-client-reset>` 
 that your app must define. The Realm SDKs cannot automatically perform a 
 client reset when you make a breaking schema change.
+
+Automatic client reset mode has several advantages compared to manual recovery:
+
+- Your application can perform a client reset without writing any custom
+  logic, other than specifying the mode. You don't have to manually
+  initiate the client reset or interact with the error object at all.
+- Your application can perform a client reset without closing any
+  realms, disconnecting from the backend app, or manual restarts. This
+  means you don't have to write any logic to handle these situations.
+- Application users receive notifications for changes as the local realm
+  updates to match the state of the backend realm.
 
 .. _recover-unsynced-changes:
 
@@ -131,12 +142,13 @@ the client reset.
 After the client reset, the app can open and operate as usual. 
 
 Client Recovery can recover unsynced data in client resets except where 
-there has been a schema change. Client Recovery applies :ref:`client-reset-recovery-rules`
-when determining how to integrate unsynced data from the device.
+there has been a breaking schema change. Client Recovery applies 
+:ref:`client-reset-recovery-rules` when determining how to integrate 
+unsynced data from the device.
 
-If your app has a :ref:`non-breaking schema change <breaking-change-quick-reference>`, 
-you can choose to fall back to :ref:`discard-unsynced-changes`. You cannot 
-recover unsynced changes, but the client can automatically perform 
+You can choose to fall back to :ref:`discard-unsynced-changes` in the
+event that the client cannot recover unsynced data. In this case, local
+data is discarded, but the client can automatically perform 
 the client reset. To fall back to discard local changes, choose your 
 preferred SDK's version of the ``recoverOrDiscard`` client reset mode.
 
@@ -145,9 +157,9 @@ preferred SDK's version of the ``recoverOrDiscard`` client reset mode.
 Client Reset Recovery Rules
 ```````````````````````````
 
-In a client reset that does not involve a schema change, the Realm SDKs 
-attempt to recover unsynced changes. The SDK integrates objects created 
-locally that did not sync before the client reset. These rules 
+In a client reset that does not involve a breaking schema change, the 
+Realm SDKs attempt to recover unsynced changes. The SDK integrates objects 
+created locally that did not sync before the client reset. These rules 
 determine how conflicts are resolved when both the backend and the client 
 make changes to the same object:
 
@@ -171,25 +183,11 @@ Discard Unsynced Changes
    application needs to preserve unsynced changes.
 
 The **discard unsynced changes** client reset mode automatically handles 
-client resets in the event of non-breaking schema changes. 
-
-This client reset mode has several advantages compared to manual recovery:
-
-- Your application can perform a client reset without writing any custom
-  logic, other than specifying this mode. You don't have to manually
-  initiate the client reset or interact with the error object at all.
-- Your application can perform this client reset without closing any
-  realms, disconnecting from the backend app, or manual restarts. This
-  means you don't have to write any logic to handle these situations.
-- Application users receive notifications for changes as the local realm
-  updates to match the state of the backend realm.
-
-There is one major disadvantage to this client reset mode, however:
-
-- There is no way to recover changes that have not yet synced to the
-  backend at the time of the client reset. When this mode uses a
-  diff to bring the local realm to the same state as the backend, unsynced
-  changes are permanently deleted and cannot ever be recovered.
+client resets without attempting to recover data from the client device. 
+You might choose this mode if the :ref:`client-reset-recovery-rules` do
+not work for your app, or if you don't need to save unsynced data. When 
+this mode uses a diff to bring the local realm to the same state as the 
+backend, unsynced changes are permanently deleted.
 
 Discard Unsynced Changes mode cannot perform an automated client reset in 
 the event of a breaking schema change.

--- a/source/sync/error-handling/client-resets.txt
+++ b/source/sync/error-handling/client-resets.txt
@@ -155,8 +155,8 @@ make changes to the same object:
   client, the delete takes precedence and the client discards the update.
 - If an object is deleted on the recovering client, but not the server, 
   then the client applies the delete instruction.
-- In the case of conflicting updates to the same field, the most recent 
-  update is applied.
+- In the case of conflicting updates to the same field, the client update 
+  is applied.
 
 .. _discard-unsynced-changes:
 

--- a/source/sync/error-handling/client-resets.txt
+++ b/source/sync/error-handling/client-resets.txt
@@ -102,17 +102,20 @@ During an automatic client reset, the client:
    any inserts, updates, and deletes from the backend that haven't yet 
    synced to the client.
 
-   If there are non-breaking schema changes, the SDK can discard local changes
-   that have not yet synced to the backend. Then it can apply any inserts, 
-   updates, and deletes from the backend that haven't yet synced to the client.
+   If there are non-breaking schema changes, or if Recovery Mode cannot 
+   recover unsynced changes, the SDK can discard local changes that have 
+   not yet synced to the backend. Then it can apply any inserts, updates, 
+   and deletes from the backend that haven't yet synced to the client.
+   To fall back to discard local changes, choose your preferred SDK's 
+   version of the ``recoverOrDiscard`` client reset mode.
 
 #. Discards the fresh copy. The app continues to use
    the original copy of the realm with the diff applied.
 
-In a breaking schema change, the client reset falls back to a :ref:`manual 
-client reset handler <manual-client-reset>` that your app must define. The 
-Realm SDKs cannot automatically perform a client reset when you make a 
-breaking schema change.
+In a breaking schema change, or if automatic client reset fails, the client 
+reset falls back to a :ref:`manual client reset handler <manual-client-reset>` 
+that your app must define. The Realm SDKs cannot automatically perform a 
+client reset when you make a breaking schema change.
 
 .. _recover-unsynced-changes:
 
@@ -134,7 +137,8 @@ when determining how to integrate unsynced data from the device.
 If your app has a :ref:`non-breaking schema change <breaking-change-quick-reference>`, 
 you can choose to fall back to :ref:`discard-unsynced-changes`. You cannot 
 recover unsynced changes, but the client can automatically perform 
-the client reset.
+the client reset. To fall back to discard local changes, choose your 
+preferred SDK's version of the ``recoverOrDiscard`` client reset mode.
 
 .. _client-reset-recovery-rules:
 

--- a/source/sync/error-handling/client-resets.txt
+++ b/source/sync/error-handling/client-resets.txt
@@ -91,9 +91,9 @@ event of a breaking schema change.
 During an automatic client reset, the client:
 
 1. Downloads a fresh copy of the realm from the backend.
-#. Performs a diff to figure out the set of steps required to
-   bring the original (local) copy of the realm to the same state as
-   the fresh copy of the backend.
+#. Performs a diff to figure out the steps required to bring the original 
+   (local) copy of the realm to the same state as the fresh copy of the 
+   backend.
 #. Applies that set of steps to transform the local realm into a state
    where it can sync with the backend. 
    
@@ -147,7 +147,7 @@ Client Reset Recovery Rules
 
 In a client reset that does not involve a schema change, the Realm SDKs 
 attempt to recover unsynced changes. The SDK integrates objects created 
-locally that have did not sync before the client reset. These rules 
+locally that did not sync before the client reset. These rules 
 determine how conflicts are resolved when both the backend and the client 
 make changes to the same object:
 

--- a/source/sync/error-handling/client-resets.txt
+++ b/source/sync/error-handling/client-resets.txt
@@ -122,7 +122,7 @@ client reset when you make a breaking schema change.
 Recover Unsynced Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-When **Recovery Mode** is enabled in your Device Sync configuration - as it 
+When **Client Recovery** is enabled in your Device Sync configuration - as it 
 is by default - client applications can automatically recover unsynced 
 changes. In most scenarios, the client application can detect that a 
 client reset error has occurred and start an automated process to handle 
@@ -130,8 +130,8 @@ the client reset.
 
 After the client reset, the app can open and operate as usual. 
 
-Recovery Mode can recover unsynced data in client resets except where 
-there has been a schema change. Recovery Mode applies :ref:`client-reset-recovery-rules`
+Client Recovery can recover unsynced data in client resets except where 
+there has been a schema change. Client Recovery applies :ref:`client-reset-recovery-rules`
 when determining how to integrate unsynced data from the device.
 
 If your app has a :ref:`non-breaking schema change <breaking-change-quick-reference>`, 

--- a/source/sync/error-handling/client-resets.txt
+++ b/source/sync/error-handling/client-resets.txt
@@ -18,14 +18,16 @@ Overview
 A **client reset error** is a scenario where a client realm cannot sync
 data with the application backend. Clients in this state may continue to
 run and save data locally but cannot send or receive sync changesets
-until they perform a client reset.
+until they perform a client reset. The Realm SDKs provide methods to 
+automatically handle client resets under most scenarios.
 
 .. warning::
    
-   The client reset process loses any unsynced changes even if they were
-   successfully saved locally. To avoid data loss, you must manually back up and
-   restore any unsynced changes when you :ref:`handle a client reset
-   <handle-a-client-reset>`.
+   By default, the client reset process attempts to recover unsynced changes
+   that were successfully saved locally. When your client application 
+   has schema changes, or if :ref:`Recovery Mode <recover-unsynced-changes>` 
+   is disabled on the server, the client reset process cannot recover unsynced
+   data that may be persisted locally on the device.
 
 Client reset scenarios occur when the server's history is incompatible
 with the client's history. The most common causes of client resets are:
@@ -55,10 +57,10 @@ with the client's history. The most common causes of client resets are:
 - **Breaking schema changes**: A :ref:`breaking or destructive change
   <destructive-changes-synced-schema>`, like changing a property type or a
   primary key, requires you to terminate and re-enable Sync. This creates a new
-  synced realm file with a version unrelated to the client's file. Because
-  this scenario requires a new realm file, you can only handle client resets
-  caused by breaking changes using the :ref:`manually recover unsynced changes
-  <manually-recover-unsynced-changes>` strategy.
+  synced realm file with a version unrelated to the client's file. In this
+  scenario, the client reset process cannot complete automatically, and your 
+  app must provide a :ref:`manual client reset handler 
+  <manually-recover-unsynced-changes>`. 
 
 - **Upgrading from a Shared to Dedicated cluster**: When you :ref:`upgrade from 
   a shared to a dedicated cluster <upgrade-shared-cluster>`, you must 
@@ -82,50 +84,95 @@ with the client's history. The most common causes of client resets are:
 Handle a Client Reset
 ---------------------
 
-The SDKs automatically detect the need for client resets. You
-can handle client resets in your application using one of the available
-**client reset strategies**:
+The SDKs automatically detect the need for client resets. They can 
+automatically perform a client reset in most cases, except in the 
+event of a breaking schema change.
 
-.. note:: Breaking Changes Require Manual Recovery
-
-   You can only handle a client reset triggered by breaking changes
-   using the :ref:`manually recover unsynced changes
-   <manually-recover-unsynced-changes>` strategy.
-
-.. _discard-unsynced-changes:
-
-Discard Unsynced Changes
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. warning:: This Strategy Deletes Unsynced Local Changes Permanently
-
-   This client reset strategy permanently deletes any changes made
-   locally that have not yet synchronized to the backend.
-   Do not use this client reset strategy if your
-   application needs to preserve unsynced changes.
-
-The **discard unsynced changes** strategy automatically handles client
-reset events without the need for app-specific logic. During a client
-reset that uses this strategy, the client:
+During an automatic client reset, the client:
 
 1. Downloads a fresh copy of the realm from the backend.
 #. Performs a diff to figure out the set of steps required to
    bring the original (local) copy of the realm to the same state as
    the fresh copy of the backend.
 #. Applies that set of steps to transform the local realm into a state
-   where it can sync with the backend. This includes:
+   where it can sync with the backend. 
+   
+   If there are no schema changes, the SDK attempts to recover all local 
+   changes that have not yet synced to the backend. It also applies 
+   any inserts, updates, and deletes from the backend that haven't yet 
+   synced to the client.
 
-   - deleting all local changes that haven't yet synced to the backend
-   - any inserts, updates, and deletes that haven't yet synced to the client
+   If there are non-breaking schema changes, the SDK can discard local changes
+   that have not yet synced to the backend. Then it can apply any inserts, 
+   updates, and deletes from the backend that haven't yet synced to the client.
 
 #. Discards the fresh copy. The app continues to use
    the original copy of the realm with the diff applied.
 
-The "discard unsynced changes" strategy has several advantages compared
-to manual recovery:
+In a breaking schema change, the client reset falls back to a :ref:`manual 
+client reset handler <manual-client-reset>` that your app must define. The 
+Realm SDKs cannot automatically perform a client reset when you make a 
+breaking schema change.
+
+.. _recover-unsynced-changes:
+
+Recover Unsynced Changes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+When **Recovery Mode** is enabled in your Device Sync configuration - as it 
+is by default - client applications can automatically recover unsynced 
+changes. In most scenarios, the client application can detect that a 
+client reset error has occurred and start an automated process to handle 
+the client reset.
+
+After the client reset, the app can open and operate as usual. 
+
+Recovery Mode can recover unsynced data in client resets except where 
+there has been a schema change. Recovery Mode applies :ref:`client-reset-recovery-rules`
+when determining how to integrate unsynced data from the device.
+
+If your app has a :ref:`non-breaking schema change <breaking-change-quick-reference>`, 
+you can choose to fall back to :ref:`discard-unsynced-changes`. You cannot 
+recover unsynced changes, but the client can automatically perform 
+the client reset.
+
+.. _client-reset-recovery-rules:
+
+Client Reset Recovery Rules
+```````````````````````````
+
+In a client reset that does not involve a schema change, the Realm SDKs 
+attempt to recover unsynced changes. The SDK integrates objects created 
+locally that have did not sync before the client reset. These rules 
+determine how conflicts are resolved when both the backend and the client 
+make changes to the same object:
+
+- If an object is deleted on the server, but is modified on the recovering 
+  client, the delete takes precedence and the client discards the update.
+- If an object is deleted on the recovering client, but not the server, 
+  then the client applies the delete instruction.
+- In the case of conflicting updates to the same field, the most recent 
+  update is applied.
+
+.. _discard-unsynced-changes:
+
+Discard Unsynced Changes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. warning:: Deletes Unsynced Local Changes Permanently
+
+   This client reset mode permanently deletes any changes made
+   locally that have not yet synchronized to the backend.
+   Do not use this client reset mode if your
+   application needs to preserve unsynced changes.
+
+The **discard unsynced changes** client reset mode automatically handles 
+client resets in the event of non-breaking schema changes. 
+
+This client reset mode has several advantages compared to manual recovery:
 
 - Your application can perform a client reset without writing any custom
-  logic, other than specifying this strategy. You don't have to manually
+  logic, other than specifying this mode. You don't have to manually
   initiate the client reset or interact with the error object at all.
 - Your application can perform this client reset without closing any
   realms, disconnecting from the backend app, or manual restarts. This
@@ -133,61 +180,30 @@ to manual recovery:
 - Application users receive notifications for changes as the local realm
   updates to match the state of the backend realm.
 
-There is one major disadvantage to this strategy, however:
+There is one major disadvantage to this client reset mode, however:
 
 - There is no way to recover changes that have not yet synced to the
-  backend at the time of the client reset. When this strategy uses a
+  backend at the time of the client reset. When this mode uses a
   diff to bring the local realm to the same state as the backend, unsynced
   changes are permanently deleted and cannot ever be recovered.
 
-You can use this strategy to resolve a client reset caused by anything
-*except* a breaking schema change.
+Discard Unsynced Changes mode cannot perform an automated client reset in 
+the event of a breaking schema change.
 
+.. _manual-client-reset:
 .. _manually-recover-unsynced-changes:
 
-Manually Recover Unsynced Changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Manual Client Reset
+~~~~~~~~~~~~~~~~~~~
 
-.. note:: Manual Recovery Replaces Client Reset Handlers
+In the event of :ref:`a breaking schema change <breaking-change-quick-reference>`,
+Realm SDKs cannot automatically handle a client reset. You must define 
+a manual client reset handler if you make breaking schema changes.
 
-   This strategy works just like the deprecated
-   "Client Reset Handler" method of performing client resets.
-   Applications that use deprecated client reset handling can switch
-   directly to the "manually recover unsynced changes" strategy with
-   no logic changes.
-
-The **manually recover unsynced changes** client reset strategy gives
-the app developer complete control over recovery from client reset errors.
-During a client reset that uses this strategy, the client:
-
-1. Makes a backup of the original (local) copy of the realm. Before making
-   the backup, you must close all instances of the realm. If your application
-   architecture makes this difficult, you can restart the app and handle
-   the client reset on reconnect.
-#. Downloads a fresh copy of the realm from the backend. This fresh copy
-   replaces the original local realm.
-#. Provides a reference to the local realm backup and the fresh copy of
-   the realm.
-
-With the local realm backup and the fresh copy in hand, you can triage
-and save local data by copying it from the local realm backup to the
-fresh copy of the realm. Recovering unsynced changes is highly dependent
-on your schema and application logic, so you may need to supplement
-your schema with "last modified" timestamps for best results.
-
-Manual recovery has one major advantage compared
-to discarding unsynced changes:
-
-- You can recover local changes that haven't yet synced to the backend.
-
-There are several disadvantage to this strategy, however:
-
-- You must write custom logic to initiate the client reset.
-- You must close all realms before performing the client reset.
-- Application users never receive notifications for new changes that synced
-  from the backend during the client reset.
-- You must either restart the application or write custom logic to re-initialize
-  the backend app connection after performing the client reset.
+In this scenario, a manual client reset handler should do something like 
+tell the user to update the app. In Realm SDK versions that automatically 
+handle client resets, a manual client reset only occurs in error scenarios
+where no meaningful recovery can occur.
 
 Examples
 ~~~~~~~~
@@ -195,8 +211,88 @@ Examples
 For more information on performing a client reset, check out the client
 reset examples for your SDK:
 
-- :ref:`Android <java-client-resets>`
-- :ref:`iOS, macOS, tvOS, and watchOS <ios-client-resets>`
-- :ref:`.NET <dotnet-client-resets>`
-- :ref:`React Native <react-native-client-resets>`
-- :ref:`Node.js <node-client-resets>`
+.. tabs-realm-sdks::
+
+   .. tab::
+      :tabid: android
+
+      :ref:`Reset a Client Realm - Java SDK <java-client-resets>`
+
+   .. tab::
+      :tabid: ios
+
+      :ref:`Handle Sync Errors - Client Reset - Swift SDK <ios-client-resets>`
+
+   .. tab::
+      :tabid: node
+
+      :ref:`Reset a Client Realm - Node.js SDK <node-client-resets>`
+
+   .. tab::
+      :tabid: react-native
+
+      :ref:`Reset a Client Realm - React Native SDK <react-native-client-resets>`
+
+   .. tab::
+      :tabid: dotnet
+
+      :ref:`Client Resets - .NET SDK <dotnet-client-resets>`
+
+.. _enable-or-disable-recovery-mode:
+
+Enable or Disable Recovery Mode
+-------------------------------
+
+Recovery Mode is enabled by default in every Device Sync configuration.
+You can disable Recovery Mode, or re-enable it if you have previously
+disabled it.
+
+.. tabs-realm-admin-interfaces::
+
+   .. tab::
+      :tabid: ui
+      
+      1. Select the :guilabel:`Device Sync` menu in the sidebar.
+
+      2. Click the :guilabel:`Advanced Configuration` pane to display 
+         additional configuration options.
+
+      3. Click the :guilabel:`Enable Client Recovery` toggle.
+
+      4. Press the :guilabel:`Save` button to confirm your
+         changes.
+
+         If your app uses deployment drafts, you must deploy your application
+         after making changes.
+   
+   .. tab::
+      :tabid: cli
+      
+      1. Pull a local copy of the latest version of your app with the
+         following :ref:`pull command <realm-cli-pull>`:
+
+         .. code-block:: bash
+            :caption: Pull
+
+            realm-cli pull --remote="<Your App ID>"
+
+      2. You can configure the number of days for your application's
+         client maximum offline time with the ``is_recovery_mode_disabled``
+         property in your app's ``sync/config.json`` file:
+
+         .. code-block:: json
+            :caption: ``sync/config.json``
+           
+            {
+              ...
+              "is_recovery_mode_disabled": false,
+              ...
+            }
+
+      3. Deploy the updated app configuration with the following
+         :ref:`push command <realm-cli-push>`:
+
+         .. code-block:: bash
+            :caption: Push
+
+            realm-cli push --remote="<Your App ID>"

--- a/source/sync/error-handling/errors.txt
+++ b/source/sync/error-handling/errors.txt
@@ -203,8 +203,8 @@ The following errors may occur when your {+app+} uses :ref:`Flexible Sync
 
        - When using older SDK versions that are linked to a realm-core version
          before realm-core 12.1.0. In this case, the server will not undo the
-         illegal write, and you will need to perform a :ref:`client reset
-         <client-resets>`.
+         illegal write, and you will need to perform a :ref:`manual client reset
+         <manual-client-reset>`.
        - When modifying an object in a collection with :ref:`asymmetric sync
          <optimize-asymmetric-sync>` enabled. In this case, the error is
          non-fatal and does not trigger a client reset. The server skips over


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-25395

### Staged Changes (Requires MongoDB Corp SSO)

- [Atlas Device Sync Configuration Files](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-25395/manage-apps/configure/config/sync/)
- [Enable Atlas Device Sync](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-25395/sync/configure/enable-sync/)
- [Pause or Terminate Sync](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-25395/sync/configure/pause-or-terminate-sync/)
- [Update Your Schema](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-25395/sync/data-model/update-schema/)
- [Client Resets](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-25395/sync/error-handling/client-resets/)
- [Sync Errors](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-25395/sync/error-handling/errors/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
