### PR TITLE
(DOCSP-27327) Update user metadata SDK links

### DIFF
--- a/source/users/enable-user-metadata.txt
+++ b/source/users/enable-user-metadata.txt
@@ -226,13 +226,10 @@ Procedure
 Access User Metadata from a Client Application
 ----------------------------------------------
 
-.. tabs-realm-sdks::
+Realm SDKs have different implementations for accessing user metadata in a client
+application. Check out the details in the SDK documentation:
 
-   .. tab::
-      :tabid: ios
-
-      .. tip:: Read a User's Metadata
-         
-         Learn how to :ref:`read a user's metadata from an iOS
-         application <ios-read-user-metadata>`.
-
+- :ref:`Realm Swift SDK <ios-read-user-metadata>`
+- :ref:`Realm Flutter SDK <flutter-read-user-metadata>`
+- :ref:`Realm .NET SDK <dotnet-read-user-metadata>`
+- :ref:`Realm Node.js SDK <ios-read-user-metadata>`

--- a/source/users/enable-user-metadata.txt
+++ b/source/users/enable-user-metadata.txt
@@ -85,9 +85,7 @@ Procedure
             - Press the :guilabel:`EDIT` button for the provider whose metadata
               you want to configure.
 
-
          .. step:: Configure User Metadata
-
 
             **Google or Facebook**
 
@@ -118,7 +116,6 @@ Procedure
             After you configure the metadata you want to access, press
             the :guilabel:`Save Draft` button.
 
-
          .. step:: Deploy the Updated Application
 
             After you update the metadata configuration, you must deploy your
@@ -137,7 +134,6 @@ Procedure
             App Services exposes the data in that user's :ref:`user object
             <user-objects>`.
 
-   
    .. tab::
       :tabid: cli
       
@@ -159,7 +155,6 @@ Procedure
                You can also download a copy of your application's configuration files from
                the App Services UI. Go to the :guilabel:`Deploy > Export App` screen from
                the App Dashboard.
-
 
          .. step:: Configure User Metadata
 
@@ -211,7 +206,6 @@ Procedure
                  ]
                }
 
-
          .. step:: Deploy the Custom User Data Configuration
 
             Once you've configured custom user data, you can push the updated config to
@@ -220,8 +214,6 @@ Procedure
             .. code-block:: bash
 
                realm-cli push --remote="<Your App ID>"
-
-
 
 Access User Metadata from a Client Application
 ----------------------------------------------
@@ -232,4 +224,4 @@ application. Check out the details in the SDK documentation:
 - :ref:`Realm Swift SDK <ios-read-user-metadata>`
 - :ref:`Realm Flutter SDK <flutter-read-user-metadata>`
 - :ref:`Realm .NET SDK <dotnet-read-user-metadata>`
-- :ref:`Realm Node.js SDK <ios-read-user-metadata>`
+- :ref:`Realm Node.js SDK <node-read-user-metadata>`


### PR DESCRIPTION
## Pull Request Info

This PR adds several SDK links  to the User Metadata page. It should be merged _after_ the new Node.js SDK page for [user meta data PR](https://github.com/mongodb/docs-realm/pull/2503) is merged.

### Jira

- https://jira.mongodb.org/browse/DOCSP-27327

### Staged Changes

- [Enable User Metadata](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-27372/users/enable-user-metadata/#access-user-metadata-from-a-client-application)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
