### PR TITLE
remove sdk realm language tabs

### DIFF
--- a/source/authentication/custom-jwt.txt
+++ b/source/authentication/custom-jwt.txt
@@ -803,8 +803,7 @@ Custom JWT authentication, see the documentation for the Realm SDKs:
 
 - :ref:`Custom JWT Authentication - Flutter SDK<flutter-login-custom-jwt>`.
 - :ref:`Custom JWT Authentication - Java SDK <java-login-custom-jwt>`.
-- To register or log in a Custom JWT user from the Kotlin SDK, see the
-  :ref:`Custom JWT Authentication - Kotlin SDK <kotlin-login-jwt>`.
+- :ref:`Custom JWT Authentication - Kotlin SDK <kotlin-login-jwt>`.
 - :ref:`Custom JWT Authentication - .NET SDK <dotnet-login-custom-jwt>`.
 - :ref:`Custom JWT Authentication - Node.js SDK<node-login-custom-jwt>`.
 - :ref:`Custom JWT Authentication - React Native SDK<react-native-login-custom-jwt>`.

--- a/source/authentication/custom-jwt.txt
+++ b/source/authentication/custom-jwt.txt
@@ -801,22 +801,22 @@ Examples
 For code examples that demonstrate how to register and log in using
 Custom JWT authentication, see the documentation for the Realm SDKs:
 
-- To register or log in a Custom JWT user from the Android Client SDK, see the
-  :ref:`Java SDK guide to Custom JWT authentication <java-login-custom-jwt>`.
-- To register or log in a Custom JWT user from the iOS Client SDK, see the
-  :ref:`Swift SDK guide to Custom JWT authentication <ios-login-custom-jwt>`.
-- To register or log in a Custom JWT user from the Web Client SDK, see the
-  :ref:`Web SDK guide to Custom JWT authentication <web-login-custom-jwt>`.
-- To register or log in a Custom JWT user from the Node Client SDK, see the
-  :ref:`Node SDK guide to Custom JWT authentication <node-login-custom-jwt>`.
-- To register or log in a Custom JWT user from the React Native Client SDK, see the
-  :ref:`React Native SDK guide to Custom JWT authentication <react-native-login-custom-jwt>`.
-- To register or log in a Custom JWT user from the .NET Client SDK, see the
-  :ref:`.NET SDK guide to Custom JWT authentication <dotnet-login-custom-jwt>`.
-- To register or log in a Custom JWT user from the Kotlin Client SDK, see the
-  :ref:`Kotlin SDK guide to Custom JWT authentication <kotlin-login-jwt>`.
-- To register or log in a Custom JWT user from the Flutter Client SDK, see the
+- To register or log in a Custom JWT user from the Flutter SDK, see the
   :ref:`Flutter SDK guide to Custom JWT authentication <flutter-login-custom-jwt>`.
+- To register or log in a Custom JWT user from the Java SDK, see the
+  :ref:`Java SDK guide to Custom JWT authentication <java-login-custom-jwt>`.
+- To register or log in a Custom JWT user from the Kotlin SDK, see the
+  :ref:`Kotlin SDK guide to Custom JWT authentication <kotlin-login-jwt>`.
+- To register or log in a Custom JWT user from the .NET SDK, see the
+  :ref:`.NET SDK guide to Custom JWT authentication <dotnet-login-custom-jwt>`.
+- To register or log in a Custom JWT user from the Node SDK, see the
+  :ref:`Node.js SDK guide to Custom JWT authentication <node-login-custom-jwt>`.
+- To register or log in a Custom JWT user from the React Native SDK, see the
+  :ref:`React Native SDK guide to Custom JWT authentication <react-native-login-custom-jwt>`.
+- To register or log in a Custom JWT user from the Swift SDK, see the
+  :ref:`Swift SDK guide to Custom JWT authentication <ios-login-custom-jwt>`.
+- To register or log in a Custom JWT user from the Web SDK, see the
+  :ref:`Web SDK guide to Custom JWT authentication <web-login-custom-jwt>`.
 
 .. _jwt-tutorial:
 

--- a/source/authentication/custom-jwt.txt
+++ b/source/authentication/custom-jwt.txt
@@ -801,22 +801,15 @@ Examples
 For code examples that demonstrate how to register and log in using
 Custom JWT authentication, see the documentation for the Realm SDKs:
 
-- To register or log in a Custom JWT user from the Flutter SDK, see the
-  :ref:`Flutter SDK guide to Custom JWT authentication <flutter-login-custom-jwt>`.
-- To register or log in a Custom JWT user from the Java SDK, see the
-  :ref:`Java SDK guide to Custom JWT authentication <java-login-custom-jwt>`.
+- :ref:`Custom JWT Authentication - Flutter SDK<flutter-login-custom-jwt>`.
+- :ref:`Custom JWT Authentication - Java SDK <java-login-custom-jwt>`.
 - To register or log in a Custom JWT user from the Kotlin SDK, see the
-  :ref:`Kotlin SDK guide to Custom JWT authentication <kotlin-login-jwt>`.
-- To register or log in a Custom JWT user from the .NET SDK, see the
-  :ref:`.NET SDK guide to Custom JWT authentication <dotnet-login-custom-jwt>`.
-- To register or log in a Custom JWT user from the Node SDK, see the
-  :ref:`Node.js SDK guide to Custom JWT authentication <node-login-custom-jwt>`.
-- To register or log in a Custom JWT user from the React Native SDK, see the
-  :ref:`React Native SDK guide to Custom JWT authentication <react-native-login-custom-jwt>`.
-- To register or log in a Custom JWT user from the Swift SDK, see the
-  :ref:`Swift SDK guide to Custom JWT authentication <ios-login-custom-jwt>`.
-- To register or log in a Custom JWT user from the Web SDK, see the
-  :ref:`Web SDK guide to Custom JWT authentication <web-login-custom-jwt>`.
+  :ref:`Custom JWT Authentication - Kotlin SDK <kotlin-login-jwt>`.
+- :ref:`Custom JWT Authentication - .NET SDK <dotnet-login-custom-jwt>`.
+- :ref:`Custom JWT Authentication - Node.js SDK<node-login-custom-jwt>`.
+- :ref:`Custom JWT Authentication - React Native SDK<react-native-login-custom-jwt>`.
+- :ref:`Custom JWT Authentication - Swift SDK<ios-login-custom-jwt>`.
+- :ref:`Custom JWT Authentication - Web SDK<web-login-custom-jwt>`.
 
 .. _jwt-tutorial:
 

--- a/source/authentication/custom-jwt.txt
+++ b/source/authentication/custom-jwt.txt
@@ -801,55 +801,22 @@ Examples
 For code examples that demonstrate how to register and log in using
 Custom JWT authentication, see the documentation for the Realm SDKs:
 
-.. tabs-realm-sdks::
-
-   .. tab::
-      :tabid: android
-
-      To register or log in a Custom JWT user from the Android Client SDK, see the
-      :ref:`Java SDK guide to Custom JWT authentication <java-login-custom-jwt>`.
-
-   .. tab::
-      :tabid: ios
-
-      To register or log in a Custom JWT user from the iOS Client SDK, see the
-      :ref:`Swift SDK guide to Custom JWT authentication <ios-login-custom-jwt>`.
-
-   .. tab::
-      :tabid: web
-
-      To register or log in a Custom JWT user from the Web Client SDK, see the
-      :ref:`Web SDK guide to Custom JWT authentication <web-login-custom-jwt>`.
-
-   .. tab::
-      :tabid: node
-      
-      To register or log in a Custom JWT user from the Node Client SDK, see the
-      :ref:`Node SDK guide to Custom JWT authentication <node-login-custom-jwt>`.
-
-   .. tab::
-      :tabid: react-native
-
-      To register or log in a Custom JWT user from the React Native Client SDK, see the
-      :ref:`React Native SDK guide to Custom JWT authentication <react-native-login-custom-jwt>`.
-
-   .. tab::
-      :tabid: dotnet
-
-      To register or log in a Custom JWT user from the .NET Client SDK, see the
-      :ref:`.NET SDK guide to Custom JWT authentication <dotnet-login-custom-jwt>`.
-
-   .. tab::
-      :tabid: kotlin
-
-      To register or log in a Custom JWT user from the Kotlin Client SDK, see the
-      :ref:`Kotlin SDK guide to Custom JWT authentication <kotlin-login-jwt>`.
-
-   .. tab::
-      :tabid: flutter
-
-      To register or log in a Custom JWT user from the Flutter Client SDK, see the
-      :ref:`Flutter SDK guide to Custom JWT authentication <flutter-login-custom-jwt>`.
+- To register or log in a Custom JWT user from the Android Client SDK, see the
+  :ref:`Java SDK guide to Custom JWT authentication <java-login-custom-jwt>`.
+- To register or log in a Custom JWT user from the iOS Client SDK, see the
+  :ref:`Swift SDK guide to Custom JWT authentication <ios-login-custom-jwt>`.
+- To register or log in a Custom JWT user from the Web Client SDK, see the
+  :ref:`Web SDK guide to Custom JWT authentication <web-login-custom-jwt>`.
+- To register or log in a Custom JWT user from the Node Client SDK, see the
+  :ref:`Node SDK guide to Custom JWT authentication <node-login-custom-jwt>`.
+- To register or log in a Custom JWT user from the React Native Client SDK, see the
+  :ref:`React Native SDK guide to Custom JWT authentication <react-native-login-custom-jwt>`.
+- To register or log in a Custom JWT user from the .NET Client SDK, see the
+  :ref:`.NET SDK guide to Custom JWT authentication <dotnet-login-custom-jwt>`.
+- To register or log in a Custom JWT user from the Kotlin Client SDK, see the
+  :ref:`Kotlin SDK guide to Custom JWT authentication <kotlin-login-jwt>`.
+- To register or log in a Custom JWT user from the Flutter Client SDK, see the
+  :ref:`Flutter SDK guide to Custom JWT authentication <flutter-login-custom-jwt>`.
 
 .. _jwt-tutorial:
 

--- a/source/includes/warn-terminate-sync-client-reset.rst
+++ b/source/includes/warn-terminate-sync-client-reset.rst
@@ -1,37 +1,12 @@
 .. warning:: Restore Sync after Terminating Sync
 
- When you terminate and re-enable Atlas Device Sync, clients can no longer Sync. 
- Your client must implement a client reset handler to restore Sync. This 
- handler can discard or attempt to recover unsynchronized changes.
+   When you terminate and re-enable Atlas Device Sync, clients can no longer Sync. 
+   Your client must implement a client reset handler to restore Sync. This 
+   handler can discard or attempt to recover unsynchronized changes.
 
