### PR TITLE
(DOCSP-24761) [BAAS] Limit enabling hosting to users who have a linked paid cluster

### DIFF
--- a/source/hosting.txt
+++ b/source/hosting.txt
@@ -28,6 +28,8 @@ Static Hosting
 Introduction
 ------------
 
+.. include:: /includes/note-static-hosting-requires-paid-tier-cluster.rst
+
 Atlas Hosting allows you to host, manage, and serve your application's
 static media and document files. You can use Hosting to store individual
 pieces of content or to upload and serve your entire client application.

--- a/source/hosting/enable-hosting.txt
+++ b/source/hosting/enable-hosting.txt
@@ -15,6 +15,8 @@ Enable Hosting
 Overview
 --------
 
+.. include:: /includes/note-static-hosting-requires-paid-tier-cluster.rst
+
 You need to enable static hosting for your application before you can
 upload and access content. You can enable static hosting from the App Services UI.
 
@@ -132,4 +134,3 @@ Enable hosting from the UI with the following procedure:
 ..               content to App Services </hosting/upload-content-to-app-services>`
 ..               immediately, but you will need to wait for provisioning to complete before
 ..               App Services serves your files.
-

--- a/source/includes/note-static-hosting-requires-paid-tier-cluster.rst
+++ b/source/includes/note-static-hosting-requires-paid-tier-cluster.rst
@@ -1,0 +1,6 @@
+.. important:: Static Hosting Requires a Paid-Tier Atlas Cluster
+   
+   To enable static hosting, you must have a paid-tier (i.e. ``M2`` or
+   higher) Atlas cluster linked to your app as a data source. For more
+   information on Atlas cluster tiers, see :atlas:`Create a Cluster
+   </tutorial/create-new-cluster/>`.


### PR DESCRIPTION


## Pull Request Info

### Jira

- (DOCSP-24761) [BAAS] Limit enabling hosting to users who have a linked paid cluster

### Staged Changes (Requires MongoDB Corp SSO)

- [Static Hosting](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/paid-hosting/hosting/)
- [Enable Hosting](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/paid-hosting/hosting/enable-hosting/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
