### PR TITLE
Remove unneeded redirect

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -22,8 +22,6 @@ raw: ${prefix}/endpoints/configure -> ${base}/data-api/custom-endpoints/
 
 raw: ${prefix}/reference/cli-auth-with-api-token -> ${base}/cli/
 
-raw: ${prefix}/security -> ${base}/manage-apps/secure/
-
 raw: ${prefix}/triggers/overview -> ${base}/triggers/
 raw: ${prefix}/triggers/examples/resume-a-suspended-trigger -> ${base}/triggers/database-triggers/
 raw: ${prefix}/triggers/examples/disable-a-trigger -> ${base}/triggers/disable-a-trigger/


### PR DESCRIPTION
Per a Slack convo, this redirect appears to be causing 404s and breaking JS on the page.