### PR TITLE
(DOCSP-26166) Copy prereq from SwiftUI tutorial to React Native tutorial

### DIFF
--- a/source/includes/kotlin-install-prerequisites.rst
+++ b/source/includes/kotlin-install-prerequisites.rst
@@ -1,7 +1,0 @@
-Prerequisites
--------------
-
-- :android:`Android Studio <studio/index.html>` Bumblebee 2021.1.1 or higher.
-- JDK 11 or higher.
-- Kotlin Plugin for Android Studio, version 1.6.10 or higher.
-- An Android Virtual Device (AVD) using a supported CPU architecture.

--- a/source/includes/tutorial-template-prerequisite.rst
+++ b/source/includes/tutorial-template-prerequisite.rst
@@ -1,0 +1,16 @@
+- This tutorial starts with a Template App. You need an `Atlas Account 
+  <https://cloud.mongodb.com/user/register?tck=docs_realm>`_, an API key, and 
+  ``realm-cli`` to create a Template App.
+
+  - You can learn more about creating an Atlas account in the 
+    :atlas:`Atlas Getting Started </getting-started>` documentation. For this 
+    tutorial, you need an Atlas account with a free-tier cluster.
+
+  - You also need an Atlas :atlas:`API key </configure-api-access/#programmatic-api-keys>`
+    for the MongoDB Cloud account you wish to log in with. 
+    You must be a :atlas:`Project Owner </reference/user-roles/#project-roles>` 
+    to create a Template App using ``realm-cli``.
+
+  - To learn more about installing ``realm-cli``, see 
+    :ref:`Install realm-cli <install-realm-cli>`. After you have installed ``realm-cli``, 
+    :ref:`login <realm-cli-login>` using the API key for your Atlas project. 

--- a/source/tutorial/backend.txt
+++ b/source/tutorial/backend.txt
@@ -38,8 +38,8 @@ After completing this tutorial, you will know how to do the following tasks:
 
 - Connect to an external service through an API
 
-Before You Start
-----------------
+Prerequisites
+-------------
 
 You need the following before you can begin this tutorial:
 

--- a/source/tutorial/dotnet.txt
+++ b/source/tutorial/dotnet.txt
@@ -42,9 +42,9 @@ Prerequisites
 -------------
 
 - Ensure that you have the necessary software installed. Select the tab for 
-   your development environment:
+  your development environment:
 
-   .. tabs::
+  .. tabs::
 
       .. tab:: MacOS
          :tabid: vs-mac

--- a/source/tutorial/dotnet.txt
+++ b/source/tutorial/dotnet.txt
@@ -41,7 +41,7 @@ around 30 minutes.
 Prerequisites
 -------------
 
-1. Ensure that you have the necessary software installed. Select the tab for 
+- Ensure that you have the necessary software installed. Select the tab for 
    your development environment:
 
    .. tabs::
@@ -66,8 +66,10 @@ Prerequisites
            network-accessible from the Windows computer, that 
            conforms to the minimum requirements for running Xamarin on macOS.
 
-2. You need previous experience deploying a Xamarin app to an Android Emulator, 
-   iOS Simulator, and/or a physical device.
+- You need previous experience deploying a Xamarin app to an Android Emulator, 
+  iOS Simulator, and/or a physical device.
+
+.. include:: /includes/tutorial-template-prerequisite.rst 
 
 Start with the Template
 -----------------------

--- a/source/tutorial/flutter.txt
+++ b/source/tutorial/flutter.txt
@@ -50,6 +50,8 @@ Prerequisites
 Before you begin, You should have previous experience deploying a Flutter app
 to an Android Emulator, iOS Simulator, and/or a physical device.
 
+.. include:: /includes/tutorial-template-prerequisite.rst 
+
 Start with the Template
 -----------------------
 

--- a/source/tutorial/flutter.txt
+++ b/source/tutorial/flutter.txt
@@ -47,8 +47,8 @@ need to set up a Realm Flutter SDK application.
 Prerequisites
 -------------
 
-Before you begin, You should have previous experience deploying a Flutter app
-to an Android Emulator, iOS Simulator, and/or a physical device.
+- You should have previous experience deploying a Flutter app
+  to an Android Emulator, iOS Simulator, and/or a physical device.
 
 .. include:: /includes/tutorial-template-prerequisite.rst 
 

