### PR TITLE
(DOCSP-26214) Auth provider name must be the same as type

### DIFF
--- a/source/authentication/anonymous.txt
+++ b/source/authentication/anonymous.txt
@@ -113,6 +113,8 @@ Configuration
              "disabled": <boolean>
            }
          }
+      
+      .. include:: /includes/auth-provider-config-same-name-and-type.rst
 
 .. note::
 

--- a/source/authentication/anonymous.txt
+++ b/source/authentication/anonymous.txt
@@ -103,7 +103,7 @@ Configuration
       
       Anonymous provider configurations have the following form:
 
-      .. code-block:: javascript
+      .. code-block:: json
          :caption: /auth/providers.json
          
          {

--- a/source/authentication/api-key.txt
+++ b/source/authentication/api-key.txt
@@ -56,7 +56,7 @@ The API Key authentication provider does not have any configuration options.
 
       API Key provider configurations have the following form:
 
-      .. code-block:: none
+      .. code-block:: json
          :caption: /auth/providers.json
 
          {

--- a/source/authentication/api-key.txt
+++ b/source/authentication/api-key.txt
@@ -66,6 +66,8 @@ The API Key authentication provider does not have any configuration options.
              "disabled": false
            }
          }
+      
+      .. include:: /includes/auth-provider-config-same-name-and-type.rst
 
 .. _api-key-user-objects:
 

--- a/source/authentication/email-password.txt
+++ b/source/authentication/email-password.txt
@@ -65,7 +65,7 @@ Configuration
 
       Email/Password provider configurations have the following form:
 
-      .. code-block:: none
+      .. code-block:: json
          :caption: /auth/providers.json
          
          {

--- a/source/authentication/email-password.txt
+++ b/source/authentication/email-password.txt
@@ -86,6 +86,8 @@ Configuration
              "disabled": <boolean>
            }
          }
+      
+      .. include:: /includes/auth-provider-config-same-name-and-type.rst
 
 .. _email-password-authentication-confirmation:
 

--- a/source/includes/auth-provider-config-same-name-and-type.rst
+++ b/source/includes/auth-provider-config-same-name-and-type.rst
@@ -1,0 +1,3 @@
+.. tip::
+         
+   The ``name`` of an authentication provider is always the same as its ``type``.

--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -4744,6 +4744,7 @@ components:
           type: string
         name:
           type: string
+          description: The name of the authentication provider. This value must be the same as the value of `type`.
         type:
           "$ref": "#/components/schemas/ProviderType"
         disabled:
@@ -4754,6 +4755,7 @@ components:
           type: string
         name:
           type: string
+          description: The name of the authentication provider. This value must be the same as the value of `type`.
         type:
           "$ref": "#/components/schemas/ProviderType"
         disabled:
@@ -4764,6 +4766,7 @@ components:
       properties:
         name:
           type: string
+          description: The name of the authentication provider. This value must be the same as the value of `type`.
         type:
           "$ref": "#/components/schemas/ProviderType"
         disabled:


### PR DESCRIPTION
## Pull Request Info

- Small additions for clarity in this PR. In future we should do more work to refresh all of the auth provider pages + auth provider openapi defs

### Jira

- (DOCSP-26214) Auth provider name must be the same as type

### Staged Changes (Requires MongoDB Corp SSO)

- [Anonymous Auth](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/authproviders/authentication/anonymous/)
- [Email/Password Auth](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/authproviders/authentication/email-password/)
- [API Key Auth](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/authproviders/authentication/api-key/)
- [OpenAPI > Authentication Providers](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/authproviders/admin/api/v3/#tag/authproviders)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