- .. tabs-realm-sdks::
-
-   .. tab::
-      :tabid: android
-
-      Learn how to perform a :ref:`Client Reset using the Realm Java SDK <java-client-resets>`.
-
-   .. tab::
-      :tabid: ios
-
-      Learn how to perform a :ref:`Client Reset using the Realm Swift SDK <ios-client-resets>`.
-
-   .. tab::
-      :tabid: node
-      
-      Learn how to perform a :ref:`Client Reset using the Realm Node SDK <node-client-resets>`.
-
-   .. tab::
-      :tabid: react-native
-      
-      Learn how to perform a :ref:`Client Reset using the Realm React Native SDK <react-native-client-resets>`.
-
-   .. tab::
-      :tabid: dotnet
-
-      Learn how to perform a :ref:`Client Reset using the Realm .NET SDK <dotnet-client-resets>`.
-
-   .. tab::
-      :tabid: flutter
-
-      Learn how to perform a :ref:`Client Reset using the Realm Flutter SDK <flutter-client-reset>`.
+   - Learn how to perform a :ref:`Client Reset using the Realm Flutter SDK <flutter-client-reset>`.
+   - Learn how to perform a :ref:`Client Reset using the Realm Java SDK <java-client-resets>`.
+   - Learn how to perform a :ref:`Client Reset using the Realm .NET SDK <dotnet-client-resets>`.
+   - Learn how to perform a :ref:`Client Reset using the Realm Node SDK <node-client-resets>`.
+   - Learn how to perform a :ref:`Client Reset using the Realm React Native SDK <react-native-client-resets>`.
+   - Learn how to perform a :ref:`Client Reset using the Realm Swift SDK <ios-client-resets>`.

--- a/source/includes/warn-terminate-sync-client-reset.rst
+++ b/source/includes/warn-terminate-sync-client-reset.rst
@@ -4,9 +4,9 @@
    Your client must implement a client reset handler to restore Sync. This 
    handler can discard or attempt to recover unsynchronized changes.
 
-   - Learn how to perform a :ref:`Client Reset using the Realm Flutter SDK <flutter-client-reset>`.
-   - Learn how to perform a :ref:`Client Reset using the Realm Java SDK <java-client-resets>`.
-   - Learn how to perform a :ref:`Client Reset using the Realm .NET SDK <dotnet-client-resets>`.
-   - Learn how to perform a :ref:`Client Reset using the Realm Node SDK <node-client-resets>`.
-   - Learn how to perform a :ref:`Client Reset using the Realm React Native SDK <react-native-client-resets>`.
-   - Learn how to perform a :ref:`Client Reset using the Realm Swift SDK <ios-client-resets>`.
+   - Learn how to perform a :ref:`Client Reset using the Flutter SDK <flutter-client-reset>`.
+   - Learn how to perform a :ref:`Client Reset using the Java SDK <java-client-resets>`.
+   - Learn how to perform a :ref:`Client Reset using the .NET SDK <dotnet-client-resets>`.
+   - Learn how to perform a :ref:`Client Reset using the Node SDK <node-client-resets>`.
+   - Learn how to perform a :ref:`Client Reset using the React Native SDK <react-native-client-resets>`.
+   - Learn how to perform a :ref:`Client Reset using the Swift SDK <ios-client-resets>`.

--- a/source/includes/warn-terminate-sync-client-reset.rst
+++ b/source/includes/warn-terminate-sync-client-reset.rst
@@ -4,9 +4,9 @@
    Your client must implement a client reset handler to restore Sync. This 
    handler can discard or attempt to recover unsynchronized changes.
 
-   - Learn how to perform a :ref:`Client Reset using the Flutter SDK <flutter-client-reset>`.
-   - Learn how to perform a :ref:`Client Reset using the Java SDK <java-client-resets>`.
-   - Learn how to perform a :ref:`Client Reset using the .NET SDK <dotnet-client-resets>`.
-   - Learn how to perform a :ref:`Client Reset using the Node SDK <node-client-resets>`.
-   - Learn how to perform a :ref:`Client Reset using the React Native SDK <react-native-client-resets>`.
-   - Learn how to perform a :ref:`Client Reset using the Swift SDK <ios-client-resets>`.
+   - :ref:`Client Reset - Flutter SDK <flutter-client-reset>`.
+   - :ref:`Client Reset - Java SDK <java-client-resets>`.
+   - :ref:`Client Reset - .NET SDK <dotnet-client-resets>`.
+   - :ref:`Client Reset - Node SDK <node-client-resets>`.
+   - :ref:`Client Reset - React Native SDK <react-native-client-resets>`.
+   - :ref:`Client Reset - Swift SDK <ios-client-resets>`.

--- a/source/sync/app-builder/stream-data-from-client-to-atlas.txt
+++ b/source/sync/app-builder/stream-data-from-client-to-atlas.txt
@@ -25,6 +25,13 @@ Asymmetric Sync is optimized to provide performance improvements for heavy
 client-side *insert-only* workloads. You cannot read this data from the
 realm where you're streaming it.
 
+Currently Asymmetric Sync is only available for the following Realm SDKs:
+
+- .NET SDK
+- Node.js SDK
+- React Native SDK
+- Swift SDK
+
 Follow these high-level steps to get started:
 
 Set up Atlas Access
@@ -106,9 +113,6 @@ and you can prepare your client application to sync data unidirectionally.
       App Services features like authentication, and enables opening a 
       synced realm.
 
-      - :ref:`Connect to App Services - Flutter SDK <flutter-connect-to-backend>`
-      - :ref:`Connect to an Atlas App Services backend - Java SDK <java-init-appclient>`
-      - :ref:`Connect to an Atlas App Services backend - Kotlin SDK <kotlin-connect-to-backend>`
       - :ref:`Connect to an Atlas App Services Backend - .NET SDK <dotnet-init-appclient>`
       - :ref:`Connect to an Atlas App Services Backend - Node.js SDK <node-connect-to-mongodb-realm-backend-app>`
       - :ref:`Connect to an Atlas App Services Backend - React Native SDK <react-native-connect-to-mongodb-realm-backend-app>`
@@ -120,9 +124,6 @@ and you can prepare your client application to sync data unidirectionally.
       backend in order to write synchronized data. Add logic to your 
       client app to register and log in users.
 
-      - :ref:`Authenticate Users - Flutter SDK <flutter-authenticate>`
-      - :ref:`Authenticate Users - Java SDK <java-authenticate>`
-      - :ref:`Authenticate Users - Kotlin SDK <kotlin-authenticate>`
       - :ref:`Authenticate Users - .NET SDK <dotnet-authenticate>`
       - :ref:`Authenticate Users - Node.js SDK <node-authenticate-users>`
       - :ref:`Authenticate Users - React Native SDK <react-native-authenticate-users>`
@@ -137,9 +138,6 @@ and you can prepare your client application to sync data unidirectionally.
       where you would create a query subscription to determine what data 
       to sync to the device.
 
-      - :ref:`Open a Synced Realm - Flutter SDK <flutter-open-synced-realm>`
-      - :ref:`Open a Synced Realm - Java SDK <java-synced-realms>`
-      - :ref:`Open a Synced Realm - Kotlin SDK <kotlin-open-a-synced-realm>`
       - :ref:`Open a Synced Realm - .NET SDK <dotnet-configure-and-open-a-synced-realm>`
       - :ref:`Open a Synced Realm - Node.js SDK <node-open-a-synced-realm>`
       - :ref:`Configure & Open a Synced Realm - React Native SDK <react-native-open-a-synced-realm>`

--- a/source/sync/app-builder/stream-data-from-client-to-atlas.txt
+++ b/source/sync/app-builder/stream-data-from-client-to-atlas.txt
@@ -106,42 +106,13 @@ and you can prepare your client application to sync data unidirectionally.
       App Services features like authentication, and enables opening a 
       synced realm.
 
-      .. tabs-realm-sdks::
-
-         .. tab::
-            :tabid: android
-
-            :ref:`Connect to an Atlas App Services backend - Java SDK <java-init-appclient>`
-
-         .. tab::
-            :tabid: ios
-
-            :ref:`Connect to an Atlas App Services backend - Swift SDK <ios-init-appclient>`
-
-         .. tab::
-            :tabid: node
-
-            :ref:`Connect to an Atlas App Services Backend - Node.js SDK <node-connect-to-mongodb-realm-backend-app>`
-
-         .. tab::
-            :tabid: react-native
-
-            :ref:`Connect to an Atlas App Services Backend - React Native SDK <react-native-connect-to-mongodb-realm-backend-app>`
-
-         .. tab::
-            :tabid: dotnet
-
-            :ref:`Connect to an Atlas App Services Backend - .NET SDK <dotnet-init-appclient>`
-
-         .. tab::
-            :tabid: flutter
-
-            :ref:`Connect to App Services - Flutter SDK <flutter-connect-to-backend>`
-
-         .. tab::
-            :tabid: kotlin
-
-            :ref:`Connect to an Atlas App Services backend - Kotlin SDK <kotlin-connect-to-backend>`
+      - :ref:`Connect to App Services - Flutter SDK <flutter-connect-to-backend>`
+      - :ref:`Connect to an Atlas App Services backend - Java SDK <java-init-appclient>`
+      - :ref:`Connect to an Atlas App Services backend - Kotlin SDK <kotlin-connect-to-backend>`
+      - :ref:`Connect to an Atlas App Services Backend - .NET SDK <dotnet-init-appclient>`
+      - :ref:`Connect to an Atlas App Services Backend - Node.js SDK <node-connect-to-mongodb-realm-backend-app>`
+      - :ref:`Connect to an Atlas App Services Backend - React Native SDK <react-native-connect-to-mongodb-realm-backend-app>`
+      - :ref:`Connect to an Atlas App Services backend - Swift SDK <ios-init-appclient>`
 
    .. step:: Authenticate a User
 
@@ -149,42 +120,13 @@ and you can prepare your client application to sync data unidirectionally.
       backend in order to write synchronized data. Add logic to your 
       client app to register and log in users.
 