--- a/source/tutorial/kotlin.txt
+++ b/source/tutorial/kotlin.txt
@@ -39,6 +39,8 @@ around 30 minutes.
 
 .. include:: /includes/kotlin-install-prerequisites.rst
 
+.. include:: /includes/tutorial-template-prerequisite.rst 
+
 Start with the Template
 -----------------------
 This tutorial is based on the Kotlin SDK Flexible Sync Template App named 

--- a/source/tutorial/kotlin.txt
+++ b/source/tutorial/kotlin.txt
@@ -37,7 +37,13 @@ around 30 minutes.
    It includes copyable code examples and the essential information that you 
    need to set up an Atlas App Services backend.
 
-.. include:: /includes/kotlin-install-prerequisites.rst
+Prerequisites
+-------------
+
+- :android:`Android Studio <studio/index.html>` Bumblebee 2021.1.1 or higher.
+- JDK 11 or higher.
+- Kotlin Plugin for Android Studio, version 1.6.10 or higher.
+- An Android Virtual Device (AVD) using a supported CPU architecture.
 
 .. include:: /includes/tutorial-template-prerequisite.rst 
 

--- a/source/tutorial/react-native.txt
+++ b/source/tutorial/react-native.txt
@@ -35,11 +35,30 @@ This tutorial should take around 30 minutes.
 Before You Begin
 ----------------
 
-You must set up your local environment for React Native development
+1. You must set up your local environment for React Native development
 before you can begin this tutorial. For detailed instructions, see
 `Setting up the development environment
 <https://reactnative.dev/docs/environment-setup>`_ in the React Native
 docs.
+
+2. This tutorial starts with a Template App. You need an `Atlas Account 
+   <https://cloud.mongodb.com/user/register?tck=docs_realm>`_, an API key, 
+   and ``realm-cli`` to create a Template App.
+
+   A. You can learn more about creating an Atlas account in the
+      :atlas:`Atlas Getting Started </getting-started>`
+      documentation. For this tutorial, you need an Atlas account with a free-tier
+      cluster.
+
+   B. You also need an Atlas :atlas:`API key 
+      </configure-api-access/#programmatic-api-keys>`
+      for the MongoDB Cloud account you wish to log in with. You must be a
+      :atlas:`Project Owner </reference/user-roles/#project-roles>` to create a
+      Template App using ``realm-cli``.
+
+   C. To learn more about installing ``realm-cli``, see :ref:`Install realm-cli 
+      <install-realm-cli>`. After you have installed ``realm-cli``, 
+      :ref:`login <realm-cli-login>` using the API key for your Atlas project. 
 
 Start with the Template App
 ---------------------------

--- a/source/tutorial/react-native.txt
+++ b/source/tutorial/react-native.txt
@@ -35,30 +35,13 @@ This tutorial should take around 30 minutes.
 Before You Begin
 ----------------
 
-1. You must set up your local environment for React Native development
-   before you can begin this tutorial. For detailed instructions, see
-   `Setting up the development environment
-   <https://reactnative.dev/docs/environment-setup>`_ in the React Native
-   docs.
+- You must set up your local environment for React Native development
+  before you can begin this tutorial. For detailed instructions, see
+  `Setting up the development environment
+  <https://reactnative.dev/docs/environment-setup>`_ in the React Native
+  docs.
 
-2. This tutorial starts with a Template App. You need an `Atlas Account 
-   <https://cloud.mongodb.com/user/register?tck=docs_realm>`_, an API key, 
-   and ``realm-cli`` to create a Template App.
-
-   A. You can learn more about creating an Atlas account in the
-      :atlas:`Atlas Getting Started </getting-started>`
-      documentation. For this tutorial, you need an Atlas account with a free-tier
-      cluster.
-
-   B. You also need an Atlas :atlas:`API key 
-      </configure-api-access/#programmatic-api-keys>`
-      for the MongoDB Cloud account you wish to log in with. You must be a
-      :atlas:`Project Owner </reference/user-roles/#project-roles>` to create a
-      Template App using ``realm-cli``.
-
-   C. To learn more about installing ``realm-cli``, see :ref:`Install realm-cli 
-      <install-realm-cli>`. After you have installed ``realm-cli``, 
-      :ref:`login <realm-cli-login>` using the API key for your Atlas project. 
+.. include:: /includes/tutorial-template-prerequisite.rst 
 
 Start with the Template App
 ---------------------------

