### PR TITLE
(DOCSP-28233): Add Kotlin link to Functions page

### DIFF
--- a/source/functions.txt
+++ b/source/functions.txt
@@ -633,6 +633,7 @@ for the Realm SDKs:
 - :ref:`C++ SDK <cpp-call-a-function>`
 - :ref:`Flutter SDK <flutter-call-function>`
 - :ref:`Java SDK <java-call-a-function>`
+- :ref:`Kotlin SDK <kotlin-call-function>`
 - :ref:`.NET SDK <dotnet-call-a-function>`
 - :ref:`Node SDK <node-call-a-function>`
 - :ref:`React Native SDK <react-native-call-a-function>`


### PR DESCRIPTION
## Pull Request Info

Adding link to new Kotlin Call a Function page

### Jira

- https://jira.mongodb.org/browse/DOCSP-28233

### Staged Changes

- [Atlas Functions](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/docsp-28233-kotlin-functions/functions/#call-from-realm-sdks)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any: https://jira.mongodb.org/browse/DOCSP-28243 (done)
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
