### PR TITLE
(DOCSP-26974): Add end-to-end example for a custom HTTPS endpoint function

### DIFF
--- a/source/data-api/custom-endpoints.txt
+++ b/source/data-api/custom-endpoints.txt
@@ -136,16 +136,18 @@ deploying configuration files with Realm CLI:
          JSON or EJSON. You can enable :guilabel:`Respond With Result`
          to automatically include the endpoint function's return value
          as the response body.
+
+      5. Optionally, specify or write an :ref:`endpoint function <endpoint-function>`.
       
-      5. For additional security, you can configure :ref:`request
+      6. For additional security, you can configure :ref:`request
          authorization <endpoint-authorization>`.
       
-      6. Save the Data API configuration.
+      7. Save the Data API configuration.
       
-      6. Configure :ref:`access permissions <data-api-permissions>` to
+      8. Configure :ref:`access permissions <data-api-permissions>` to
          allow requests to securely read and write data.
       
-      7. Save and deploy your app.
+      9. Save and deploy your app.
      
    .. tab::
       :tabid: cli
@@ -347,14 +349,20 @@ that runs whenever the endpoint receives an incoming request. In the
 function, you can import libraries from npm, connect to a linked MongoDB
 Atlas cluster, and call other serverless functions. 
 
-To define and edit endpoint handler functions:
+To define a new function when :ref:`creating an endpoint 
+<create-custom-endpoint>` in the App Services UI, navigate
+to the :guilabel:`Function` section and select
+:guilabel:`+ New Function` from the dropdown.
 
-- Use the editor in the :guilabel:`Functions` page of the App Services UI.
-- Directly edit the :ref:`/functions <appconfig-functions>` folder of an app 
-  configuration directory. 
-- Select the :guilabel:`+ New Function` option
-  in the :guilabel:`Function` section when using the UI to 
-  :ref:`add an endpoint <create-custom-endpoint>`.
+Depending on your workflow, you can also define and edit endpoint 
+handler functions:
+
+- On the :guilabel:`Functions` page in the :ref:`App Services UI 
+  <define-a-function>`.
+- In the ``functions`` directory of your application using the 
+  :ref:`App Services CLI <define-a-function>`.
+- From your client using the :admin-api-endpoint:`Admin API 
+  <operation/adminCreateFunction>`.
 
 Endpoint functions always receive two arguments:
 

--- a/source/data-api/custom-endpoints.txt
+++ b/source/data-api/custom-endpoints.txt
@@ -556,11 +556,7 @@ responds to the caller:
       }
    }
 
-The following example demonstrates a sample request and response when using the
-preceding function. After the function verifies that the body of the incoming 
-request is defined, it stores the parsed body as a new document in 
-a collection named ``myCollection``. The resulting output displays 
-the configured response, which includes a custom message and the ``insertedId``.
+The function receives the following ``POST`` request:
 
 .. io-code-block::
    
@@ -581,6 +577,11 @@ the configured response, which includes a custom message and the ``insertedId``.
         "message": "Successfully saved the request body", 
         "insertedId": "639a521bbdec9b85ba94014b" 
       }
+
+After the function verifies that the body of the incoming request 
+is defined, it stores the parsed body as a new document in a collection 
+named ``myCollection``. The resulting output displays the configured 
+response, which includes a custom message and the ``insertedId``.
 
 Call a Custom Endpoint
 ----------------------

--- a/source/data-api/custom-endpoints.txt
+++ b/source/data-api/custom-endpoints.txt
@@ -107,6 +107,8 @@ Custom endpoints support the following standard HTTP methods:
 - :mdn:`PATCH <Web/HTTP/Methods/PATCH>`
 - :mdn:`DELETE <Web/HTTP/Methods/DELETE>`
 
+.. _create-custom-endpoint: 
+
 Create a Custom HTTPS Endpoint
 ------------------------------
 
@@ -345,19 +347,24 @@ that runs whenever the endpoint receives an incoming request. In the
 function, you can import libraries from npm, connect to a linked MongoDB
 Atlas cluster, and call other serverless functions. 
 
-To define and edit endpoint handler functions, use the editor in the
-:guilabel:`Functions` page of the App Services UI or directly 
-edit the :ref:`/functions <appconfig-functions>` folder of an app 
-configuration directory. For a complete example, see 
-:ref:`endpoint-function-example`.
+To define and edit endpoint handler functions:
+
+- Use the editor in the :guilabel:`Functions` page of the App Services UI.
+- Directly edit the :ref:`/functions <appconfig-functions>` folder of an app 
+  configuration directory. 
+- Select the :guilabel:`+ New Function` option
+  in the :guilabel:`Function` section when using the UI to 
+  :ref:`add an endpoint <create-custom-endpoint>`.
 
 Endpoint functions always receive two arguments:
 
 - A :ref:`Request <endpoint-request-object>` object that lets you access
   incoming request headers, query parameters, and body data.
-
 - A :ref:`Response <endpoint-response-object>` object that you use to
   configure the HTTPS response sent back to the caller.
+
+For a sample function and an example request and response, see 
+:ref:`endpoint-function-example`.
 
 .. _endpoint-request-object:
 
@@ -564,7 +571,7 @@ the configured response, which includes a custom message and the ``insertedId``.
          -H 'apiKey: abcde12345' \
          -H 'Content-Type: application/json' \
          -H 'Accept: application/json' \
-         -d '{ "foo": "bar" }'
+         -d '{ "foo": "bar" }' \
          https://data.mongodb-api.com/app/myapp-abcde/endpoint/custom
    
    .. output::

--- a/source/data-api/custom-endpoints.txt
+++ b/source/data-api/custom-endpoints.txt
@@ -343,13 +343,13 @@ Write an Endpoint Function
 Every custom endpoint is associated with a :ref:`function <functions>`
 that runs whenever the endpoint receives an incoming request. In the
 function, you can import libraries from npm, connect to a linked MongoDB
-Atlas cluster, and call other serverless functions.
+Atlas cluster, and call other serverless functions. 
 
-.. tip::
-   
-   You define and edit endpoint handler functions on the
-   :guilabel:`Functions` page of the App Services UI or in the :ref:`/functions
-   <appconfig-functions>` folder of an app configuration directory.
+To define and edit endpoint handler functions, use the editor in the
+:guilabel:`Functions` page of the App Services UI or directly 
+edit the :ref:`/functions <appconfig-functions>` folder of an app 
+configuration directory. For a complete example, see 
+:ref:`endpoint-function-example`.
 
 Endpoint functions always receive two arguments:
 
@@ -358,40 +358,6 @@ Endpoint functions always receive two arguments:
 
 - A :ref:`Response <endpoint-response-object>` object that you use to
   configure the HTTPS response sent back to the caller.
-
-.. example::
-   
-   This endpoint function parses the body of an incoming ``POST``
-   request, stores the parsed body in a MongoDB collection, and then
-   responds to the caller:
-
-   .. code-block:: javascript
-   
-      exports = async function (request, response) {
-        try {
-          // 1. Parse data from the incoming request
-          if(request.body === undefined) {
-            throw new Error(`Request body was not defined.`)
-          }
-          const body = JSON.parse(request.body.text());
-          // 2. Handle the request
-          const { insertedId } = await context.services
-            .get("mongodb-atlas")
-            .db("myDb")
-            .collection("myCollection")
-            .insertOne({ date: new Date(), requestBody: body });
-          // 3. Configure the response
-          response.setStatusCode(201);
-          // tip: You can also use EJSON.stringify instead of JSON.stringify.
-          response.setBody(JSON.stringify({
-             message: "Successfully saved the request body",
-             insertedId,
-          }));
-        } catch (error) {
-          response.setStatusCode(400);
-          response.setBody(error.message);
-        }
-      }
 
 .. _endpoint-request-object:
 
@@ -545,6 +511,69 @@ headers, and include data in the response body.
                "Cache-Control",
                "min-fresh=60"
              )
+
+.. _endpoint-function-example:
+
+Example
+~~~~~~~
+
+Consider an endpoint function that parses the body of an incoming ``POST``
+request, stores the parsed body in a MongoDB collection, and then
+responds to the caller:
+
+.. code-block:: javascript
+
+   exports = async function (request, response) {
+      try {
+         // 1. Parse data from the incoming request
+         if(request.body === undefined) {
+         throw new Error(`Request body was not defined.`)
+         }
+         const body = JSON.parse(request.body.text());
+         // 2. Handle the request
+         const { insertedId } = await context.services
+         .get("mongodb-atlas")
+         .db("myDb")
+         .collection("myCollection")
+         .insertOne({ date: new Date(), requestBody: body });
+         // 3. Configure the response
+         response.setStatusCode(201);
+         // tip: You can also use EJSON.stringify instead of JSON.stringify.
+         response.setBody(JSON.stringify({
+            message: "Successfully saved the request body",
+            insertedId,
+         }));
+      } catch (error) {
+         response.setStatusCode(400);
+         response.setBody(error.message);
+      }
+   }
+
+The following example demonstrates a sample request and response when using the
+preceding function. After the function verifies that the body of the incoming 
+request is defined, it stores the parsed body as a new document in 
+a collection named ``myCollection``. The resulting output displays 
+the configured response, which includes a custom message and the ``insertedId``.
+
+.. io-code-block::
+   
+   .. input::
+      :language: bash
+      
+      curl -X POST \
+         -H 'apiKey: abcde12345' \
+         -H 'Content-Type: application/json' \
+         -H 'Accept: application/json' \
+         -d '{ "foo": "bar" }'
+         https://data.mongodb-api.com/app/myapp-abcde/endpoint/custom
+   
+   .. output::
+      :language: json
+      
+      { 
+        "message": "Successfully saved the request body", 
+        "insertedId": "639a521bbdec9b85ba94014b" 
+      }
 
 Call a Custom Endpoint
 ----------------------


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-26974

### Staged Changes

- [Custom HTTPS Endpoints](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-26974/data-api/custom-endpoints/#write-an-endpoint-function)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
