### PR TITLE
(DOCSP-26070): Remove bolded text after link

### DIFF
--- a/source/billing.txt
+++ b/source/billing.txt
@@ -50,8 +50,8 @@ usage.
 
 App Services is free to use below the following monthly free tier thresholds:
 
-- 1,000,000 :ref:`requests <billing-requests>` **or** 500 hours of
-  :ref:`compute <billing-compute>` **or** 10,000 hours of :ref:`sync
+- 1,000,000 :ref:`requests <billing-requests>` or 500 hours of
+  :ref:`compute <billing-compute>` or 10,000 hours of :ref:`sync
   <billing-sync>` runtime (whichever occurs first)
 
 - 10GB of :ref:`data transfer <billing-data-transfer>`
@@ -117,8 +117,8 @@ following:
 
 **Formula:** (Function Executions + Trigger Executions + GraphQL/Webhook/HTTPS Endpoint Requests + Sync Updates) * $0.000002
 
-**Free Tier Threshold:** 1,000,000 :ref:`requests <billing-requests>` **or** 500
-hours of :ref:`compute <billing-compute>` **or** 10,000 hours of :ref:`sync
+**Free Tier Threshold:** 1,000,000 :ref:`requests <billing-requests>` or 500
+hours of :ref:`compute <billing-compute>` or 10,000 hours of :ref:`sync
 <billing-sync>` runtime (whichever occurs first)
 
 .. example:: Estimate Your Usage
@@ -159,8 +159,8 @@ and increases by 1 for every 32MB of memory that a given request uses.
 
 **Formula:** (# Requests) * (Runtime (ms)) * (Memory (MB) / 32MB) * $0.000000005 / ms
 
-**Free Tier Threshold:** 1,000,000 :ref:`requests <billing-requests>` **or** 500
-hours of :ref:`compute <billing-compute>` **or** 10,000 hours of :ref:`sync
+**Free Tier Threshold:** 1,000,000 :ref:`requests <billing-requests>` or 500
+hours of :ref:`compute <billing-compute>` or 10,000 hours of :ref:`sync
 <billing-sync>` runtime (whichever occurs first)
 
 .. example:: Estimate Your Usage
@@ -196,8 +196,8 @@ millisecond of sync runtime per user.
 
 **Formula:** (# Active Users) * (Sync time (min / user)) * ($0.00000008 / min)
 
-**Free Tier Threshold:** 1,000,000 :ref:`requests <billing-requests>` **or** 500
-hours of :ref:`compute <billing-compute>` **or** 10,000 hours of :ref:`sync
+**Free Tier Threshold:** 1,000,000 :ref:`requests <billing-requests>` or 500
+hours of :ref:`compute <billing-compute>` or 10,000 hours of :ref:`sync
 <billing-sync>` runtime (whichever occurs first)
 
 .. example:: Estimate Your Usage


### PR DESCRIPTION
## Pull Request Info

Remove bolded text after link to address Snooty Platform bug (see https://jira.mongodb.org/browse/DOP-3330)

note: looked throughout rest of docs for similar error pattern of link + bold, and didn't find anything.

### Jira

- https://jira.mongodb.org/browse/DOCSP-26070

### Staged Changes (Requires MongoDB Corp SSO)

- [Billing](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26070/billing/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
