### PR TITLE
(DOCSP-25878) Arrayfilters is noted in the unsupported options even though it is supported

### DIFF
--- a/source/mongodb/crud-and-aggregation-apis.txt
+++ b/source/mongodb/crud-and-aggregation-apis.txt
@@ -691,7 +691,6 @@ Database Command Availability
    * - :manual:`update </reference/command/update>`
      - - ``bypassDocumentValidation``
        - ``collation``
-       - ``arrayFilters``
      - 
 
    * - :manual:`delete </reference/command/delete>`


### PR DESCRIPTION


## Pull Request Info

### Jira

- (DOCSP-25878) Arrayfilters is noted in the unsupported options even though it is supported

### Staged Changes (Requires MongoDB Corp SSO)

- [CRUD & Aggregation APIs](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/arrayFilters/mongodb/crud-and-aggregation-apis/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
