### PR TITLE
Remove iOS template note

### DIFF
--- a/source/reference/template-apps.txt
+++ b/source/reference/template-apps.txt
@@ -45,12 +45,6 @@ option is most convenient for you.
       :ref:`create-a-realm-app` guide, and select
       the :guilabel:`Create App from Template` tab in the :guilabel:`Create a new App` step. 
 
-      .. note:: iOS with UIKit
-
-         If you want to use the iOS with UIKit template app, select :guilabel:`SwiftUI + Atlas Device Sync Starter`
-         in the list of template apps, but specify ``ios.swift.todo`` when you pull the
-         client code using the {+cli-bin+}.
-
    .. tab:: {+cli+}
       :tabid: cli
 
@@ -158,9 +152,9 @@ Template Apps Available
      - ``swiftui.todo``
      - iOS to-do list app using SwiftUI and the :ref:`Realm Swift SDK <ios-intro>`. Syncs local data to MongoDB Atlas using Device Sync with :ref:`Partition-Based Sync <partition-based-sync>`.
 
-   * - Swift + Atlas Device Sync Starter
+   * - Swift + Atlas Device Sync Starter (Partition-Based Sync)
      - ``ios.swift.todo``
-     - iOS to-do list app using UIKit and the :ref:`Realm Swift SDK <ios-intro>`. Syncs local data to MongoDB Atlas using Device Sync.
+     - iOS to-do list app using UIKit and the :ref:`Realm Swift SDK <ios-intro>`. Syncs local data to MongoDB Atlas using Device Sync with :ref:`Partition-Based Sync <partition-based-sync>`.
 
    * - React Native + Atlas Device Sync Starter (Flexible Sync)
      - ``react-native.todo.flex``


### PR DESCRIPTION
- The iOS UIKit template client is no longer compatible with the SwiftUI backend. The former uses PBS while the latter uses FS.
- TBD whether to support UIKit + FS.

## Pull Request Info

### Jira

- 

### Staged Changes (Requires MongoDB Corp SSO)

- 

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
