### PR TITLE
(DOCSP-27741) Bearer Auth Example for Custom & Generated Endpoints

### DIFF
--- a/source/data-api/custom-endpoints.txt
+++ b/source/data-api/custom-endpoints.txt
@@ -208,21 +208,19 @@ each request to include credentials for one of your application users,
 like an API key or JWT. You can also configure other custom
 authentication schemes to fit your application's needs.
 
+For examples of how to authenticate requests, see :ref:`Authenticate
+Data API Requests <data-api-authenticate-requests>`.
+
 .. tabs::
 
    .. tab:: Application
       :tabid: auth-credentials
 
-      Application authentication requires users to authenticate each
-      Data API request by providing login credentials for one of the
-      following supported authentication providers:
-      
-      - :ref:`Email/Password <email-password-authentication>`
-      - :ref:`API Key <api-key-authentication>`
-      - :ref:`Custom JWT <custom-jwt-authentication>`
-      
-      To see how to include authentication credentials in endpoint
-      requests, see :ref:`endpoint-authenticate`.
+      Application authentication requires users to log in with an
+      authentication provider that you have enabled for your App.
+      Requests can either include an access token granted by the
+      authentication provider or the credentials the user would log in
+      with (e.g. their email and password).
       
       .. note::
          
@@ -725,14 +723,32 @@ data format specified in the endpoint configuration.
 Authenticate the Request
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-An endpoint function can require requests to include valid credentials
-for an application user in the request headers. You can authenticate
-requests for users that log in with any of the following enabled
-authentication providers:
+If an endpoint is configured to use Application Authentication then you
+must include a valid user access token or login credentials with every
+request.
 
-- :ref:`Email/Password <email-password-authentication>`
-- :ref:`API Key <api-key-authentication>`
-- :ref:`Custom JWT <custom-jwt-authentication>`
+In general, prefer to use an access token over login credentials when
+possible. The token lets you run multiple requests without
+re-authenticating the user. It also lets you send requests from a web
+browser or other environment that enforces :wikipedia:`CORS
+<Cross-origin_resource_sharing>`.
+
+To use an access token, authenticate the user through an authentication
+provider and then include the access token in the request's
+Authorization header using a Bearer token scheme. For more information
+on how to acquire and use an access token, see :ref:`Bearer Token
+Authentication <data-api-bearer-authentication>`.
+
+.. code-block:: shell
+   :emphasize-lines: 2
+
+   curl -X GET \
+      -H 'Authorization: Bearer <AccessToken>' \
+      -H 'Content-Type: application/json' \
+      https://data.mongodb-api.com/app/myapp-abcde/endpoint/hello
+
+Alternatively, you can include valid login credentials for the user in
+the request headers.
 
 .. tabs-realm-auth-providers::
    

--- a/source/data-api/custom-endpoints.txt
+++ b/source/data-api/custom-endpoints.txt
@@ -220,12 +220,7 @@ Data API Requests <data-api-authenticate-requests>`.
       authentication provider that you have enabled for your App.
       Requests can either include an access token granted by the
       authentication provider or the credentials the user would log in
-      with (e.g. their email and password).
-      
-      .. note::
-         
-         You must enable an authentication provider before users can
-         authenticate through it.
+      with (e.g. their API key or email and password).
    
    .. tab:: User ID
       :tabid: auth-userid
@@ -727,17 +722,17 @@ If an endpoint is configured to use Application Authentication then you
 must include a valid user access token or login credentials with every
 request.
 
-In general, prefer to use an access token over login credentials when
+In general, use an access token over login credentials when
 possible. The token lets you run multiple requests without
 re-authenticating the user. It also lets you send requests from a web
-browser or other environment that enforces :wikipedia:`CORS
-<Cross-origin_resource_sharing>`.
+browser that enforces :wikipedia:`CORS <Cross-origin_resource_sharing>`.
 
-To use an access token, authenticate the user through an authentication
-provider and then include the access token in the request's
-Authorization header using a Bearer token scheme. For more information
-on how to acquire and use an access token, see :ref:`Bearer Token
-Authentication <data-api-bearer-authentication>`.
+To use an access token, first authenticate the user through an App
+Services authentication provider. Then, get the access token returned
+from App Services and include it in the request's Authorization header
+using a Bearer token scheme. For more information on how to acquire and
+use an access token, see :ref:`Bearer Token Authentication
+<data-api-bearer-authentication>`.
 
 .. code-block:: shell
    :emphasize-lines: 2

--- a/source/data-api/generated-endpoints.txt
+++ b/source/data-api/generated-endpoints.txt
@@ -173,23 +173,12 @@ Data API Requests <data-api-authenticate-requests>`.
    .. tab:: Application
       :tabid: auth-credentials
 
-      Application authentication requires users to authenticate each
-      Data API request by providing login credentials for one of the
-      following supported authentication providers:
-      
-      - :ref:`Email/Password <email-password-authentication>`
-      - :ref:`API Key <api-key-authentication>`
-      - :ref:`Custom JWT <custom-jwt-authentication>`
-      
-      To see how to include authentication credentials in Data API
-      requests, see :ref:`data-api-authenticate`.
-      
-      .. note::
-         
-         You must :ref:`enable an authentication provider
-         <authentication-providers>` before users can authenticate with
-         it.
-   
+      Application authentication requires users to log in with an
+      authentication provider that you have enabled for your App.
+      Requests can either include an access token granted by the
+      authentication provider or the credentials the user would log in
+      with (e.g. their email and password).
+
    .. tab:: User ID
       :tabid: auth-userid
 
