### PR TITLE
(DOCSP-28584) [Admin API] Don't use function_name in endpoint request body

### DIFF
--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -4030,7 +4030,11 @@ paths:
               schema:
                 type: array
                 items:
-                  "$ref": "#/components/schemas/Endpoint"
+                  allOf:
+                    - "$ref": "#/components/schemas/Endpoint"
+                    - properties:
+                        function_name:
+                          type: string
 
     post:
       tags:
@@ -4051,7 +4055,11 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/Endpoint"
+                allOf:
+                  - "$ref": "#/components/schemas/Endpoint"
+                  - properties:
+                      function_name:
+                        type: string
 
   "/groups/{groupId}/apps/{appId}/endpoints/{endpointId}":
     parameters:
@@ -4071,7 +4079,11 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/Endpoint"
+                allOf:
+                  - "$ref": "#/components/schemas/Endpoint"
+                  - properties:
+                      function_name:
+                        type: string
 
     put:
       tags:
@@ -4092,7 +4104,11 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/Endpoint"
+                allOf:
+                  - "$ref": "#/components/schemas/Endpoint"
+                  - properties:
+                      function_name:
+                        type: string
 
     delete:
       tags:


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-28584) [Admin API] Don't use function_name in endpoint request body

### Staged Changes

- [Admin API](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/admin-function-name/admin/api/v3/)