### PR TITLE
(DOCSP-25812): Updating read/write device sync permissions for %stringToOid

### DIFF
--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -479,7 +479,7 @@ flexible sync roles:
    
    * - :json-operator:`%stringToOid`, :json-operator:`%oidToString`
      - Yes
-     - No
+     - Yes
    
    * - :json-operator:`%function`
      - Yes


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-25812

### Staged Changes (Requires MongoDB Corp SSO)

- [Sync Rules and Permissions](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-25812-add-stringToOid-flex-sync/sync/data-access-patterns/permissions/#expressions) 

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
