### PR TITLE
(DOCS-28243): Add Kotlin link to Custom Function Auth page

### DIFF
--- a/source/authentication/custom-function.txt
+++ b/source/authentication/custom-function.txt
@@ -79,75 +79,18 @@ included with the custom function provider credential in the client app.
 The function accepts any value provided from your client app, so the
 actual field names and values depend on your implementation.
 
-.. example::
+For examples of how to create a custom credential ``payload`` object
+using the Realm SDKs, refer to the documentation for a specific SDK:
 
-   The following code examples show how to create a function credential
-   using the Realm SDKs. The credential includes a ``payload`` object
-   that is passed to the authentication function.
-
-   .. tabs-realm-sdks::
-   
-      .. tab::
-         :tabid: javascript
-   
-         .. code-block:: javascript
-         
-            const credentials = Realm.Credentials.function({
-              username: "someUsername",
-              pin: "24601",
-            });
-   
-      .. tab::
-         :tabid: android
-   
-         .. code-block:: java
-            
-            import org.bson.Document;
-            import static java.util.Map.entry;
-   
-            val credentials: Credentials = Credentials.customFunction(
-              Document(
-                Map.ofEntries(
-                  entry("username", "someUsername"),
-                  entry("pin", "24601")
-                )
-              )
-            )
-   
-      .. tab::
-         :tabid: dotnet
-   
-         .. code-block:: csharp
-         
-            var credentials = Credentials.Function(new {
-              username = "someUsername",
-              pin = "24601"
-            })
-   
-      .. tab::
-         :tabid: ios
-   
-         .. code-block:: swift
-         
-            let credentials = Credentials.function(payload: [
-               "username": "someUsername",
-               "pin": "24601"
-            ])
-
-      .. tab::
-         :tabid: flutter
-
-         .. code-block:: dart
-
-            Map<String, String> credentials = {
-               "username": "someUsername",
-               "pin": "24601"
-            };
-            // payload must be a JSON-encoded string
-            String payload = jsonEncode(credentials);
-
-            Credentials customCredentials = Credentials.function(payload);
-            User currentUser = await app.logIn(customCredentials);
+- :ref:`C++ SDK (Alpha) <cpp-login-custom-function>`
+- :ref:`Flutter SDK <flutter-login-custom-function>`
+- :ref:`Java SDK <java-login-custom-function>`
+- :ref:`Kotlin SDK <kotlin-login-custom-function>`
+- :ref:`.NET SDK <dotnet-login-custom-function>`
+- :ref:`Node.js SDK <node-login-custom-function>`
+- :ref:`React Native SDK <react-native-login-custom-function>`
+- :ref:`Swift SDK <ios-login-custom-function>`
+- :ref:`Web SDK <web-login-custom-function>`
 
 Return an Authenticated User ID
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -433,6 +376,7 @@ For examples, refer to the documentation for a specific SDK:
 - :ref:`C++ SDK (Alpha) <cpp-login-custom-function>`
 - :ref:`Flutter SDK <flutter-login-custom-function>`
 - :ref:`Java SDK <java-login-custom-function>`
+- :ref:`Kotlin SDK <kotlin-login-custom-function>`
 - :ref:`.NET SDK <dotnet-login-custom-function>`
 - :ref:`Node.js SDK <node-login-custom-function>`
 - :ref:`React Native SDK <react-native-login-custom-function>`

--- a/source/authentication/custom-function.txt
+++ b/source/authentication/custom-function.txt
@@ -80,7 +80,7 @@ The function accepts any value provided from your client app, so the
 actual field names and values depend on your implementation.
 
 For examples of how to create a custom credential ``payload`` object
-using the Realm SDKs, refer to the documentation for a specific SDK:
+using the Realm SDKs, refer to the documentation for each SDK:
 
 - :ref:`C++ SDK <cpp-login-custom-function>`
 - :ref:`Flutter SDK <flutter-login-custom-function>`

--- a/source/authentication/custom-function.txt
+++ b/source/authentication/custom-function.txt
@@ -82,7 +82,7 @@ actual field names and values depend on your implementation.
 For examples of how to create a custom credential ``payload`` object
 using the Realm SDKs, refer to the documentation for a specific SDK:
 
-- :ref:`C++ SDK (Alpha) <cpp-login-custom-function>`
+- :ref:`C++ SDK <cpp-login-custom-function>`
 - :ref:`Flutter SDK <flutter-login-custom-function>`
 - :ref:`Java SDK <java-login-custom-function>`
 - :ref:`Kotlin SDK <kotlin-login-custom-function>`


### PR DESCRIPTION
## Pull Request Info

- Add link to Authenticate Users - Kotlin SDK page for new Custom Function authentication
- Replace tabbed, hardcoded examples with links to respective SDK docs

### Jira

- https://jira.mongodb.org/browse/DOCSP-28243

### Staged Changes

- [Custom Function Authentication](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/docsp-28243-kotlin-custom-functions/authentication/custom-function/)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any: https://jira.mongodb.org/browse/DOCSP-26563 
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