-      .. tabs-realm-sdks::
-
-         .. tab::
-            :tabid: android
-
-            :ref:`Authenticate Users - Java SDK <java-authenticate>`
-
-         .. tab::
-            :tabid: ios
-
-            :ref:`Authenticate Users - Swift SDK <ios-authenticate-users>`
-
-         .. tab::
-            :tabid: node
-
-            :ref:`Authenticate Users - Node.js SDK <node-authenticate-users>`
-
-         .. tab::
-            :tabid: react-native
-
-            :ref:`Authenticate Users - React Native SDK <react-native-authenticate-users>`
-
-         .. tab::
-            :tabid: dotnet
-
-            :ref:`Authenticate Users - .NET SDK <dotnet-authenticate>`
-
-         .. tab::
-            :tabid: flutter
-
-            :ref:`Authenticate Users - Flutter SDK <flutter-authenticate>`
-
-         .. tab::
-            :tabid: kotlin
-
-            :ref:`Authenticate Users - Kotlin SDK <kotlin-authenticate>`
+      - :ref:`Authenticate Users - Flutter SDK <flutter-authenticate>`
+      - :ref:`Authenticate Users - Java SDK <java-authenticate>`
+      - :ref:`Authenticate Users - Kotlin SDK <kotlin-authenticate>`
+      - :ref:`Authenticate Users - .NET SDK <dotnet-authenticate>`
+      - :ref:`Authenticate Users - Node.js SDK <node-authenticate-users>`
+      - :ref:`Authenticate Users - React Native SDK <react-native-authenticate-users>`
+      - :ref:`Authenticate Users - Swift SDK <ios-authenticate-users>`
 
    .. step:: Open a Synced Realm
 
@@ -195,42 +137,13 @@ and you can prepare your client application to sync data unidirectionally.
       where you would create a query subscription to determine what data 
       to sync to the device.
 
-      .. tabs-realm-sdks::
-
-         .. tab::
-            :tabid: android
-
-            :ref:`Open a Synced Realm - Java SDK <java-synced-realms>`
-
-         .. tab::
-            :tabid: ios
-
-            :ref:`Configure & Open a Synced Realm - Swift SDK <ios-configure-and-open-a-synced-realm>`
-
-         .. tab::
-            :tabid: node
-
-            :ref:`Open a Synced Realm - Node.js SDK <node-open-a-synced-realm>`
-
-         .. tab::
-            :tabid: react-native
-
-            :ref:`Open & Close a Realm - React Native SDK <react-native-open-close-realm>`
-
-         .. tab::
-            :tabid: dotnet
-
-            :ref:`Configure & Open a Synced Realm - .NET SDK <dotnet-configure-and-open-a-synced-realm>`
-
-         .. tab::
-            :tabid: flutter
-
-            :ref:`Open a Synced Realm - Flutter SDK <flutter-open-synced-realm>`
-
-         .. tab::
-            :tabid: kotlin
-
-            :ref:`Open a Synced Realm - Kotlin SDK <kotlin-open-a-synced-realm>`
+      - :ref:`Open a Synced Realm - Flutter SDK <flutter-open-synced-realm>`
+      - :ref:`Open a Synced Realm - Java SDK <java-synced-realms>`
+      - :ref:`Open a Synced Realm - Kotlin SDK <kotlin-open-a-synced-realm>`
+      - :ref:`Open a Synced Realm - .NET SDK <dotnet-configure-and-open-a-synced-realm>`
+      - :ref:`Open a Synced Realm - Node.js SDK <node-open-a-synced-realm>`
+      - :ref:`Configure & Open a Synced Realm - React Native SDK <react-native-open-a-synced-realm>`
+      - :ref:`Configure & Open a Synced Realm - Swift SDK <ios-configure-and-open-a-synced-realm>`
 
    .. step:: Create Asymmetric Objects and Write Data
 
@@ -246,24 +159,7 @@ and you can prepare your client application to sync data unidirectionally.
       the device and automatically uploads when the network connection is 
       restored.
 
-      .. tabs-realm-sdks::
-
-         .. tab::
-            :tabid: ios
-
-            :ref:`Stream Data to Atlas - Swift SDK <swift-stream-data-to-atlas>`
-
-         .. tab::
-            :tabid: node
-
-            :ref:`Define an Asymmetric Object - Node.js SDK <node-define-an-asymmetric-object>`
-
-         .. tab::
-            :tabid: react-native
-
-            :ref:`Define an Asymmetric Object - React Native SDK <react-native-define-an-asymmetric-object>`
-
-         .. tab::
-            :tabid: dotnet
-
-            :ref:`Stream Data to Atlas - .NET SDK <dotnet-asymmetric-sync>`
+      - :ref:`Stream Data to Atlas - .NET SDK <dotnet-asymmetric-sync>`
+      - :ref:`Define an Asymmetric Object - Node.js SDK <node-define-an-asymmetric-object>`
+      - :ref:`Define an Asymmetric Object - React Native SDK <react-native-define-an-asymmetric-object>`
+      - :ref:`Stream Data to Atlas - Swift SDK <swift-stream-data-to-atlas>`

--- a/source/sync/app-builder/sync-data-in-atlas-with-client.txt
+++ b/source/sync/app-builder/sync-data-in-atlas-with-client.txt
@@ -98,42 +98,13 @@ data with a Realm Database on the device.
       App Services features like authentication, and enables opening a 
       synced realm.
 
-      .. tabs-realm-sdks::
-
-         .. tab::
-            :tabid: android
-
-            :ref:`Connect to an Atlas App Services backend - Java SDK <java-init-appclient>`
-
-         .. tab::
-            :tabid: ios
-
-            :ref:`Connect to an Atlas App Services backend - Swift SDK <ios-init-appclient>`
-
-         .. tab::
-            :tabid: node
-
-            :ref:`Connect to an Atlas App Services Backend - Node.js SDK <node-connect-to-mongodb-realm-backend-app>`
-
-         .. tab::
-            :tabid: react-native
-
-            :ref:`Connect to an Atlas App Services Backend - React Native SDK <react-native-connect-to-mongodb-realm-backend-app>`
-
-         .. tab::
-            :tabid: dotnet
-
-            :ref:`Connect to an Atlas App Services Backend - .NET SDK <dotnet-init-appclient>`
-
-         .. tab::
-            :tabid: flutter
-
-            :ref:`Connect to App Services - Flutter SDK <flutter-connect-to-backend>`
-
-         .. tab::
-            :tabid: kotlin
-
-            :ref:`Connect to an Atlas App Services backend - Kotlin SDK <kotlin-connect-to-backend>`
+      - :ref:`Connect to App Services - Flutter SDK <flutter-connect-to-backend>`
+      - :ref:`Connect to an Atlas App Services backend - Java SDK <java-init-appclient>`
+      - :ref:`Connect to an Atlas App Services backend - Kotlin SDK <kotlin-connect-to-backend>`
+      - :ref:`Connect to an Atlas App Services Backend - .NET SDK <dotnet-init-appclient>`
+      - :ref:`Connect to an Atlas App Services Backend - Node.js SDK <node-connect-to-mongodb-realm-backend-app>`
+      - :ref:`Connect to an Atlas App Services Backend - React Native SDK <react-native-connect-to-mongodb-realm-backend-app>`
+      - :ref:`Connect to an Atlas App Services backend - Swift SDK <ios-init-appclient>`
 
    .. step:: Authenticate a User
 
@@ -141,42 +112,13 @@ data with a Realm Database on the device.
       backend in order to access synchronized data. Add logic to your 
       client app to register and log in users.
 
-      .. tabs-realm-sdks::
-
-         .. tab::
-            :tabid: android
-
-            :ref:`Authenticate Users - Java SDK <java-authenticate>`
-
-         .. tab::
-            :tabid: ios
-
-            :ref:`Authenticate Users - Swift SDK <ios-authenticate-users>`
-
-         .. tab::
-            :tabid: node
-
-            :ref:`Authenticate Users - Node.js SDK <node-authenticate-users>`
-
-         .. tab::
-            :tabid: react-native
-
-            :ref:`Authenticate Users - React Native SDK <react-native-authenticate-users>`
-
-         .. tab::
-            :tabid: dotnet
-
-            :ref:`Authenticate Users - .NET SDK <dotnet-authenticate>`
-
-         .. tab::
-            :tabid: flutter
-
-            :ref:`Authenticate Users - Flutter SDK <flutter-authenticate>`
-
-         .. tab::
-            :tabid: kotlin
-
-            :ref:`Authenticate Users - Kotlin SDK <kotlin-authenticate>`
+      - :ref:`Authenticate Users - Flutter SDK <flutter-authenticate>`
+      - :ref:`Authenticate Users - Java SDK <java-authenticate>`
+      - :ref:`Authenticate Users - Kotlin SDK <kotlin-authenticate>`
+      - :ref:`Authenticate Users - .NET SDK <dotnet-authenticate>`
+      - :ref:`Authenticate Users - Node.js SDK <node-authenticate-users>`
+      - :ref:`Authenticate Users - React Native SDK <react-native-authenticate-users>`
+      - :ref:`Authenticate Users - Swift SDK <ios-authenticate-users>`
 
    .. step:: Open a Synced Realm
 
@@ -191,56 +133,41 @@ data with a Realm Database on the device.
       remove, or update Flexible Sync query subscriptions to change the 
       documents that sync to the device.
 
-      .. tabs-realm-sdks::
+      - Flutter SDK
 
-         .. tab::
-            :tabid: android
+        - :ref:`Open a Synced Realm - Flutter SDK <flutter-open-synced-realm>`
+        - :ref:`Manage a Sync Session - Flutter SDK <flutter-manage-sync-session>`
 
-            :ref:`Open a Synced Realm - Java SDK <java-synced-realms>`
+      - Java SDK
 
-            :ref:`Flexible Sync - Java SDK <java-flexible-sync>`
+        - :ref:`Open a Synced Realm - Java SDK <java-synced-realms>`
+        - :ref:`Flexible Sync - Java SDK <java-flexible-sync>`
 
-         .. tab::
-            :tabid: ios
 
-            :ref:`Configure & Open a Synced Realm - Swift SDK <ios-configure-and-open-a-synced-realm>`
+      - Kotlin SDK
 
-            :ref:`Manage Flexible Sync Subscriptions - Swift SDK <swift-manage-flexible-sync-subscriptions>`
+        - :ref:`Open a Synced Realm - Kotlin SDK <kotlin-open-a-synced-realm>`
+        - :ref:`Subscribe to Queryable Fields - Kotlin SDK <kotlin-subscriptions>`
 
-         .. tab::
-            :tabid: node
+      - .NET SDK
 
-            :ref:`Open a Synced Realm - Node.js SDK <node-open-a-synced-realm>`
+        - :ref:`Configure & Open a Synced Realm - .NET SDK <dotnet-configure-and-open-a-synced-realm>`
+        - :ref:`Manage Flexible Sync Subscriptions - .NET SDK <dotnet-flexible-sync>`
 