@@ -570,15 +559,39 @@ specified in your :ref:`Data API configuration <data-api-response-type>`.
 Authenticate the Request
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Incoming requests must include headers that authenticate the calling
-user.
+If an endpoint is configured to use Application Authentication then you
+must include a valid user access token or login credentials with every
+request.
 
-Requests can authenticate with any of the following authentication
-providers by including user credentials directly in the request headers:
+In general, prefer to use an access token over login credentials when
+possible. The token lets you run multiple requests without
+re-authenticating the user. It also lets you send requests from a web
+browser or other environment that enforces :wikipedia:`CORS
+<Cross-origin_resource_sharing>`.
 
-- :ref:`Email/Password <email-password-authentication>`
-- :ref:`API Key <api-key-authentication>`
-- :ref:`Custom JWT <custom-jwt-authentication>`
+To use an access token, authenticate the user through an authentication
+provider and then include the access token in the request's
+Authorization header using a Bearer token scheme. For more information
+on how to acquire and use an access token, see :ref:`Bearer Token
+Authentication <graphql-bearer-authentication>`.
+
+.. code-block:: shell
+   :emphasize-lines: 2
+
+   curl -X POST 'https://data.mongodb-api.com/app/<AppID>/endpoint/data/v1/action/find' \
+      --header 'Authorization: Bearer <AccessToken>' \
+      --header 'Content-Type: application/json' \
+      --data-raw '{
+        "dataSource": "mongodb-atlas",
+        "database": "sample_mflix",
+        "collection": "movies",
+        "filter": {
+          "title": "The Matrix"
+        }
+      }'
+
+Alternatively, you can include valid login credentials for the user in
+the request headers.
 
 .. tabs-realm-auth-providers::
    
@@ -631,29 +644,6 @@ providers by including user credentials directly in the request headers:
              "collection": "hello",
            }'
 
-Alternatively, you can exchange the user's login credentials for an
-access token that you can then include in a request header. This token
-lets you run multiple requests without re-authenticating the user. It
-also lets you send requests from a browser or other environment that
-enforces :wikipedia:`CORS <Cross-origin_resource_sharing>`.
-
-For more information on how to acquire and use an access token, see
-:ref:`Bearer Token Authentication <data-api-bearer-authentication>`.
-
-.. code-block:: shell
-   :emphasize-lines: 2
-
-   curl -X POST 'https://data.mongodb-api.com/app/<AppID>/endpoint/data/v1/action/find' \
-      --header 'Authorization: Bearer <AccessToken>' \
-      --header 'Content-Type: application/json' \
-      --data-raw '{
-        "dataSource": "mongodb-atlas",
-        "database": "sample_mflix",
-        "collection": "movies",
-        "filter": {
-          "title": "The Matrix"
-        }
-      }'
 .. _data-api-authorize:
 
 Authorize the Request

--- a/source/data-api/generated-endpoints.txt
+++ b/source/data-api/generated-endpoints.txt
@@ -177,7 +177,7 @@ Data API Requests <data-api-authenticate-requests>`.
       authentication provider that you have enabled for your App.
       Requests can either include an access token granted by the
       authentication provider or the credentials the user would log in
-      with (e.g. their email and password).
+      with (e.g. their API key or email and password).
 
    .. tab:: User ID
       :tabid: auth-userid
@@ -563,17 +563,17 @@ If an endpoint is configured to use Application Authentication then you
 must include a valid user access token or login credentials with every
 request.
 
-In general, prefer to use an access token over login credentials when
+In general, use an access token over login credentials when
 possible. The token lets you run multiple requests without
 re-authenticating the user. It also lets you send requests from a web
-browser or other environment that enforces :wikipedia:`CORS
-<Cross-origin_resource_sharing>`.
+browser that enforces :wikipedia:`CORS <Cross-origin_resource_sharing>`.
 
-To use an access token, authenticate the user through an authentication
-provider and then include the access token in the request's
-Authorization header using a Bearer token scheme. For more information
-on how to acquire and use an access token, see :ref:`Bearer Token
-Authentication <graphql-bearer-authentication>`.
+To use an access token, first authenticate the user through an App
+Services authentication provider. Then, get the access token returned
+from App Services and include it in the request's Authorization header
+using a Bearer token scheme. For more information on how to acquire and
+use an access token, see :ref:`Bearer Token Authentication
+<data-api-bearer-authentication>`.
 
 .. code-block:: shell
    :emphasize-lines: 2


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-27741) Bearer Auth Example for Custom & Generated Endpoints

### Staged Changes

- [Generated Endpoints > Authenticate the Request](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/api-auth/data-api/generated-endpoints/#authenticate-the-request)
- [Custom Endpoints > Authenticate the Request](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/api-auth/data-api/custom-endpoints/#authenticate-the-request)