### PR TITLE
(DOCSP-28388) Consistent GraphQL app metric naming

### DIFF
--- a/source/reference/metrics.txt
+++ b/source/reference/metrics.txt
@@ -117,25 +117,25 @@ Available Metrics
     - SCALAR_PER_SECOND
     - The rate of successful endpoint requests.
 
-  * - GQL_RESPONSE_MS
+  * - GRAPHQL_RESPONSE_MS
     - MILLISECONDS
     - 95th percentile GraphQL response time.
 
-  * - GRAPH_QL_COMPUTE_MS
+  * - GRAPHQL_COMPUTE_MS
     - SCALAR_PER_SECOND
     - The number of milliseconds spent computing GraphQL requests since the last
       data point divided by the total number of seconds since the last data
       point.
 
-  * - GRAPH_QL_EGRESS_BYTES
+  * - GRAPHQL_EGRESS_BYTES
     - BYTES_PER_SECOND
     - The rate of data transferred from the server for GraphQL.
 
-  * - GRAPH_QL_FAILED_REQUESTS
+  * - GRAPHQL_FAILED_REQUESTS
     - SCALAR_PER_SECOND
     - The rate of failed GraphQL requests.
 
-  * - GRAPH_QL_SUCCESSFUL_REQUESTS
+  * - GRAPHQL_SUCCESSFUL_REQUESTS
     - SCALAR_PER_SECOND
     - The rate of successful GraphQL requests.
 


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-28388) Consistent GraphQL app metric naming

### Staged Changes

- [Reference > Metrics](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/graphql-metrics/reference/metrics/#available-metrics)