-            :ref:`Flexible Sync - Node.js SDK <node-flexible-sync>`
+      - Node.js SDK
 
-         .. tab::
-            :tabid: react-native
+        - :ref:`Open a Synced Realm - Node.js SDK <node-open-a-synced-realm>`
+        - :ref:`Flexible Sync - Node.js SDK <node-flexible-sync>`
 
-            :ref:`Open & Close a Realm - React Native SDK <react-native-open-close-realm>`
+      - React Native SDK
 
-            :ref:`Flexible Sync - React Native SDK <react-native-flexible-sync>`
+        - :ref:`Open & Close a Realm - React Native SDK <react-native-open-a-synced-realm>`
+        - :ref:`Flexible Sync - React Native SDK <react-native-flexible-sync>`
 
-         .. tab::
-            :tabid: dotnet
+      - Swift SDK
 
-            :ref:`Configure & Open a Synced Realm - .NET SDK <dotnet-configure-and-open-a-synced-realm>`
-
-            :ref:`Manage Flexible Sync Subscriptions - .NET SDK <dotnet-flexible-sync>`
-
-         .. tab::
-            :tabid: flutter
-
-            :ref:`Open a Synced Realm - Flutter SDK <flutter-open-synced-realm>`
-
-            :ref:`Manage a Sync Session - Flutter SDK <flutter-manage-sync-session>`
-
-         .. tab::
-            :tabid: kotlin
-
-            :ref:`Open a Synced Realm - Kotlin SDK <kotlin-open-a-synced-realm>`
-
-            :ref:`Subscribe to Queryable Fields - Kotlin SDK <kotlin-subscriptions>`
+        - :ref:`Configure & Open a Synced Realm - Swift SDK <ios-configure-and-open-a-synced-realm>`
+        - :ref:`Manage Flexible Sync Subscriptions - Swift SDK <swift-manage-flexible-sync-subscriptions>`
 
    .. step:: Use the Synced Realm
 
@@ -260,51 +187,32 @@ data with a Realm Database on the device.
       template apps. Optionally, you can go through SDK-specific tutorials 
       that build on the Device Sync template app.
 
-      .. tabs-realm-sdks::
+      - Flutter SDK
 
-         .. tab::
-            :tabid: android
+        - :ref:`Quick Start - Flutter SDK <flutter-quick-start>`
+        - :ref:`Device Sync Tutorial - Flutter SDK <flutter-tutorial>`
 
-            :ref:`Quick Start with Sync - Java SDK <java-client-quick-start-sync>`
+      - :ref:`Quick Start with Sync - Java SDK <java-client-quick-start-sync>`
 
-         .. tab::
-            :tabid: ios
+      - Kotlin SDK
 
-            :ref:`Quick Start - Swift SDK <ios-client-quick-start>`
+        - :ref:`Quick Start - Kotlin SDK <kotlin-client-quick-start>`
+        - :ref:`Device Sync Tutorial - Android with Kotlin SDK <kotlin-tutorial>`
 
-            :ref:`Quick Start - SwiftUI <ios-swiftui-examples>`
+      - .NET SDK
 
-            :ref:`Device Sync Tutorial - SwiftUI <ios-swift-tutorial>`
+        - :ref:`Quick Start - .NET SDK <dotnet-client-quick-start>`
+        - :ref:`Device Sync Tutorial - Xamarin (Android & iOS) <dotnet-tutorial>`
 
-         .. tab::
-            :tabid: node
+      - :ref:`Quick Start - Node.js SDK <node-client-quick-start>`
+      - React Native SDK
 
-            :ref:`Quick Start with Sync - Node.js SDK <node-client-quick-start>`
+        - :ref:`Quick Start  - React Native SDK <react-native-client-quick-start>`
+        - :ref:`Device Sync Tutorial - React Native <react-native-tutorial>`
 
-         .. tab::
-            :tabid: react-native
+      - Swift SDK
 
-            :ref:`Quick Start with Sync - React Native SDK <react-native-client-quick-start>`
+        - :ref:`Quick Start - Swift SDK <ios-client-quick-start>`
+        - :ref:`Quick Start - SwiftUI <ios-swiftui-examples>`
+        - :ref:`Device Sync Tutorial - SwiftUI <ios-swift-tutorial>`
 
-            :ref:`Device Sync Tutorial - React Native <react-native-tutorial>`
-
-         .. tab::
-            :tabid: dotnet
-
-            :ref:`Quick Start - .NET SDK <dotnet-client-quick-start>`
-
-            :ref:`Device Sync Tutorial - Xamarin (Android & iOS)<dotnet-tutorial>`
-
-         .. tab::
-            :tabid: flutter
-
-            :ref:`Quick Start - Flutter SDK <flutter-quick-start>`
-
-            :ref:`Device Sync Tutorial - Flutter SDK <flutter-tutorial>`
-
-         .. tab::
-            :tabid: kotlin
-
-            :ref:`Quick Start - Kotlin SDK <kotlin-client-quick-start>`
-
-            :ref:`Device Sync Tutorial - Android with Kotlin SDK <kotlin-tutorial>`

--- a/source/sync/app-builder/sync-data-in-client-with-atlas.txt
+++ b/source/sync/app-builder/sync-data-in-client-with-atlas.txt
@@ -91,42 +91,13 @@ Atlas.
       App Services features like authentication, and enables opening a 
       synced realm.
 
-      .. tabs-realm-sdks::
-
-         .. tab::
-            :tabid: android
-
-            :ref:`Connect to an Atlas App Services backend - Java SDK <java-init-appclient>`
-
-         .. tab::
-            :tabid: ios
-
-            :ref:`Connect to an Atlas App Services backend - Swift SDK <ios-init-appclient>`
-
-         .. tab::
-            :tabid: node
-
-            :ref:`Connect to an Atlas App Services Backend - Node.js SDK <node-connect-to-mongodb-realm-backend-app>`
-
-         .. tab::
-            :tabid: react-native
-
-            :ref:`Connect to an Atlas App Services Backend - React Native SDK <react-native-connect-to-mongodb-realm-backend-app>`
-
-         .. tab::
-            :tabid: dotnet
-
-            :ref:`Connect to an Atlas App Services Backend - .NET SDK <dotnet-init-appclient>`
-
-         .. tab::
-            :tabid: flutter
-
-            :ref:`Connect to App Services - Flutter SDK <flutter-connect-to-backend>`
-
-         .. tab::
-            :tabid: kotlin
-
-            :ref:`Connect to an Atlas App Services backend - Kotlin SDK <kotlin-connect-to-backend>`
+      - :ref:`Connect to App Services - Flutter SDK <flutter-connect-to-backend>`
+      - :ref:`Connect to an Atlas App Services backend - Java SDK <java-init-appclient>`
+      - :ref:`Connect to an Atlas App Services backend - Kotlin SDK <kotlin-connect-to-backend>`
+      - :ref:`Connect to an Atlas App Services Backend - .NET SDK <dotnet-init-appclient>`
+      - :ref:`Connect to an Atlas App Services Backend - Node.js SDK <node-connect-to-mongodb-realm-backend-app>`
+      - :ref:`Connect to an Atlas App Services Backend - React Native SDK <react-native-connect-to-mongodb-realm-backend-app>`
+      - :ref:`Connect to an Atlas App Services backend - Swift SDK <ios-init-appclient>`
 
    .. step:: Authenticate a User
 
@@ -134,42 +105,13 @@ Atlas.
       backend in order to access synchronized data. Add logic to your 
       client app to register and log in users.
 
-      .. tabs-realm-sdks::
-
-         .. tab::
-            :tabid: android
-
-            :ref:`Authenticate Users - Java SDK <java-authenticate>`
-
-         .. tab::
-            :tabid: ios
-
-            :ref:`Authenticate Users - Swift SDK <ios-authenticate-users>`
-
-         .. tab::
-            :tabid: node
-
-            :ref:`Authenticate Users - Node.js SDK <node-authenticate-users>`
-
-         .. tab::
-            :tabid: react-native
-
-            :ref:`Authenticate Users - React Native SDK <react-native-authenticate-users>`
-
-         .. tab::
-            :tabid: dotnet
-
-            :ref:`Authenticate Users - .NET SDK <dotnet-authenticate>`
-
-         .. tab::
-            :tabid: flutter
-
-            :ref:`Authenticate Users - Flutter SDK <flutter-authenticate>`
-
-         .. tab::
-            :tabid: kotlin
-
-            :ref:`Authenticate Users - Kotlin SDK <kotlin-authenticate>`
+      - :ref:`Authenticate Users - Flutter SDK <flutter-authenticate>`
+      - :ref:`Authenticate Users - Java SDK <java-authenticate>`
+      - :ref:`Authenticate Users - Kotlin SDK <kotlin-authenticate>`
+      - :ref:`Authenticate Users - .NET SDK <dotnet-authenticate>`
+      - :ref:`Authenticate Users - Node.js SDK <node-authenticate-users>`
+      - :ref:`Authenticate Users - React Native SDK <react-native-authenticate-users>`
+      - :ref:`Authenticate Users - Swift SDK <ios-authenticate-users>`
 
    .. step:: Open a Synced Realm
 
@@ -184,56 +126,40 @@ Atlas.
       remove, or update Flexible Sync query subscriptions to change the 
       documents that sync to the device.
 
-      .. tabs-realm-sdks::
+      - Flutter SDK
 
-         .. tab::
-            :tabid: android
+        - :ref:`Open a Synced Realm - Flutter SDK <flutter-open-synced-realm>`
+        - :ref:`Manage Flexible Sync Subscriptions - Flutter SDK <flutter-flexible-sync-manage-subscriptions>`
 
-            :ref:`Open a Synced Realm - Java SDK <java-synced-realms>`
+      - Java SDK
 
-            :ref:`Flexible Sync - Java SDK <java-flexible-sync>`
+        - :ref:`Open a Synced Realm - Java SDK <java-synced-realms>`
+        - :ref:`Flexible Sync - Java SDK <java-flexible-sync>`
 
-         .. tab::
-            :tabid: ios
+      - Kotlin SDK
 
-            :ref:`Configure & Open a Synced Realm - Swift SDK <ios-configure-and-open-a-synced-realm>`
+        - :ref:`Open a Synced Realm - Kotlin SDK <kotlin-open-a-synced-realm>`
+        - :ref:`Subscribe to Queryable Fields - Kotlin SDK <kotlin-subscriptions>`
 
