### PR TITLE
Fix reported typo in Schemas page

### DIFF
--- a/source/schemas.txt
+++ b/source/schemas.txt
@@ -25,7 +25,7 @@ Overview
 What is a Schema?
 ~~~~~~~~~~~~~~~~~
 
-A schema is a JSON object that defines the the structure and contents of your
+A schema is a JSON object that defines the structure and contents of your
 data. You can use Atlas App Services' BSON schemas, which extend the `JSON Schema
 <https://json-schema.org/>`_ standard, to define your application's data model
 and validate documents whenever they're created, changed, or deleted.


### PR DESCRIPTION
## Pull Request Info

[Feedback] Remove extra `the` in Schemas page 

### Staged Changes

- [Schemas](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/no-jira-schema-typo-fix/schemas/#what-is-a-schema-)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
