### PR TITLE
(DOCSP-27945) Bearer Auth: Client API Keys & Throughput

### DIFF
--- a/source/data-api/authenticate.txt
+++ b/source/data-api/authenticate.txt
@@ -67,6 +67,15 @@ For example, the following request uses Bearer Authentication:
         }
       }'
 
+In general, bearer authentication with an access token has higher
+throughput and is more secure than credential headers. Use an access
+token over credential headers when possible. The token lets you run
+multiple requests without re-authenticating the user. It also lets you
+send requests from a web browser that enforces :wikipedia:`CORS
+<Cross-origin_resource_sharing>`.
+
+.. include:: /includes/dont-use-api-key-in-browsers.rst
+
 .. include:: /includes/api-user-access-token.rst
 
 .. _data-api-credential-headers:
@@ -138,6 +147,8 @@ To authenticate a Data API request with an :ref:`API Key
           "title": "The Matrix"
         }
       }'
+
+.. include:: /includes/dont-use-api-key-in-browsers.rst
 
 Custom JWT
 ~~~~~~~~~~

--- a/source/data-api/authenticate.txt
+++ b/source/data-api/authenticate.txt
@@ -67,12 +67,7 @@ For example, the following request uses Bearer Authentication:
         }
       }'
 
-In general, bearer authentication with an access token has higher
-throughput and is more secure than credential headers. Use an access
-token over credential headers when possible. The token lets you run
-multiple requests without re-authenticating the user. It also lets you
-send requests from a web browser that enforces :wikipedia:`CORS
-<Cross-origin_resource_sharing>`.
+.. include:: /includes/bearer-auth-performance.rst
 
 .. include:: /includes/dont-use-api-key-in-browsers.rst
 

--- a/source/data-api/custom-endpoints.txt
+++ b/source/data-api/custom-endpoints.txt
@@ -722,12 +722,7 @@ If an endpoint is configured to use Application Authentication then you
 must include a valid user access token or login credentials with every
 request.
 
-In general, bearer authentication with an access token has higher
-throughput and is more secure than credential headers. Use an access
-token over credential headers when possible. The token lets you run
-multiple requests without re-authenticating the user. It also lets you
-send requests from a web browser that enforces :wikipedia:`CORS
-<Cross-origin_resource_sharing>`.
+.. include:: /includes/bearer-auth-performance.rst
 
 To use an access token, first authenticate the user through an App
 Services authentication provider. Then, get the access token returned

--- a/source/data-api/custom-endpoints.txt
+++ b/source/data-api/custom-endpoints.txt
@@ -722,10 +722,12 @@ If an endpoint is configured to use Application Authentication then you
 must include a valid user access token or login credentials with every
 request.
 
-In general, use an access token over login credentials when
-possible. The token lets you run multiple requests without
-re-authenticating the user. It also lets you send requests from a web
-browser that enforces :wikipedia:`CORS <Cross-origin_resource_sharing>`.
+In general, bearer authentication with an access token has higher
+throughput and is more secure than credential headers. Use an access
+token over credential headers when possible. The token lets you run
+multiple requests without re-authenticating the user. It also lets you
+send requests from a web browser that enforces :wikipedia:`CORS
+<Cross-origin_resource_sharing>`.
 
 To use an access token, first authenticate the user through an App
 Services authentication provider. Then, get the access token returned
@@ -780,6 +782,8 @@ the request headers.
             -H 'jwtTokenString: <Custom JSON Web Token>' \
             -H 'Content-Type: application/json' \
             https://data.mongodb-api.com/app/myapp-abcde/endpoint/hello
+
+.. include:: /includes/dont-use-api-key-in-browsers.rst
 
 .. _endpoint-authorize:
 

--- a/source/data-api/generated-endpoints.txt
+++ b/source/data-api/generated-endpoints.txt
@@ -563,12 +563,7 @@ If an endpoint is configured to use Application Authentication then you
 must include a valid user access token or login credentials with every
 request.
 
-In general, bearer authentication with an access token has higher
-throughput and is more secure than credential headers. Use an access
-token over credential headers when possible. The token lets you run
-multiple requests without re-authenticating the user. It also lets you
-send requests from a web browser that enforces :wikipedia:`CORS
-<Cross-origin_resource_sharing>`.
+.. include:: /includes/bearer-auth-performance.rst
 
 To use an access token, first authenticate the user through an App
 Services authentication provider. Then, get the access token returned

--- a/source/data-api/generated-endpoints.txt
+++ b/source/data-api/generated-endpoints.txt
@@ -563,10 +563,12 @@ If an endpoint is configured to use Application Authentication then you
 must include a valid user access token or login credentials with every
 request.
 
-In general, use an access token over login credentials when
-possible. The token lets you run multiple requests without
-re-authenticating the user. It also lets you send requests from a web
-browser that enforces :wikipedia:`CORS <Cross-origin_resource_sharing>`.
+In general, bearer authentication with an access token has higher
+throughput and is more secure than credential headers. Use an access
+token over credential headers when possible. The token lets you run
+multiple requests without re-authenticating the user. It also lets you
+send requests from a web browser that enforces :wikipedia:`CORS
+<Cross-origin_resource_sharing>`.
 
 To use an access token, first authenticate the user through an App
 Services authentication provider. Then, get the access token returned
@@ -643,6 +645,8 @@ the request headers.
              "database": "learn-data-api",
              "collection": "hello",
            }'
+
+.. include:: /includes/dont-use-api-key-in-browsers.rst
 
 .. _data-api-authorize:
 

--- a/source/graphql/authenticate.txt
+++ b/source/graphql/authenticate.txt
@@ -61,6 +61,15 @@ For example, the following request uses Bearer Authentication:
         "query": "query AllMovies {\n  movies {\n    title\n    year\n  }\n}"
       }'
 
+In general, bearer authentication with an access token has higher
+throughput and is more secure than credential headers. Use an access
+token over credential headers when possible. The token lets you run
+multiple requests without re-authenticating the user. It also lets you
+send requests from a web browser that enforces :wikipedia:`CORS
+<Cross-origin_resource_sharing>`.
+
+.. include:: /includes/dont-use-api-key-in-browsers.rst
+
 .. include:: /includes/api-user-access-token.rst
 
 .. _graphql-credential-headers:
@@ -122,6 +131,8 @@ To authenticate a GraphQL request with an :ref:`API Key
       --data-raw '{
         "query": "query AllMovies {\n  movies {\n    title\n    year\n  }\n}"
       }'
