### PR TITLE
(DOCSP-26228): Update tutorial to not delete all app data

### DIFF
--- a/source/tutorial/flutter.txt
+++ b/source/tutorial/flutter.txt
@@ -209,24 +209,18 @@ Modify the Application
 
          .. include:: /examples/generated/flutter/tutorial/item_card.snippet.item-card.dart.modified.rst
 
-   .. step:: Delete App from Device
-
-      Delete the Flutter app and all associated data from the device or simulator
-      that you're running it on.
-      You should do this to prevent issues with the schema migration.
-      Because the data is syncing, any Items you made still exist in MongoDB
-      Atlas and will sync when you reopen the app.
-
-      How to delete the app and associated data varies depending on where you're
-      running the app. Refer to your device or simulator's documentation
-      for help deleting app data.
-
    .. step:: Run and Test
 
-      At this point, you can run the application again. Log in using the account
-      you created earlier in this tutorial. You will see the one Item you
-      previously created. Add a new Item, and you will see that you can now
-      set the priority. Choose ``High`` for the priority and save the Item.
+      At this point, you can run the application again.
+
+      First, perform a `hot restart <https://docs.flutter.dev/development/tools/hot-reload#special-cases>`__.
+      This makes sure that the sync session restarts with the new schema and prevents
+      sync errors.
+
+      Then, Log in using the account you created earlier in this tutorial.
+      You will see the one Item you previously created.
+      Add a new Item, and you will see that you can now set the priority.
+      Choose ``High`` for the priority and save the Item.
 
       Now switch back to the Atlas data page in your browser, and refresh the
       ``Item`` collection. You should now see the new Item with the ``priority``

--- a/source/tutorial/flutter.txt
+++ b/source/tutorial/flutter.txt
@@ -211,9 +211,7 @@ Modify the Application
 
    .. step:: Run and Test
 
-      At this point, you can run the application again.
-
-      First, perform a `hot restart <https://docs.flutter.dev/development/tools/hot-reload#special-cases>`__.
+      Before you run the application again, perform a `hot restart <https://docs.flutter.dev/development/tools/hot-reload#special-cases>`__.
       This makes sure that the sync session restarts with the new schema and prevents
       sync errors.
 


### PR DESCRIPTION
## Pull Request Info

Update tutorial to not delete all app data. This step is no longer necessary b/c of a bug fix in Realm Flutter SDK v0.6.0+beta.

This change **must** be merged after the changes from https://github.com/mongodb-university/realm-template-apps/pull/102 have been deployed for use in the Realm CLI. (However, the changes don't need to be merged in tandem, b/c the tutorial as currently documented still works with the previous version..just the app deletion step is no longer necessary.)

### Jira

- https://jira.mongodb.org/browse/DOCSP-26228

### Staged Changes (Requires MongoDB Corp SSO)

- [Flutter Device Sync Tutorial](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26228/tutorial/flutter/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
