### PR TITLE
(DOCSP-24570): Add Flutter client reset tab

### DIFF
--- a/source/sync/error-handling/client-resets.txt
+++ b/source/sync/error-handling/client-resets.txt
@@ -243,7 +243,7 @@ reset examples for your SDK:
    .. tab::
       :tabid: flutter
 
-      :ref:`Client Resets - Flutter SDK <flutter-client-reset>`
+      :ref:`Handle Sync Errors - Client Reset - Flutter SDK <flutter-client-reset>`
 
 .. _enable-or-disable-recovery-mode:
 

--- a/source/sync/error-handling/client-resets.txt
+++ b/source/sync/error-handling/client-resets.txt
@@ -240,6 +240,11 @@ reset examples for your SDK:
 
       :ref:`Client Resets - .NET SDK <dotnet-client-resets>`
 
+   .. tab::
+      :tabid: flutter
+
+      :ref:`Client Resets - Flutter SDK <flutter-client-reset>`
+
 .. _enable-or-disable-recovery-mode:
 
 Enable or Disable Recovery Mode


### PR DESCRIPTION
## Pull Request Info

Add Flutter SDK client reset tab to Device Sync docs.

Note: do not merge until after https://github.com/mongodb/docs-realm/pull/2266 has been merged & deployed. otherwise ref won't work.

### Jira

- https://jira.mongodb.org/browse/DOCSP-24570

### Staged Changes (Requires MongoDB Corp SSO)

- [Client Resets](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-24570/sync/error-handling/client-resets/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