--- a/source/tutorial/react-native.txt
+++ b/source/tutorial/react-native.txt
@@ -32,8 +32,8 @@ This tutorial should take around 30 minutes.
    examples and the essential information that you need to set up a
    React Native app with {+sync+}.
 
-Before You Begin
-----------------
+Prerequisites
+-------------
 
 - You must set up your local environment for React Native development
   before you can begin this tutorial. For detailed instructions, see

--- a/source/tutorial/react-native.txt
+++ b/source/tutorial/react-native.txt
@@ -36,10 +36,10 @@ Before You Begin
 ----------------
 
 1. You must set up your local environment for React Native development
-before you can begin this tutorial. For detailed instructions, see
-`Setting up the development environment
-<https://reactnative.dev/docs/environment-setup>`_ in the React Native
-docs.
+   before you can begin this tutorial. For detailed instructions, see
+   `Setting up the development environment
+   <https://reactnative.dev/docs/environment-setup>`_ in the React Native
+   docs.
 
 2. This tutorial starts with a Template App. You need an `Atlas Account 
    <https://cloud.mongodb.com/user/register?tck=docs_realm>`_, an API key, 

--- a/source/tutorial/swiftui.txt
+++ b/source/tutorial/swiftui.txt
@@ -41,27 +41,10 @@ around 30 minutes.
 Prerequisites
 -------------
 
-1. Ensure that you have the necessary software installed. The Swift SDK requires
-   `Xcode <https://developer.apple.com/xcode/>`_ version 13.1 or newer.
+- Ensure that you have the necessary software installed. The Swift SDK requires
+  `Xcode <https://developer.apple.com/xcode/>`_ version 13.1 or newer.
 
-2. This tutorial starts with a Template App. You need an `Atlas Account 
-   <https://cloud.mongodb.com/user/register?tck=docs_realm>`_, an API key, 
-   and ``realm-cli`` to create a Template App.
-
-   A. You can learn more about creating an Atlas account in the
-      :atlas:`Atlas Getting Started </getting-started>`
-      documentation. For this tutorial, you need an Atlas account with a free-tier
-      cluster.
-
-   B. You also need an Atlas :atlas:`API key 
-      </configure-api-access/#programmatic-api-keys>`
-      for the MongoDB Cloud account you wish to log in with. You must be a
-      :atlas:`Project Owner </reference/user-roles/#project-roles>` to create a
-      Template App using ``realm-cli``.
-
-   C. To learn more about installing ``realm-cli``, see :ref:`Install realm-cli 
-      <install-realm-cli>`. After you have installed ``realm-cli``, 
-      :ref:`login <realm-cli-login>` using the API key for your Atlas project. 
+.. include:: /includes/tutorial-template-prerequisite.rst  
 
 Start with the Template
 -----------------------


### PR DESCRIPTION
## Pull Request Info

This PR adds more prerequisite info to the React Native Tutorial. The Swift tutorial had excellent relevant content for this, so I just pulled it over. ~~Long term, we should look at standardizing these prerequisite sections - potentially refactoring common bits like what's added here into an include that can be shared.~~

I abstracted the generic prerequisites to an include and updated the other tutorials with it.

### Jira

- https://jira.mongodb.org/browse/DOCSP-26166

### Staged Changes (Requires MongoDB Corp SSO)

- [React Native Tutorial > Prerequisites](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26166/tutorial/react-native/#prerequisites)
- [Flutter Tutorial > Prerequisites](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26166/tutorial/flutter/#prerequisites)
- [SwiftUI Tutorial> Prerequisites](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26166/tutorial/swiftui/#prerequisites)
- [Kotlin Tutorial > Prerequisites](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26166/tutorial/kotlin/#prerequisites)
- [Xamarin Tutorial > Prerequisites](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26166/tutorial/dotnet/#prerequisites)
- [Triggers, Functions, and Values Tutorial > Prerequisites](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26166/tutorial/backend/) - just the section name

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