-            :ref:`Manage Flexible Sync Subscriptions - Swift SDK <swift-manage-flexible-sync-subscriptions>`
+      - .NET SDK
 
-         .. tab::
-            :tabid: node
+        - :ref:`Open a Synced Realm - .NET SDK <dotnet-configure-and-open-a-synced-realm>`
+        - :ref:`Manage Flexible Sync Subscriptions - .NET SDK <dotnet-flexible-sync>`
 
-            :ref:`Open a Synced Realm - Node.js SDK <node-open-a-synced-realm>`
+      - Node.js SDK
 
-            :ref:`Flexible Sync - Node.js SDK <node-flexible-sync>`
+        - :ref:`Open a Synced Realm - Node.js SDK <node-open-a-synced-realm>`
+        - :ref:`Flexible Sync - Node.js SDK <node-flexible-sync>`
 
-         .. tab::
-            :tabid: react-native
+      - React Native SDK
 
-            :ref:`Open & Close a Realm - React Native SDK <react-native-open-close-realm>`
+        - :ref:`Configure a Synced Realm <react-native-open-a-synced-realm>`
+        - :ref:`Flexible Sync - React Native SDK <react-native-flexible-sync>`
 
-            :ref:`Flexible Sync - React Native SDK <react-native-flexible-sync>`
+      - Swift SDK
 
-         .. tab::
-            :tabid: dotnet
-
-            :ref:`Configure & Open a Synced Realm - .NET SDK <dotnet-configure-and-open-a-synced-realm>`
-
-            :ref:`Manage Flexible Sync Subscriptions - .NET SDK <dotnet-flexible-sync>`
-
-         .. tab::
-            :tabid: flutter
-
-            :ref:`Open a Synced Realm - Flutter SDK <flutter-open-synced-realm>`
-
-            :ref:`Manage a Sync Session - Flutter SDK <flutter-manage-sync-session>`
-
-         .. tab::
-            :tabid: kotlin
-
-            :ref:`Open a Synced Realm - Kotlin SDK <kotlin-open-a-synced-realm>`
-
-            :ref:`Subscribe to Queryable Fields - Kotlin SDK <kotlin-subscriptions>`
+        - :ref:`Configure & Open a Synced Realm - Swift SDK <ios-configure-and-open-a-synced-realm>`
+        - :ref:`Manage Flexible Sync Subscriptions - Swift SDK <swift-manage-flexible-sync-subscriptions>`
 
    .. step:: Copy Existing Data Into a Synced Realm
 

--- a/source/sync/app-builder/sync-data-in-client-with-atlas.txt
+++ b/source/sync/app-builder/sync-data-in-client-with-atlas.txt
@@ -91,13 +91,13 @@ Atlas.
       App Services features like authentication, and enables opening a 
       synced realm.
 
-      - :ref:`Connect to App Services - Flutter SDK <flutter-connect-to-backend>`
-      - :ref:`Connect to an Atlas App Services backend - Java SDK <java-init-appclient>`
-      - :ref:`Connect to an Atlas App Services backend - Kotlin SDK <kotlin-connect-to-backend>`
-      - :ref:`Connect to an Atlas App Services Backend - .NET SDK <dotnet-init-appclient>`
-      - :ref:`Connect to an Atlas App Services Backend - Node.js SDK <node-connect-to-mongodb-realm-backend-app>`
-      - :ref:`Connect to an Atlas App Services Backend - React Native SDK <react-native-connect-to-mongodb-realm-backend-app>`
-      - :ref:`Connect to an Atlas App Services backend - Swift SDK <ios-init-appclient>`
+      - :ref:`Connect to Atlas App Services - Flutter SDK <flutter-connect-to-backend>`
+      - :ref:`Connect to Atlas App Services - Java SDK <java-init-appclient>`
+      - :ref:`Connect to Atlas App Services - Kotlin SDK <kotlin-connect-to-backend>`
+      - :ref:`Connect to Atlas App Services - .NET SDK <dotnet-init-appclient>`
+      - :ref:`Connect to Atlas App Services - Node.js SDK <node-connect-to-mongodb-realm-backend-app>`
+      - :ref:`Connect to Atlas App Services - React Native SDK <react-native-connect-to-mongodb-realm-backend-app>`
+      - :ref:`Connect to Atlas App Services - Swift SDK <ios-init-appclient>`
 
    .. step:: Authenticate a User
 

--- a/source/sync/configure/pause-or-terminate-sync.txt
+++ b/source/sync/configure/pause-or-terminate-sync.txt
@@ -55,37 +55,16 @@ To pause Device Sync from the client side, using logic
 that situationally pauses Device Sync during a session, see your
 preferred SDK:
 
-.. tabs-realm-sdks::
-
-   .. tab::
-      :tabid: android
-
-      Learn how to :ref:`pause or resume a Device Sync session using the 
-      Java SDK <java-pause-or-resume-a-sync-session>`.
-
-   .. tab::
-      :tabid: ios
-
-      Learn how to :ref:`pause or resume a Device Sync session using the 
-      Swift SDK <ios-suspend-or-resume-a-sync-session>`.
-
-   .. tab::
-      :tabid: react-native
-      
-      Learn how to :ref:`pause or resume a Device Sync session using the 
-      React Native SDK <react-native-pause-or-resume-a-sync-session>`.
-
-   .. tab::
-      :tabid: node
-      
-      Learn how to :ref:`pause or resume a Device Sync session using the 
-      Node SDK <node-pause-or-resume-a-sync-session>`.
-
-   .. tab::
-      :tabid: dotnet
-
-      Learn how to :ref:`pause or resume a Device Sync session using the 
-      .Net SDK <dotnet-pause-or-resume-a-sync-session>`.
+- Learn how to :ref:`pause or resume a Device Sync session using the
+  Java SDK <java-pause-or-resume-a-sync-session>`.
+- Learn how to :ref:`pause or resume a Device Sync session using the
+  .Net SDK <dotnet-pause-or-resume-a-sync-session>`.
+- Learn how to :ref:`pause or resume a Device Sync session using the
+  Node SDK <node-pause-or-resume-a-sync-session>`.
+- Learn how to :ref:`pause or resume a Device Sync session using the
+  React Native SDK <react-native-pause-or-resume-a-sync-session>`.
+- Learn how to :ref:`pause or resume a Device Sync session using the
+  Swift SDK <ios-suspend-or-resume-a-sync-session>`.
 
 After pausing Device Sync, you can :ref:`re-enable it <resume-sync>`. 
 Pausing Device Sync maintains the configuration settings and all of the 

--- a/source/sync/configure/pause-or-terminate-sync.txt
+++ b/source/sync/configure/pause-or-terminate-sync.txt
@@ -55,18 +55,18 @@ To pause Device Sync from the client side, using logic
 that situationally pauses Device Sync during a session, see your
 preferred SDK:
 
-- Learn how to :ref:`pause or resume a Device Sync session using the
-  Flutter SDK <flutter-pause-resume-sync>`.
-- Learn how to :ref:`pause or resume a Device Sync session using the
-  Java SDK <java-pause-or-resume-a-sync-session>`.
-- Learn how to :ref:`pause or resume a Device Sync session using the
-  .Net SDK <dotnet-pause-or-resume-a-sync-session>`.
-- Learn how to :ref:`pause or resume a Device Sync session using the
-  Node SDK <node-pause-or-resume-a-sync-session>`.
-- Learn how to :ref:`pause or resume a Device Sync session using the
-  React Native SDK <react-native-pause-or-resume-a-sync-session>`.
-- Learn how to :ref:`pause or resume a Device Sync session using the
-  Swift SDK <ios-suspend-or-resume-a-sync-session>`.
+- :ref:`Pause or resume a Device Sync session - Flutter SDK
+  <flutter-pause-resume-sync>`
+- :ref:`Pause or resume a Device Sync session - Java SDK
+  <java-pause-or-resume-a-sync-session>`
+- :ref:`Pause or resume a Device Sync session - .Net SDK
+  <dotnet-pause-or-resume-a-sync-session>`
+- :ref:`Pause or resume a Device Sync session - Node SDK
+  <node-pause-or-resume-a-sync-session>`
+- :ref:`Pause or resume a Device Sync session - React Native SDK
+  <react-native-pause-or-resume-a-sync-session>`
+- :ref:`Pause or resume a Device Sync session - Swift SDK
+  <ios-suspend-or-resume-a-sync-session>`
 
 After pausing Device Sync, you can :ref:`re-enable it <resume-sync>`. 
 Pausing Device Sync maintains the configuration settings and all of the 

--- a/source/sync/configure/pause-or-terminate-sync.txt
+++ b/source/sync/configure/pause-or-terminate-sync.txt
@@ -56,6 +56,8 @@ that situationally pauses Device Sync during a session, see your
 preferred SDK:
 
 - Learn how to :ref:`pause or resume a Device Sync session using the
+  Flutter SDK <flutter-pause-resume-sync>`.
+- Learn how to :ref:`pause or resume a Device Sync session using the
   Java SDK <java-pause-or-resume-a-sync-session>`.
 - Learn how to :ref:`pause or resume a Device Sync session using the
   .Net SDK <dotnet-pause-or-resume-a-sync-session>`.

--- a/source/sync/data-model/data-model-map.txt
+++ b/source/sync/data-model/data-model-map.txt
@@ -192,13 +192,13 @@ You can configure the following constraints for a given property:
 
 Realm SDK data type documentation:
 
-:ref:`flutter-data-types`
-:ref:`java-data-types`
-:ref:`kotlin-supported-types`
-:ref:`dotnet-field-types`
-:ref:`node-data-types`
-:ref:`react-nativedata-types-field-types`
-:ref:`Supported Property Types - Swift SDK <ios-supported-property-types>`
+- :ref:`flutter-data-types`
+- :ref:`java-data-types`
+- :ref:`kotlin-supported-types`
+- :ref:`dotnet-field-types`
+- :ref:`node-data-types`
+- :ref:`react-nativedata-types-field-types`
+- :ref:`Supported Property Types - Swift SDK <ios-supported-property-types>`
 
 Array Properties
 ~~~~~~~~~~~~~~~~
@@ -208,13 +208,13 @@ Both Realm Object Schemas and App Services Schemas support array properties.
 You can find information on using array data types in the Realm SDK documentation
 on defining a Realm Object Schema.
 
