### PR TITLE
(DOCSP-26248): Correct the Flex Sync permissions template names

### DIFF
--- a/source/sync/data-access-patterns/flexible-sync-permissions-guide.txt
+++ b/source/sync/data-access-patterns/flexible-sync-permissions-guide.txt
@@ -48,9 +48,9 @@ flag to instantiate a template.
 
 ``TEMPLATE_NAME`` can be one of the following:
 
-- ``flex-sync-permissions.add-collaborators`` (corresponding to :ref:`dynamic-collaboration`)
-- ``flex-sync-permissions.restricted-feed`` (corresponding to :ref:`restricted-news-feed`)
-- ``flex-sync-permissions.tiered`` (corresponding to :ref:`tiered-privileges`)
+- ``flex-sync-guides.add-collaborators`` (corresponding to :ref:`dynamic-collaboration`)
+- ``flex-sync-guides.restricted-feed`` (corresponding to :ref:`restricted-news-feed`)
+- ``flex-sync-guides.tiered`` (corresponding to :ref:`tiered-privileges`)
 
 
 .. button:: Deploy a Template App
@@ -269,7 +269,7 @@ Restricted News Feed
 
    .. code-block:: bash
 
-      realm-cli apps create --name=restricted-feed --template=flex-sync-permissions.restricted-feed
+      realm-cli apps create --name=restricted-feed --template=flex-sync-guides.restricted-feed
   
    .. include:: /includes/template-app-custom-user-data-workaround.rst
 
@@ -278,7 +278,7 @@ Restricted News Feed
 
    .. code-block::
 
-      cd restricted-feed/frontend/flex-sync-permissions.restricted-feed/
+      cd restricted-feed/frontend/flex-sync-guides.restricted-feed/
       npm install
       npm run demo
 
@@ -475,13 +475,13 @@ Dynamic Collaboration
 
    .. code-block:: bash
 
-      realm-cli apps create --name=add-collaborators --template=flex-sync-permissions.add-collaborators
+      realm-cli apps create --name=add-collaborators --template=flex-sync-guides.add-collaborators
   
    Next, go into the client directory, install the dependencies, and run the demo:
 
    .. code-block::
 
-      cd add-collaborators/frontend/flex-sync-permissions.add-collaborators/
+      cd add-collaborators/frontend/flex-sync-guides.add-collaborators/
       npm install
       npm run demo
 
@@ -621,7 +621,7 @@ Tiered Privileges
 
    .. code-block:: bash
 
-      realm-cli apps create --name=tiered --template=flex-sync-permissions.tiered
+      realm-cli apps create --name=tiered --template=flex-sync-guides.tiered
   
    .. include:: /includes/template-app-custom-user-data-workaround.rst
 
@@ -630,7 +630,7 @@ Tiered Privileges
 
    .. code-block::
 
-      cd tiered/frontend/flex-sync-permissions.tiered/
+      cd tiered/frontend/flex-sync-guides.tiered/
       npm install
       npm run demo
 


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-26248

### Staged Changes (Requires MongoDB Corp SSO)

- [Flexible Sync Permissions Guide](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26248/sync/data-access-patterns/flexible-sync-permissions-guide/): Update permissions template app names throughout page

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
