### PR TITLE
(DOCSP-26250): App Services release notes 03-11-2022

### DIFF
--- a/source/release-notes/changelogs/backend/changelog-backend-2022.rst
+++ b/source/release-notes/changelogs/backend/changelog-backend-2022.rst
@@ -6,7 +6,7 @@
 - :ref:`Function context.app.id <context-app>` returns a string (formerly BSON ObjectId).
 - Support :ref:`App Services deployments <deployment-regions>` in the AWS region
   London (aws-eu-west-2).
-- Added Admin API Endpoint for App metrics.
+- Added :ref:`Admin API <admin-api>` endpoint to retrieve App Services metrics.
 
 .. _backend_20221020:
 

--- a/source/release-notes/changelogs/backend/changelog-backend-2022.rst
+++ b/source/release-notes/changelogs/backend/changelog-backend-2022.rst
@@ -1,6 +1,6 @@
-.. _backend_20221102:
+.. _backend_20221103:
 
-2 November 2022 Release
+3 November 2022 Release
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 - :ref:`Function context.app.id <context-app>` returns a string (formerly BSON ObjectId).

--- a/source/release-notes/changelogs/backend/changelog-backend-2022.rst
+++ b/source/release-notes/changelogs/backend/changelog-backend-2022.rst
@@ -1,3 +1,13 @@
+.. _backend_20221102:
+
+2 November 2022 Release
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- :ref:`Function context.app.id <context-app>` returns a string (formerly BSON ObjectId).
+- Support :ref:`App Services deployments <deployment-regions>` in the AWS region
+  London (aws-eu-west-2).
+- Added Admin API Endpoint for App metrics.
+
 .. _backend_20221020:
 
 20 October 2022 Release


### PR DESCRIPTION
## Pull Request Info

App Services release notes for Nov. 3, 2022 release.

### Jira

- https://jira.mongodb.org/browse/DOCSP-26250

### Staged Changes (Requires MongoDB Corp SSO)

- [Release Notes](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26250/release-notes/backend/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