-:ref:`Dart Types - Flutter SDK <flutter-dart-types>`
-:ref:`Lists - Java SDK <java-field-relationships-lists>`
-:ref:`kotlin-supported-types`
-:ref:`Lists - .NET SDK <dotnet-property-lists>`
-:ref:`Supported Property Types - Node.js SDK <node-supported-property-types>`
-:ref:`Supported Property Types - React Native SDK <react-native-supported-property-types>`
-:ref:`swift-supported-types`
+- :ref:`Dart Types - Flutter SDK <flutter-dart-types>`
+- :ref:`Lists - Java SDK <java-field-relationships-lists>`
+- :ref:`kotlin-supported-types`
+- :ref:`Lists - .NET SDK <dotnet-property-lists>`
+- :ref:`Supported Property Types - Node.js SDK <node-supported-property-types>`
+- :ref:`Supported Property Types - React Native SDK <react-native-supported-property-types>`
+- :ref:`swift-supported-types`
 
 For more information on modeling array properties in an App Services Schema,
 refer to :ref:`BSON Types - Array <schema-type-array>`.

--- a/source/sync/data-model/data-model-map.txt
+++ b/source/sync/data-model/data-model-map.txt
@@ -192,42 +192,13 @@ You can configure the following constraints for a given property:
 
 Realm SDK data type documentation:
 
-.. tabs-realm-sdks::
-
-   .. tab::
-      :tabid: android
-
-      :ref:`java-data-types`
-
-   .. tab::
-      :tabid: ios
-
-      :ref:`Supported Property Types - Swift SDK <ios-supported-property-types>`
-
-   .. tab::
-      :tabid: node
-
-      :ref:`node-data-types`
-
-   .. tab::
-      :tabid: react-native
-
-      :ref:`react-nativedata-types-field-types`
-
-   .. tab::
-      :tabid: dotnet
-
-      :ref:`dotnet-field-types`
-
-   .. tab::
-      :tabid: flutter
-
-      :ref:`flutter-data-types`
-
-   .. tab::
-      :tabid: kotlin
-
-      :ref:`kotlin-supported-types`
+:ref:`flutter-data-types`
+:ref:`java-data-types`
+:ref:`kotlin-supported-types`
+:ref:`dotnet-field-types`
+:ref:`node-data-types`
+:ref:`react-nativedata-types-field-types`
+:ref:`Supported Property Types - Swift SDK <ios-supported-property-types>`
 
 Array Properties
 ~~~~~~~~~~~~~~~~
@@ -237,42 +208,13 @@ Both Realm Object Schemas and App Services Schemas support array properties.
 You can find information on using array data types in the Realm SDK documentation
 on defining a Realm Object Schema.
 
-.. tabs-realm-sdks::
-
-   .. tab::
-      :tabid: android
-
-      :ref:`Lists - Java SDK <java-field-relationships-lists>`
-
-   .. tab::
-      :tabid: ios
-
-      :ref:`swift-supported-types`
-
-   .. tab::
-      :tabid: node
-
-      :ref:`Supported Property Types - Node.js SDK <node-supported-property-types>`
-
-   .. tab::
-      :tabid: react-native
-
-      :ref:`Supported Property Types - React Native SDK <react-native-supported-property-types>`
-
-   .. tab::
-      :tabid: dotnet
-
-      :ref:`Lists - .NET SDK <dotnet-property-lists>`
-
-   .. tab::
-      :tabid: flutter
-
-      :ref:`Dart Types - Flutter SDK <flutter-dart-types>`
-
-   .. tab::
-      :tabid: kotlin
-
-      :ref:`kotlin-supported-types`
+:ref:`Dart Types - Flutter SDK <flutter-dart-types>`
+:ref:`Lists - Java SDK <java-field-relationships-lists>`
+:ref:`kotlin-supported-types`
+:ref:`Lists - .NET SDK <dotnet-property-lists>`
+:ref:`Supported Property Types - Node.js SDK <node-supported-property-types>`
+:ref:`Supported Property Types - React Native SDK <react-native-supported-property-types>`
+:ref:`swift-supported-types`
 
 For more information on modeling array properties in an App Services Schema,
 refer to :ref:`BSON Types - Array <schema-type-array>`.
@@ -288,42 +230,13 @@ It cannot exist as an independent Realm object.
 
 Realm SDK embedded object documentation:
 
-.. tabs-realm-sdks::
-
-   .. tab::
-      :tabid: android
-
-      :ref:`Define an Embedded Object Field - Java SDK <java-define-an-embedded-object-property>`
-
-   .. tab::
-      :tabid: ios
-
-      :ref:`Define an Embedded Object Property - Swift SDK <ios-embedded-objects>`
-
-   .. tab::
-      :tabid: node
-
-      :ref:`Embedded Objects - Node.js SDK <node-embedded-objects>`
-
-   .. tab::
-      :tabid: react-native
-
-      :ref:`Embedded Objects - React Native SDK <react-native-embedded-objects>`
-
-   .. tab::
-      :tabid: dotnet
-
-      :ref:`dotnet-embedded-objects`
-
-   .. tab::
-      :tabid: flutter
-
-      :ref:`Embedded Objects - Flutter SDK <flutter-embedded-objects>`
-
-   .. tab::
-      :tabid: kotlin
-
-      The Realm Kotlin SDK does not support Embedded Objects yet.
+- :ref:`Embedded Objects - Flutter SDK <flutter-embedded-objects>`
+- The Realm Kotlin SDK does not support Embedded Objects yet.
+- :ref:`Define an Embedded Object Field - Java SDK <java-define-an-embedded-object-property>`
+- :ref:`dotnet-embedded-objects`
+- :ref:`Embedded Objects - Node.js SDK <node-embedded-objects>`
+- :ref:`Embedded Objects - React Native SDK <react-native-embedded-objects>`
+- :ref:`Define an Embedded Object Property - Swift SDK <ios-embedded-objects>`
 
 For more information on modeling to-one relationships in an App Services Schema,
 refer to :ref:`Embedded Object Relationships <relationships-embedded-object>`.
@@ -336,42 +249,13 @@ A set is a collection of unique values.
 
 Realm SDK Set documentation:
 
-.. tabs-realm-sdks::
-
-   .. tab::
-      :tabid: android
-
-      :ref:`java-realmset`
-
-   .. tab::
-      :tabid: ios
-
-      :ref:`Mutable Set - Swift SDK <ios-mutableset-data-type>`
-
-   .. tab::
-      :tabid: node
-
-      :ref:`node-data-types-sets`
-
-   .. tab::
-      :tabid: react-native
-
-      :ref:`react-native-data-types-sets`
-
-   .. tab::
-      :tabid: dotnet
-
-      :ref:`dotnet-client-sets`
-
-   .. tab::
-      :tabid: flutter
-
-      The Realm Flutter SDK does not support Sets yet.
-
-   .. tab::
-      :tabid: kotlin
-
-      The Realm Kotlin SDK does not support Sets yet.
+- :ref:`RealmSet - Flutter SDK <flutter-realm-set>`
+- The Realm Kotlin SDK does not support Sets yet.
+- :ref:`java-realmset`
+- :ref:`dotnet-client-sets`
+- :ref:`node-data-types-sets`
+- :ref:`react-native-data-types-sets`
+- :ref:`Mutable Set - Swift SDK <ios-mutableset-data-type>`
 
 
 For more information on modeling sets in an App Services Schema,
@@ -387,42 +271,13 @@ A dictionary is functionally an object or document without pre-defined field nam
 
 Realm SDK dictionary documentation:
 
-.. tabs-realm-sdks::
-
-   .. tab::
-      :tabid: android
-
-      :ref:`java-realmdictionary`
-
-   .. tab::
-      :tabid: ios
-
-      :ref:`Map/Dictionary - Swift SDK <ios-map>`
-
-   .. tab::
-      :tabid: node
-
-      :ref:`node-data-types-dictionaries`
-
-   .. tab::
-      :tabid: react-native
-
-      :ref:`react-native-data-types-dictionaries`
-
-   .. tab::
-      :tabid: dotnet
-
-      :ref:`dotnet-client-dictionaries`
-
-   .. tab::
-      :tabid: flutter
-
-      The Realm Flutter SDK does not support Dictionaries yet.
-
-   .. tab::
-      :tabid: kotlin
-
-      The Realm Kotlin SDK does not support Dictionaries yet.
+- The Realm Flutter SDK does not support Dictionaries yet.
+- :ref:`java-realmdictionary`
+- The Realm Kotlin SDK does not support Dictionaries yet.
+- :ref:`dotnet-client-dictionaries`
+- :ref:`node-data-types-dictionaries`
+- :ref:`react-native-data-types-dictionaries`
+- :ref:`Map/Dictionary - Swift SDK <ios-map>`
 
 For more information on modeling dictionaries in an App Services Schema,
 refer to :ref:`Dictionary <schema-type-dictionary>`.
@@ -444,42 +299,13 @@ App Services Schemas *do not* support inverse relationships.
 
 Realm SDK relationship documentation:
 
-.. tabs-realm-sdks::
-
-   .. tab::
-      :tabid: android
-
-      :ref:`Define a Relationship Field - Java SDK <java-relationships>`
-
-   .. tab::
-      :tabid: ios
-
-      :ref:`swift-model-relationships`
-
-   .. tab::
-      :tabid: node
-
-      :ref:`Define Relationship Properties - Node.js SDK <node-define-relationship-properties>`
-
-   .. tab::
-      :tabid: react-native
-
-      :ref:`Define Relationship Properties - React Native SDK <react-native-define-relationship-properties>`
-
-   .. tab::
-      :tabid: dotnet
-
-      :ref:`dotnet-client-relationships`
-
-   .. tab::
-      :tabid: flutter
-
-      :ref:`Define Relationship Properties - Flutter SDK <flutter-client-relationships>`
-
-   .. tab::
-      :tabid: kotlin
-
-      :ref:`kotlin-relationships`
+- :ref:`Define Relationship Properties - Flutter SDK <flutter-client-relationships>`
+- :ref:`kotlin-relationships`
+- :ref:`Define a Relationship Field - Java SDK <java-relationships>`
+- :ref:`dotnet-client-relationships`
+- :ref:`Define Relationship Properties - Node.js SDK <node-define-relationship-properties>`
+- :ref:`Define Relationship Properties - React Native SDK <react-native-relationships>`
+- :ref:`swift-model-relationships`
 
 For more information on modeling relationships in an App Services Schema,
 refer to :ref:`Relationships <relationships>`.

