### PR TITLE
(DOCSP-26263): Add Flutter to authentication tabs

### DIFF
--- a/source/authentication/apple.txt
+++ b/source/authentication/apple.txt
@@ -429,3 +429,9 @@ Apple authentication, see the documentation for the {+client-sdks+}:
 
       To register or log in an Apple user from the Kotlin Client SDK, see the
       :ref:`Kotlin SDK guide to Apple authentication <kotlin-login-google>`.
+
+   .. tab::
+      :tabid: flutter
+
+      To register or log in an Apple user from the Flutter Client SDK, see the
+      :ref:`Flutter SDK guide to Apple authentication <flutter-login-google>`.

--- a/source/authentication/apple.txt
+++ b/source/authentication/apple.txt
@@ -422,16 +422,16 @@ Apple authentication, see the documentation for the {+client-sdks+}:
       :tabid: dotnet
 
       To register or log in an Apple user from the .NET Client SDK, see the
-      :ref:`.NET SDK guide to Apple authentication <dotnet-login-google>`.
+      :ref:`.NET SDK guide to Apple authentication <dotnet-login-apple>`.
 
    .. tab::
       :tabid: kotlin
 
       To register or log in an Apple user from the Kotlin Client SDK, see the
-      :ref:`Kotlin SDK guide to Apple authentication <kotlin-login-google>`.
+      :ref:`Kotlin SDK guide to Apple authentication <kotlin-login-apple>`.
 
    .. tab::
       :tabid: flutter
 
       To register or log in an Apple user from the Flutter Client SDK, see the
-      :ref:`Flutter SDK guide to Apple authentication <flutter-login-google>`.
+      :ref:`Flutter SDK guide to Apple authentication <flutter-login-apple>`.

--- a/source/authentication/custom-function.txt
+++ b/source/authentication/custom-function.txt
@@ -93,7 +93,7 @@ actual field names and values depend on your implementation.
          .. code-block:: javascript
          
             const credentials = Realm.Credentials.function({
-              username: "mongolover",
+              username: "someUsername",
               pin: "24601",
             });
    
@@ -108,7 +108,7 @@ actual field names and values depend on your implementation.
             val credentials: Credentials = Credentials.customFunction(
               Document(
                 Map.ofEntries(
-                  entry("username", "mongolover"),
+                  entry("username", "someUsername"),
                   entry("pin", "24601")
                 )
               )
@@ -120,7 +120,7 @@ actual field names and values depend on your implementation.
          .. code-block:: csharp
          
             var credentials = Credentials.Function(new {
-              username = "mongolover",
+              username = "someUsername",
               pin = "24601"
             })
    
@@ -130,7 +130,7 @@ actual field names and values depend on your implementation.
          .. code-block:: swift
          
             let credentials = Credentials.function(payload: [
-               "username": "mongolover",
+               "username": "someUsername",
                "pin": "24601"
             ])
 
@@ -141,6 +141,7 @@ actual field names and values depend on your implementation.
 
             Map<String, String> credentials = {
                "username": "someUsername",
+               "pin": "24601"
             };
             // payload must be a JSON-encoded string
             String payload = jsonEncode(credentials);

--- a/source/authentication/custom-function.txt
+++ b/source/authentication/custom-function.txt
@@ -85,7 +85,7 @@ actual field names and values depend on your implementation.
    using the {+client-sdks+}. The credential includes a ``payload`` object
    that is passed to the authentication function.
 
-   .. tabs-realm-languages::
+   .. tabs-realm-sdks::
    
       .. tab::
          :tabid: javascript
@@ -98,7 +98,7 @@ actual field names and values depend on your implementation.
             });
    
       .. tab::
-         :tabid: java
+         :tabid: android
    
          .. code-block:: java
             
@@ -115,7 +115,7 @@ actual field names and values depend on your implementation.
             )
    
       .. tab::
