### PR TITLE
(DOCSP-25790): Add BigInt to list of unsupported JS objects

### DIFF
--- a/source/functions/javascript-support.txt
+++ b/source/functions/javascript-support.txt
@@ -88,14 +88,29 @@ Built-In Objects
    
    * - Feature
      - Supported
-   
-   * - :mdn:`TypedArray <Web/JavaScript/Reference/Global_Objects/TypedArray>`
-     - Yes
-   
+
+   * - :mdn:`BigInt <Web/JavaScript/Reference/Global_Objects/BigInt>`
+     - No
+
    * - :mdn:`Map <Web/JavaScript/Reference/Global_Objects/Map>`
      - Yes
    
+   * - :mdn:`Promise <Web/JavaScript/Reference/Global_Objects/Promise>`
+     - Yes
+
+   * - :mdn:`Proxy <Web/JavaScript/Reference/Global_Objects/Proxy>`
+     - No
+   
+   * - :mdn:`Reflect <Web/JavaScript/Reference/Global_Objects/Reflect>`
+     - No
+   
    * - :mdn:`Set <Web/JavaScript/Reference/Global_Objects/Set>`
+     - Yes
+
+   * - :mdn:`Symbol <Web/JavaScript/Reference/Global_Objects/Symbol>`
+     - Yes
+     
+   * - :mdn:`TypedArray <Web/JavaScript/Reference/Global_Objects/TypedArray>`
      - Yes
    
    * - :mdn:`WeakMap <Web/JavaScript/Reference/Global_Objects/WeakMap>`
@@ -103,18 +118,7 @@ Built-In Objects
    
    * - :mdn:`WeakSet <Web/JavaScript/Reference/Global_Objects/WeakSet>`
      - No
-   
-   * - :mdn:`Proxy <Web/JavaScript/Reference/Global_Objects/Proxy>`
-     - No
-   
-   * - :mdn:`Reflect <Web/JavaScript/Reference/Global_Objects/Reflect>`
-     - No
-   
-   * - :mdn:`Promise <Web/JavaScript/Reference/Global_Objects/Promise>`
-     - Yes
-   
-   * - :mdn:`Symbol <Web/JavaScript/Reference/Global_Objects/Symbol>`
-     - Yes
+
 
 .. _js-support-builtin-methods:
 .. _js-support-builtin-properties:


### PR DESCRIPTION
- Also alphabetize the object table

## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-25790

### Staged Changes (Requires MongoDB Corp SSO)

- https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/bigint/functions/javascript-support/#built-in-objects

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
