### PR TITLE
DOCSP-27944): Add encodeBodyAsJSON parameter to http.post()

### DIFF
--- a/source/includes/extracts-http-action.yaml
+++ b/source/includes/extracts-http-action.yaml
@@ -92,12 +92,20 @@ content: |
 
      * - :guilabel:`Request Body`
 
-         | ``body: <string>``
+         | ``body: <object> or <string>``
 
-       - Required. The stringified body of the HTTP request.
+       - Required. The object or stringified body of the HTTP request.
          If the request payload has a content type of
          ``multipart/form-data``, use the ``form`` parameter instead of
-         ``body``.
+         ``body``. If the request body is an object, the 
+         ``encodeBodyAsJSON`` parameter must be ``true``.
+    
+     * - :guilabel:`Encode Body as JSON`
+
+         | ``encodeBodyAsJSON: <boolean>``
+
+       - If ``true``, the body is encoded to EJSON. Only use when the ``body`` 
+         parameter is an object. 
 
      * - :guilabel:`Form Request Body`
 

--- a/source/includes/extracts-http-action.yaml
+++ b/source/includes/extracts-http-action.yaml
@@ -104,7 +104,7 @@ content: |
 
          | ``encodeBodyAsJSON: <boolean>``
 
-       - If ``true``, the body is encoded to EJSON. Only use when the ``body`` 
+       - If ``true``, the body is automatically encoded as an EJSON string using ``EJSON.stringify()``. Only use when the ``body`` 
          parameter is an object. 
 
      * - :guilabel:`Form Request Body`

--- a/source/services/http-actions/http.post.txt
+++ b/source/services/http-actions/http.post.txt
@@ -70,7 +70,8 @@ Parameters
             {
                 "url": <string>,
                 "headers": <document>,
-                "body": <string>,
+                "body": <object> or <string>,
+                "encodeBodyAsJSON": <boolean>,
                 "form": <document>,
                 "cookies": <string>,
                 "authUrl": <string>,


### PR DESCRIPTION
## Pull Request Info

Add missing `encodeBodyAsJSON` parameter to http.post() page and specify it's required when payload is an object

### Jira

- https://jira.mongodb.org/browse/DOCSP-27944

### Staged Changes

- [http.post()](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/docsp-27944/services/http-actions/http.post/#parameters)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any N/A
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
