### PR TITLE
(DOCSP-26912): Update Atlas Function max request timeout to 180s

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -62,4 +62,4 @@ cli-bin = ":binary:`realm-cli`" # binary -- DO NOT USE IN LINKS! Will break them
 log-retention-time = "10 days"
 max-graphql-relationship-depth = "five"
 max-graphql-resolvers = "ten"
-request-timeout-time = "150 seconds"
+request-timeout-time = "180 seconds"


### PR DESCRIPTION
## Pull Request Info

Update Atlas Function max request timeout to 180s

### Jira

- https://jira.mongodb.org/browse/DOCSP-26912

### Staged Changes

- [Atlas Functions > Constraints section](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26912/functions#constraints)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