--- a/source/sync/data-model/data-model-map.txt
+++ b/source/sync/data-model/data-model-map.txt
@@ -231,8 +231,8 @@ It cannot exist as an independent Realm object.
 Realm SDK embedded object documentation:
 
 - :ref:`Embedded Objects - Flutter SDK <flutter-embedded-objects>`
-- The Realm Kotlin SDK does not support Embedded Objects yet.
 - :ref:`Define an Embedded Object Field - Java SDK <java-define-an-embedded-object-property>`
+- :ref:`Embedded Objects - Kotlin SDK <kotlin-embedded-objects>`
 - :ref:`dotnet-embedded-objects`
 - :ref:`Embedded Objects - Node.js SDK <node-embedded-objects>`
 - :ref:`Embedded Objects - React Native SDK <react-native-embedded-objects>`
@@ -250,8 +250,8 @@ A set is a collection of unique values.
 Realm SDK Set documentation:
 
 - :ref:`RealmSet - Flutter SDK <flutter-realm-set>`
-- The Realm Kotlin SDK does not support Sets yet.
 - :ref:`java-realmset`
+- :ref:`RealmSet - Kotlin SDK <kotlin-realm-set>`
 - :ref:`dotnet-client-sets`
 - :ref:`node-data-types-sets`
 - :ref:`react-native-data-types-sets`

--- a/source/sync/error-handling/client-resets.txt
+++ b/source/sync/error-handling/client-resets.txt
@@ -213,37 +213,12 @@ Examples
 For more information on performing a client reset, check out the client
 reset examples for your SDK:
 
-.. tabs-realm-sdks::
-
-   .. tab::
-      :tabid: android
-
-      :ref:`Reset a Client Realm - Java SDK <java-client-resets>`
-
-   .. tab::
-      :tabid: ios
-
-      :ref:`Handle Sync Errors - Client Reset - Swift SDK <ios-client-resets>`
-
-   .. tab::
-      :tabid: node
-
-      :ref:`Reset a Client Realm - Node.js SDK <node-client-resets>`
-
-   .. tab::
-      :tabid: react-native
-
-      :ref:`Reset a Client Realm - React Native SDK <react-native-client-resets>`
-
-   .. tab::
-      :tabid: dotnet
-
-      :ref:`Client Resets - .NET SDK <dotnet-client-resets>`
-
-   .. tab::
-      :tabid: flutter
-
-      :ref:`Handle Sync Errors - Client Reset - Flutter SDK <flutter-client-reset>`
+- :ref:`Handle Sync Errors - Client Reset - Flutter SDK <flutter-client-reset>`
+- :ref:`Reset a Client Realm - Java SDK <java-client-resets>`
+- :ref:`Client Resets - .NET SDK <dotnet-client-resets>`
+- :ref:`Reset a Client Realm - Node.js SDK <node-client-resets>`
+- :ref:`Reset a Client Realm - React Native SDK <react-native-client-resets>`
+- :ref:`Handle Sync Errors - Client Reset - Swift SDK <ios-client-resets>`
 
 .. _enable-or-disable-recovery-mode:
 

--- a/source/sync/error-handling/errors.txt
+++ b/source/sync/error-handling/errors.txt
@@ -293,42 +293,13 @@ Handle Sync Errors
 Every application that uses Sync needs a sync error handler. To learn more
 about sync error handling, see your preferred SDK:
 
-.. tabs-realm-sdks::
-
-   .. tab::
-      :tabid: android
-
-      :ref:`Handle Sync Errors - Java SDK <java-handle-sync-errors>`
-
-   .. tab::
-      :tabid: ios
-
-      :ref:`Handle Sync Errors - Swift SDK <ios-handle-sync-errors>`
-
-   .. tab::
-      :tabid: node
-
-      :ref:`Handle Sync Errors - Node.js SDK <node-handle-sync-errors>`
-
-   .. tab::
-      :tabid: react-native
-
-      :ref:`Handle Sync Errors - React Native SDK <react-native-handle-sync-errors>`
-
-   .. tab::
-      :tabid: dotnet
-
-      :ref:`Handle Sync Errors - .NET SDK <dotnet-handle-sync-errors>`
-
-   .. tab::
-      :tabid: flutter
-
-      :ref:`Handle Sync Errors - Flutter SDK <flutter-handle-sync-errors>`
-
-   .. tab::
-      :tabid: kotlin
-
-      :ref:`Handle App Errors - Kotlin SDK <kotlin-app-errors>`
+- :ref:`Handle Sync Errors - Flutter SDK <flutter-handle-sync-errors>`
+- :ref:`Handle Sync Errors - Java SDK <java-handle-sync-errors>`
+- :ref:`Handle App Errors - Kotlin SDK <kotlin-app-errors>`
+- :ref:`Handle Sync Errors - .NET SDK <dotnet-handle-sync-errors>`
+- :ref:`Handle Sync Errors - Node.js SDK <node-handle-sync-errors>`
+- :ref:`Handle Sync Errors - React Native SDK <react-native-handle-sync-errors>`
+- :ref:`Handle Sync Errors - Swift SDK <ios-handle-sync-errors>`
 
 .. _set-log-level:
 
@@ -348,29 +319,8 @@ only warnings or errors.
 For more information about available log levels, including how to set the 
 client log level, see your preferred SDK.
 
-.. tabs-realm-sdks::
-
-   .. tab::
-      :tabid: android
-      
-      :ref:`Set the Client Log Level - Java SDK <java-set-the-client-log-level>`
-
-   .. tab::
-      :tabid: ios
-      
-      :ref:`Set the Client Log Level - Swift SDK <ios-set-the-client-log-level>`
-
-   .. tab::
-      :tabid: node
-      
-      :ref:`Set the Client Log Level - Node.js SDK <node-set-the-client-log-level>`
-
-   .. tab::
-      :tabid: react-native
-      
-      :ref:`Set the Client Log Level - React Native SDK <react-native-set-the-client-log-level>`
-
-   .. tab::
-      :tabid: dotnet
-      
-      :ref:`Set the Client Log Level - .NET SDK <dotnet-set-the-client-log-level>`
+- :ref:`Set the Client Log Level - Java SDK <java-set-the-client-log-level>`
+- :ref:`Set the Client Log Level - .NET SDK <dotnet-set-the-client-log-level>`
+- :ref:`Set the Client Log Level - Node.js SDK <node-set-the-client-log-level>`
+- :ref:`Set the Client Log Level - React Native SDK <react-native-set-the-client-log-level>`
+- :ref:`Set the Client Log Level - Swift SDK <ios-set-the-client-log-level>`

--- a/source/sync/get-started.txt
+++ b/source/sync/get-started.txt
@@ -175,17 +175,12 @@ client application. The SDKs use **subscriptions** to maintain those queries on
 the client side. Through these subscriptions, your applications sync objects
 with the backend app and can watch for and react to changes.
 
-- To create queries from the Flutter Client SDK, see the :ref:`Flutter SDK
-  guide to Flexible Sync <flutter-sync>`.
-- To create queries from the Java Client SDK, see the
-  :ref:`Java SDK guide to Flexible Sync <java-flexible-sync>`.
-- To create queries from the Kotlin Client SDK, see the :ref:`Kotlin SDK
-  guide to Flexible Sync <kotlin-subscriptions>`.
-- To create queries from the .NET Client SDK, see the :ref:`.NET SDK
-  guide to Flexible Sync <dotnet-flexible-sync>`.
-- To create queries from the Node Client SDK, see the :ref:`Node SDK
-  guide to Flexible Sync <node-flexible-sync>`.
-- To create queries from the React Native Client SDK, see the
-  :ref:`React Native SDK guide to Flexible Sync <react-native-flexible-sync>`.
-- To create queries from the Swift Client SDK, see the :ref:`Swift SDK
-  guide to Flexible Sync <ios-flexible-sync>`.
+To create queries from your client application, refer to the Realm SDK documentation:
+
+- :ref:`Flexible Sync - Flutter SDK <flutter-sync>`
+- :ref:`Flexible Sync - Java SDK<java-flexible-sync>`
+- :ref:`Flexible Sync - Kotlin SDK <kotlin-subscriptions>`
+- :ref:`Flexible Sync - .NET SDK <dotnet-flexible-sync>`
+- :ref:`Flexible Sync - Node.js SDK <node-flexible-sync>`
+- :ref:`Flexible Sync - React Native SDK <react-native-flexible-sync>`
+- :ref:`Flexible Sync - Swift SDK <ios-flexible-sync>`

--- a/source/sync/get-started.txt
+++ b/source/sync/get-started.txt
@@ -175,46 +175,17 @@ client application. The SDKs use **subscriptions** to maintain those queries on
 the client side. Through these subscriptions, your applications sync objects
 with the backend app and can watch for and react to changes.
 
-.. tabs-realm-sdks::
-
-   .. tab::
-      :tabid: android
-
-      To create queries from the Java Client SDK, see the
-      :ref:`Java SDK guide to Flexible Sync <java-flexible-sync>`.
-
-   .. tab::
-      :tabid: ios
-
-      To create queries from the Swift Client SDK, see the :ref:`Swift SDK 
-      guide to Flexible Sync <ios-flexible-sync>`.
-
-   .. tab::
-      :tabid: node
-      
-      To create queries from the Node Client SDK, see the :ref:`Node SDK 
-      guide to Flexible Sync <node-flexible-sync>`.
-
-   .. tab::
-      :tabid: react-native
-
-      To create queries from the React Native Client SDK, see the
-      :ref:`React Native SDK guide to Flexible Sync <react-native-flexible-sync>`.
-
-   .. tab::
-      :tabid: dotnet
-
-      To create queries from the .NET Client SDK, see the :ref:`.NET SDK 
-      guide to Flexible Sync <dotnet-flexible-sync>`.
-   
-   .. tab::
-      :tabid: flutter
-
-      To create queries from the Flutter Client SDK, see the :ref:`Flutter SDK
-      guide to Flexible Sync <flutter-sync>`.
-
-   .. tab::
-      :tabid: kotlin
-
-      To create queries from the Kotlin Client SDK, see the :ref:`Kotlin SDK
-      guide to Flexible Sync <kotlin-subscriptions>`.
+- To create queries from the Flutter Client SDK, see the :ref:`Flutter SDK
+  guide to Flexible Sync <flutter-sync>`.
+- To create queries from the Java Client SDK, see the
+  :ref:`Java SDK guide to Flexible Sync <java-flexible-sync>`.
+- To create queries from the Kotlin Client SDK, see the :ref:`Kotlin SDK
+  guide to Flexible Sync <kotlin-subscriptions>`.
+- To create queries from the .NET Client SDK, see the :ref:`.NET SDK
+  guide to Flexible Sync <dotnet-flexible-sync>`.
+- To create queries from the Node Client SDK, see the :ref:`Node SDK
+  guide to Flexible Sync <node-flexible-sync>`.
+- To create queries from the React Native Client SDK, see the
+  :ref:`React Native SDK guide to Flexible Sync <react-native-flexible-sync>`.
+- To create queries from the Swift Client SDK, see the :ref:`Swift SDK
+  guide to Flexible Sync <ios-flexible-sync>`.