+
+.. include:: /includes/dont-use-api-key-in-browsers.rst
 
 Custom JWT
 ~~~~~~~~~~

--- a/source/graphql/authenticate.txt
+++ b/source/graphql/authenticate.txt
@@ -61,12 +61,7 @@ For example, the following request uses Bearer Authentication:
         "query": "query AllMovies {\n  movies {\n    title\n    year\n  }\n}"
       }'
 
-In general, bearer authentication with an access token has higher
-throughput and is more secure than credential headers. Use an access
-token over credential headers when possible. The token lets you run
-multiple requests without re-authenticating the user. It also lets you
-send requests from a web browser that enforces :wikipedia:`CORS
-<Cross-origin_resource_sharing>`.
+.. include:: /includes/bearer-auth-performance.rst
 
 .. include:: /includes/dont-use-api-key-in-browsers.rst
 

--- a/source/includes/bearer-auth-performance.rst
+++ b/source/includes/bearer-auth-performance.rst
@@ -1,0 +1,6 @@
+In general, bearer authentication with an access token has higher
+throughput and is more secure than credential headers. Use an access
+token instead of credential headers when possible. The token lets you
+run multiple requests without re-authenticating the user. It also lets
+you send requests from a web browser that enforces :wikipedia:`CORS
+<Cross-origin_resource_sharing>`.

--- a/source/includes/dont-use-api-key-in-browsers.rst
+++ b/source/includes/dont-use-api-key-in-browsers.rst
@@ -1,0 +1,6 @@
+.. important::
+   
+   If you're authenticating from a browser or another user-facing environment,
+   avoid using an API key to log in. Instead, use another authentication
+   provider that takes user-provided credentials. Never store API keys or other
+   sensitive credentials locally.

--- a/source/includes/dont-use-api-key-in-browsers.rst
+++ b/source/includes/dont-use-api-key-in-browsers.rst
@@ -1,6 +1,6 @@
-.. important::
+.. important:: Don't Use API Keys in User-Facing Clients
    
-   If you're authenticating from a browser or another user-facing environment,
+   If you're authenticating from a browser or another user-facing client application,
    avoid using an API key to log in. Instead, use another authentication
    provider that takes user-provided credentials. Never store API keys or other
    sensitive credentials locally.


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-27945) Bearer Auth: Client API Keys & Throughput

### Staged Changes

- [Generated Endpoints > Authenticate the Request](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/data-api/data-api/generated-endpoints/#authenticate-the-request)
- [Custom Endpoints > Authenticate the Request](custom-endpoints/#authenticate-the-request)
- [Authenticate Data API Requests](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/data-api/data-api/authenticate/)
- [Authenticate GraphQL Requests](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/data-api/graphql/authenticate/)
