### PR TITLE
Add Redocly OpenAPI lint config

### DIFF
--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,6 @@
+apis:
+  admin@v3:
+    root: ./source/openapi-admin-v3.yaml
+    rules:
+      info-license: off
+      operation-4xx-response: off


### PR DESCRIPTION
## Pull Request Info

Turns off lint rules that emitted the following warnings:

- Operation must have at least one `4XX` response.
- Info object should contain `license` field.

I created the following DOCSP tickets that will eventually turn these warnings back on:

- [(DOCSP-26643) [Admin API] Add info.license & re-enable lint rule](https://jira.mongodb.org/browse/DOCSP-26643)
- [(DOCSP-26644) [Admin API] 4XX Responses](https://jira.mongodb.org/browse/DOCSP-26644)