--- a/source/users/create.txt
+++ b/source/users/create.txt
@@ -36,22 +36,14 @@ to link identities to existing user accounts. This allows users to log in to
 a single account with more than one provider. For more information, see the 
 documentation on linking identities for your preferred SDK:
 
-- Learn how to :ref:`link user identities for a Flutter
-  application <flutter-link-user-identities>`.
-- Learn how to :ref:`link user identities for an Android
-  application with the Java SDK <java-link-user-identities>`.
-- Learn how to :ref:`link user identities for a Kotlin
-  application <kotlin-link-user-identities>`.
-- Learn how to :ref:`link user identities for a .NET
-  application <dotnet-link-user-identities>`.
-- Learn how to :ref:`link user identities for a Node.js
-  application <node-link-user-identities>`.
-- Learn how to :ref:`link user identities for a React Native
-  application <react-native-link-user-identities>`.
-- Learn how to :ref:`link user identities for an iOS
-  application <ios-link-user-identities>`.
-- Learn how to :ref:`link user identities for a web
-  application <web-link-user-identities>`.
+- :ref:`Link User Identities - Flutter SDK <flutter-link-user-identities>`
+- :ref:`Link User Identities - Java SDK <java-link-user-identities>`
+- :ref:`Link User Identities - Kotlin SDK <kotlin-link-user-identities>`
+- :ref:`Link User Identities - .NET SDK <dotnet-link-user-identities>`
+- :ref:`Link User Identities - Node.js SDK <node-link-user-identities>`
+- :ref:`Link User Identities - React Native SDK <react-native-link-user-identities>`
+- :ref:`Link User Identities - Swift SDK <ios-link-user-identities>`
+- :ref:`Link User Identities - Web SDK <web-link-user-identities>`
 
 .. _create-email-password-user:
 
@@ -74,15 +66,15 @@ After registering the user, you must confirm the user before the they can
 authenticate. For code examples that demonstrate how to manage email/password 
 users in the client application, see the documentation for the Realm SDKs:
 
-- :ref:`C++ SDK <cpp-manage-users>`
-- :ref:`Flutter SDK <flutter-manage-email-password-users-register>`
-- :ref:`Java SDK <java-register-a-new-user-account>`
-- :ref:`Kotlin SDK <kotlin-manage-email-password-users>`
-- :ref:`.NET SDK <dotnet-email-password-register-new-user>`
-- :ref:`Node SDK <node-register-new-user>`
-- :ref:`React Native SDK <react-native-register-new-user>`
-- :ref:`Swift SDK <ios-register-a-new-user-account>`
-- :ref:`Web SDK <web-manage-email-password-users>`
+- :ref:`Create Email/Password Users - C++ SDK <cpp-manage-users>`
+- :ref:`Create Email/Password Users - Flutter SDK <flutter-manage-email-password-users-register>`
+- :ref:`Create Email/Password Users - Java SDK <java-register-a-new-user-account>`
+- :ref:`Create Email/Password Users - Kotlin SDK <kotlin-manage-email-password-users>`
+- :ref:`Create Email/Password Users - .NET SDK <dotnet-email-password-register-new-user>`
+- :ref:`Create Email/Password Users - Node SDK <node-register-new-user>`
+- :ref:`Create Email/Password Users - React Native SDK <react-native-register-new-user>`
+- :ref:`Create Email/Password Users - Swift SDK <ios-register-a-new-user-account>`
+- :ref:`Create Email/Password Users - Web SDK <web-manage-email-password-users>`
 
 Manually Create an Email/Password User
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/users/create.txt
+++ b/source/users/create.txt
@@ -36,55 +36,22 @@ to link identities to existing user accounts. This allows users to log in to
 a single account with more than one provider. For more information, see the 
 documentation on linking identities for your preferred SDK:
 
-.. tabs-realm-sdks::
-   
-   .. tab::
-      :tabid: node
-      
-      Learn how to :ref:`link user identities for a Node
-      application <node-link-user-identities>`.
-
-   .. tab::
-      :tabid: react-native
-      
-      Learn how to :ref:`link user identities for a React Native
-      application <react-native-link-user-identities>`.
-
-   .. tab::
-      :tabid: android
-
-      Learn how to :ref:`link user identities for an Android
-      application <java-link-user-identities>`.
-
-   .. tab::
-      :tabid: ios
-
-      Learn how to :ref:`link user identities for an iOS
-      application <ios-link-user-identities>`.
-
-   .. tab::
-      :tabid: dotnet
-
-      Learn how to :ref:`link user identities for a .NET
-      application <dotnet-link-user-identities>`.
-
-   .. tab::
-      :tabid: flutter
-
-      Learn how to :ref:`link user identities for a Flutter
-      application <flutter-link-user-identities>`.
-
-   .. tab::
-      :tabid: kotlin
-
-      Learn how to :ref:`link user identities for a Kotlin
-      application <kotlin-link-user-identities>`.
-
-   .. tab::
-      :tabid: web
-
-      Learn how to :ref:`link user identities for a web
-      application <web-link-user-identities>`.
+- Learn how to :ref:`link user identities for a Flutter
+  application <flutter-link-user-identities>`.
+- Learn how to :ref:`link user identities for an Android
+  application with the Java SDK <java-link-user-identities>`.
+- Learn how to :ref:`link user identities for a Kotlin
+  application <kotlin-link-user-identities>`.
+- Learn how to :ref:`link user identities for a .NET
+  application <dotnet-link-user-identities>`.
+- Learn how to :ref:`link user identities for a Node.js
+  application <node-link-user-identities>`.
+- Learn how to :ref:`link user identities for a React Native
+  application <react-native-link-user-identities>`.
+- Learn how to :ref:`link user identities for an iOS
+  application <ios-link-user-identities>`.
+- Learn how to :ref:`link user identities for a web
+  application <web-link-user-identities>`.
 
 .. _create-email-password-user:
 

--- a/source/users/manage.txt
+++ b/source/users/manage.txt
@@ -111,49 +111,20 @@ Delete a User in the SDK
 You can give users the option to delete their own account from a client 
 application when you use the Realm SDKs to delete users.
 
-.. tabs-realm-sdks::
-
-   .. tab::
-      :tabid: ios
-
-      Learn how to :ref:`delete a user with the Realm Swift SDK
-      <ios-delete-user>`.
-
-   .. tab::
-      :tabid: dotnet
- 
-      Learn how to :ref:`delete a user with the Realm .NET SDK
-      <dotnet-delete-user>`.
-
-   .. tab::
-      :tabid: node
-      
-      Learn how to :ref:`delete a user with the Realm Node.js SDK
-      <node-delete-user>`.
-
-   .. tab::
-      :tabid: react-native
-
-      Learn how to :ref:`delete a user with the Realm React Native SDK
-      <react-native-delete-user>`.
-
-   .. tab::
-      :tabid: flutter
-
-      Learn how to :ref:`delete a user with the Realm Flutter SDK
-      <flutter-delete-user>`.
-
-   .. tab::
-      :tabid: kotlin
-
-      Learn how to :ref:`delete a user with the Realm Kotlin SDK
-      <kotlin-delete-users>`.
-
-   .. tab::
-      :tabid: web
-
-      Learn how to :ref:`delete a user with the Realm Web SDK
-      <web-delete-user>`.
+- Learn how to :ref:`delete a user with the Realm Flutter SDK
+  <flutter-delete-user>`.
+- Learn how to :ref:`delete a user with the Realm Kotlin SDK
+  <kotlin-delete-users>`.
+- Learn how to :ref:`delete a user with the Realm .NET SDK
+  <dotnet-delete-user>`.
+- Learn how to :ref:`delete a user with the Realm Node.js SDK
+  <node-delete-user>`.
+- Learn how to :ref:`delete a user with the Realm React Native SDK
+  <react-native-delete-user>`.
+- Learn how to :ref:`delete a user with the Realm Swift SDK
+  <ios-delete-user>`.
+- Learn how to :ref:`delete a user with the Realm Web SDK
+  <web-delete-user>`.
 
 Delete a User with a Custom Function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/users/manage.txt
+++ b/source/users/manage.txt
@@ -111,20 +111,13 @@ Delete a User in the SDK
 You can give users the option to delete their own account from a client 
 application when you use the Realm SDKs to delete users.
 
-- Learn how to :ref:`delete a user with the Realm Flutter SDK
-  <flutter-delete-user>`.
-- Learn how to :ref:`delete a user with the Realm Kotlin SDK
-  <kotlin-delete-users>`.
-- Learn how to :ref:`delete a user with the Realm .NET SDK
-  <dotnet-delete-user>`.
-- Learn how to :ref:`delete a user with the Realm Node.js SDK
-  <node-delete-user>`.
-- Learn how to :ref:`delete a user with the Realm React Native SDK
-  <react-native-delete-user>`.
-- Learn how to :ref:`delete a user with the Realm Swift SDK
-  <ios-delete-user>`.
-- Learn how to :ref:`delete a user with the Realm Web SDK
-  <web-delete-user>`.
+- :ref:`Delete a User - Flutter SDK <flutter-delete-user>`
+- :ref:`Delete a User - Kotlin SDK <kotlin-delete-users>`
+- :ref:`Delete a User - .NET SDK <dotnet-delete-user>`
+- :ref:`Delete a User - Node.js SDK <node-delete-user>`
+- :ref:`Delete a User - React Native SDK <react-native-delete-user>`
+- :ref:`Delete a User - Swift SDK <ios-delete-user>`
+- :ref:`Delete a User - Web SDK <web-delete-user>`
 
 Delete a User with a Custom Function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

remove tabs with sdk links inside step directives. done b/c causes x-overflow issues per https://jira.mongodb.org/browse/DOP-3589

also removed all `.. tabs-realm-languages::` that just contain links to SDK pages, replacing them with a list of SDK links. this is something we've talked about doing in the past. figured i'd get it in while doing related work here.

### Jira

n/a

### Staged Changes

- [App Services (changes throughout)](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/remove_long_tabs_in_steps/)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