-         :tabid: c-sharp
+         :tabid: dotnet
    
          .. code-block:: csharp
          
@@ -125,7 +125,7 @@ actual field names and values depend on your implementation.
             })
    
       .. tab::
-         :tabid: swift
+         :tabid: ios
    
          .. code-block:: swift
          
@@ -133,6 +133,20 @@ actual field names and values depend on your implementation.
                "username": "mongolover",
                "pin": "24601"
             ])
+
+      .. tab::
+         :tabid: flutter
+
+         .. code-block:: dart
+
+            Map<String, String> credentials = {
+               "username": "someUsername",
+            };
+            // payload must be a JSON-encoded string
+            String payload = jsonEncode(credentials);
+
+            Credentials customCredentials = Credentials.function(payload);
+            User currentUser = await app.logIn(customCredentials);
 
 Return an Authenticated User ID
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -421,3 +435,4 @@ For examples, refer to the documentation for a specific SDK:
 - :ref:`React Native SDK <react-native-login-custom-function>`
 - :ref:`Node.js SDK <node-login-custom-function>`
 - :ref:`Web SDK <web-login-custom-function>`
+- :ref:`Flutter SDK <flutter-login-custom-function>`

--- a/source/authentication/custom-jwt.txt
+++ b/source/authentication/custom-jwt.txt
@@ -845,6 +845,12 @@ Custom JWT authentication, see the documentation for the {+client-sdks+}:
       To register or log in a Custom JWT user from the Kotlin Client SDK, see the
       :ref:`Kotlin SDK guide to Custom JWT authentication <kotlin-login-jwt>`.
 
+   .. tab::
+      :tabid: flutter
+
+      To register or log in a Custom JWT user from the Flutter Client SDK, see the
+      :ref:`Flutter SDK guide to Custom JWT authentication <flutter-login-custom-jwt>`.
+
 .. _jwt-tutorial:
 
 Walkthrough

--- a/source/authentication/email-password.txt
+++ b/source/authentication/email-password.txt
@@ -97,8 +97,6 @@ User Confirmation
 Send a Confirmation Email
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-
-
 With this confirmation method, users must respond to an email upon 
 registration. The email contains a link to a confirmation URL. The 
 user must visit this link within 30 minutes to confirm that they 

--- a/source/authentication/facebook.txt
+++ b/source/authentication/facebook.txt
@@ -273,3 +273,9 @@ Facebook authentication, see the documentation for the {+client-sdks+}:
 
       To register or log in a Facebook user from the Kotlin Client SDK, see the
       :ref:`Kotlin SDK guide to Facebook authentication <kotlin-login-facebook>`.
+
+   .. tab::
+      :tabid: flutter
+
+      To register or log in a Facebook user from the Flutter Client SDK, see the
+      :ref:`Flutter SDK guide to Facebook authentication <flutter-login-facebook>`.

--- a/source/authentication/google.txt
+++ b/source/authentication/google.txt
@@ -384,3 +384,9 @@ Google authentication, see the documentation for the {+client-sdks+}:
 
       To register or log in a Google user from the Kotlin Client SDK, see the
       :ref:`Kotlin SDK guide to Google authentication <kotlin-login-google>`.
+
+   .. tab::
+      :tabid: flutter
+
+      To register or log in a Google user from the Flutter Client SDK, see the
+      :ref:`Flutter SDK guide to Google authentication <flutter-login-google>`.


### PR DESCRIPTION
## Pull Request Info

Add Flutter SDK to tabs about the various auth providers. 

### Jira

- https://jira.mongodb.org/browse/DOCSP-26263

### Staged Changes (Requires MongoDB Corp SSO)

- [Apple Auth](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26263/authentication/apple/)
- [Custom Function Auth](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26263/authentication/custom-function/)
- [Facebook Auth](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26263/authentication/facebook/)
- [Custom JWT Auth](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26263/authentication/custom-jwt/)
- [Google Auth](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26263/authentication/google/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
