### PR TITLE
(DOCSP-26317) [Admin API] Configure user session refresh token expiration

### DIFF
--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -2245,7 +2245,7 @@ paths:
         Get the current expiration time in seconds for user session refresh tokens.
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:

--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -2232,6 +2232,46 @@ paths:
           description: Deleted
         "404":
           description: No IP addresses or CIDR blocks to delete
+  "/groups/{groupId}/apps/{appId}/security/refresh_token_expiration":
+    parameters:
+      - "$ref": "#/components/parameters/GroupId"
+      - "$ref": "#/components/parameters/AppId"
+    get:
+      tags:
+        - security
+      operationId: adminGetRefreshTokenExpiration
+      summary: Get User Refresh Token Expiration Time
+      descripti:on: |-
+        Get the current expiration time in seconds for user session refresh tokens.
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RefreshTokenExpiration"
+        "404":
+          description: Group or App Not Found
+    put:
+      tags:
+        - security
+      operationId: adminSetRefreshTokenExpiration
+      summary: Set User Refresh Token Expiration Time
+      descripti:on: |-
+        Set the expiration time in seconds for user session refresh tokens.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RefreshTokenExpiration"
+      responses:
+        "204":
+          description: Expiration time updated
+        "400":
+          description: Invalid expiration time
+        "404":
+          description: Group or App Not Found
   "/groups/{groupId}/apps/{appId}/metrics":
     get:
       tags:
@@ -6454,6 +6494,21 @@ components:
         hash:
           type: string
           description: The MD5 checksum hash for the hosted asset
+    RefreshTokenExpiration:
+      type: object
+      properties:
+        expiration_time_seconds:
+          type: number
+          minimum: 1800
+          maximum: 15552000
+          default: 5184000
+          description: |-
+            The time in seconds that a user session refresh
+            token is valid for once issued. After this time, the
+            token is expired and the user must re-authenticate.
+
+            The expiration time must be between 30 minutes and 180 days,
+            inclusive. The default expiration time is 60 days.
     Relationship:
       type: object
       description: A [relationship](https://www.mongodb.com/docs/realm/schemas/relationships/) definition.

--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -6503,9 +6503,9 @@ components:
           maximum: 15552000
           default: 5184000
           description: |-
-            The time in seconds that a user session refresh
-            token is valid for once issued. After this time, the
-            token is expired and the user must re-authenticate.
+            The time in seconds that a user session refresh token is
+            valid for after it is issued. After this time, the token is
+            expired and the user must re-authenticate.
 
             The expiration time must be between 30 minutes and 180 days,
             inclusive. The default expiration time is 60 days.

--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -883,7 +883,7 @@ paths:
                     Use this to determine which end of a range query to start sampling from.
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -1089,7 +1089,7 @@ paths:
       description: Get the current [default roles and filters](https://www.mongodb.com/docs/atlas/app-services/rules/#default-rules).
       responses:
         "200":
-          description: Ok.
+          description: OK
           content:
             application/json:
               schema:
@@ -2555,7 +2555,7 @@ paths:
       summary: "List log forwarders."
       responses:
         200:
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -2591,7 +2591,7 @@ paths:
       summary: "Get a specific log forwarder."
       responses:
         200:
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -2609,7 +2609,7 @@ paths:
               $ref: "#/components/schemas/UpdateLogForwarderRequest"
       responses:
         200:
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -3037,7 +3037,7 @@ paths:
       description: Get information about a recent deployment of the application.
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -3797,7 +3797,7 @@ paths:
       description: Get a specific [schema](https://www.mongodb.com/docs/realm/schemas) by its `_id` value.
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -3859,7 +3859,7 @@ paths:
       description: Get all [endpoint](https://www.mongodb.com/docs/realm/endpoints/) configurations.
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -3902,7 +3902,7 @@ paths:
       description: Get a specific [endpoint](https://www.mongodb.com/docs/realm/endpoints/)'s configuration.
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -3923,7 +3923,7 @@ paths:
               "$ref": "#/components/schemas/Endpoint"
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -3936,7 +3936,7 @@ paths:
       summary: Delete an endpoint
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -3954,7 +3954,7 @@ paths:
       description: Get your app's [Data API](https://www.mongodb.com/docs/atlas/app-services/data-api/generated-endpoints/) configuration.
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -4008,7 +4008,7 @@ paths:
       description: List all possible Data API versions.
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -4059,7 +4059,7 @@ paths:
                   example: AllTasks
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -4108,7 +4108,7 @@ paths:
       description: Get all [custom resolver](https://www.mongodb.com/docs/realm/graphql/custom-resolvers/) configurations from your app's GraphQL API.
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -4148,7 +4148,7 @@ paths:
       description: Get a specific [custom resolver](https://www.mongodb.com/docs/realm/graphql/custom-resolvers/) configuration.
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -4191,7 +4191,7 @@ paths:
       description: Get the current validation level and action for reads and writes.
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -4224,7 +4224,7 @@ paths:
       description: Check if [null type schema validation](https://www.mongodb.com/docs/atlas/app-services/schemas/enforce-a-schema/#validate-null-types) is enabled.
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-26317) [Admin API] Configure user session refresh token expiration

### Staged Changes

- [Admin API > Get/Set User Session Refresh Token Expiration](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/token-expiration/admin/api/v3/#tag/security/operation/adminGetRefreshTokenExpiration)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
