### PR TITLE
(DOCSP-26247): Correcting link to Data API configuration object ref

### DIFF
--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -3451,7 +3451,7 @@ paths:
       summary: Enable the Data API
       description: Create your app's [Data API](https://www.mongodb.com/docs/atlas/app-services/data-api/generated-endpoints/) configuration.
       requestBody:
-        description: A valid [configuration object](https://www.mongodb.com/docs/realm/manage-apps/configure/config/http_endpoints/#appconfig-data-api-endpoints) for the endpoint.
+        description: A valid [configuration object](https://www.mongodb.com/docs/realm/manage-apps/configure/config/http_endpoints#std-label-appconfig-data-api-endpoints) for the endpoint.
         required: true
         content:
           application/json:
@@ -3471,7 +3471,7 @@ paths:
       summary: Modify the Data API
       description: Update your app's [Data API](https://www.mongodb.com/docs/atlas/app-services/data-api/generated-endpoints/) configuration.
       requestBody:
-        description: A valid [configuration object](https://www.mongodb.com/docs/realm/manage-apps/configure/config/http_endpoints/#appconfig-data-api-endpoints) for the endpoint.
+        description: A valid [configuration object](https://www.mongodb.com/docs/realm/manage-apps/configure/config/http_endpoints#std-label-appconfig-data-api-endpoints) for the endpoint.
         required: true
         content:
           application/json:
@@ -3607,7 +3607,7 @@ paths:
       summary: Create a custom resolver
       description: Create a new [custom resolver](https://www.mongodb.com/docs/realm/graphql/custom-resolvers/).
       requestBody:
-        description: A valid [custom resolver configuration](https://www.mongodb.com/docs/realm/manage-apps/configure/config/graphql/#appconfig-custom-resolver) object.
+        description: A valid [custom resolver configuration](https://www.mongodb.com/docs/realm/manage-apps/configure/config/graphql#std-label-appconfig-custom-resolver) object.
         required: true
         content:
           application/json:
@@ -3645,7 +3645,7 @@ paths:
       summary: Modify a custom resolver
       description: Modify an existing [custom resolver](https://www.mongodb.com/docs/realm/graphql/custom-resolvers/) configuration.
       requestBody:
-        description: A valid, updated [custom resolver configuration](https://www.mongodb.com/docs/realm/manage-apps/configure/config/graphql/#appconfig-custom-resolver) object.
+        description: A valid, updated [custom resolver configuration](https://www.mongodb.com/docs/realm/manage-apps/configure/config/graphql#std-label-appconfig-custom-resolver) object.
         required: true
         content:
           application/json:
@@ -4168,7 +4168,7 @@ components:
           type: integer
           description: |-
             A number that reports the [Maximum BSON Document
-            Size](https://www.mongodb.com/docs/manual/reference/limits/#BSON-Document-Size)
+            Size](https://www.mongodb.com/docs/manual/reference/limits#std-label-limit-bson-document-size)
     DependenciesSummary:
       type: object
       properties:
@@ -4419,7 +4419,7 @@ components:
                 - nearest
               description: |-
                 The [read
-                preference](https://www.mongodb.com/docs/atlas/app-services/mongodb/read-preference/#std-label-read-preference)
+                preference](https://www.mongodb.com/docs/atlas/app-services/mongodb/read-preference/)
                 mode for read requests to the data source.
             wireProtocolEnabled:
               type: boolean


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-26247

### Staged Changes (Requires MongoDB Corp SSO)

- Corrected links in Admin API doc sections:
   - [Data API](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26247-update-data-api-link/admin/api/v3/#tag/data-api)
   - [GraphQL API](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26247-update-data-api-link/admin/api/v3/#tag/graphql)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
