### PR TITLE
(DOCSP-27737): Split up the sync optimization page into flexible sync and partition sync

### DIFF
--- a/source/reference/partition-based-sync.txt
+++ b/source/reference/partition-based-sync.txt
@@ -1664,10 +1664,9 @@ Minimizing metadata is necessary to reduce the time and data needed for sync.
 Apps using Partition-Based Sync perform **backend compaction** to reduce the amount
 of metadata stored in an Atlas Cluster. Backend compaction is an  maintenance process
 that automatically runs for all Apps using Partition-Based Sync.
-Using compaction, the backend optimizes a
-realm's history by removing unneeded changeset metadata. The process
-removes any instruction whose effect is later overwritten by a newer
-instruction.
+Using compaction, the backend optimizes a realm's history by removing unneeded
+changeset metadata. The process removes any instruction whose effect is later
+overwritten by a newer instruction.
 
 .. example::
 

--- a/source/reference/partition-based-sync.txt
+++ b/source/reference/partition-based-sync.txt
@@ -1650,3 +1650,43 @@ Permissions. Making changes to your Device Sync configuration while
 terminating and re-enabling Device Sync will trigger a client reset. To learn
 more about handling client resets, read the :ref:`client reset <client-resets>`
 documentation.
+
+.. _backend-compaction:
+
+Backend Compaction
+------------------
+
+**Backend compaction** is a maintenance process that automatically
+runs for all apps using :ref:`Partition Based Sync <partition-based-sync>`.
+Apps using Partition Based Sync store the entire history of data changes.
+Using compaction, the backend optimizes a
+realm's history by removing unneeded changesets. The process
+removes any instruction whose effect is later overwritten by a newer
+instruction.
+
+.. example::
+
+   Consider the following realm history:
+
+   .. code-block::
+      :caption: Original History
+
+      CREATE table1.object1
+      UPDATE table1.object1.x = 4
+      UPDATE table1.object1.x = 10
+      UPDATE table1.object1.x = 42
+
+   The following history would also converge to the same state, but
+   without unneeded interim changes:
+
+   .. code-block::
+      :caption: Compacted History
+
+      CREATE table1.object1
+      UPDATE table1.object1.x = 42
+
+.. note:: 
+   
+   :ref:`Partition Based Sync <partition-based-sync>` uses backend compaction rather 
+   than :ref:`trimming <trimming>` and 
+   :ref:`client maximum offline time <client-maximum-offline-time>`.

--- a/source/reference/partition-based-sync.txt
+++ b/source/reference/partition-based-sync.txt
@@ -1688,6 +1688,6 @@ instruction.
 .. note::
 
    :ref:`Partition Based Sync <partition-based-sync>` uses backend compaction
-   to reduce Device Sync history stored in Atlas,
-   whereas Flexible Sync uses :ref:`trimming <trimming>` and 
+   to reduce Device Sync history stored in Atlas.
+   Flexible Sync achieves this with :ref:`trimming <trimming>` and 
    :ref:`client maximum offline time <client-maximum-offline-time>`.

--- a/source/reference/partition-based-sync.txt
+++ b/source/reference/partition-based-sync.txt
@@ -1657,8 +1657,8 @@ Backend Compaction
 ------------------
 
 **Backend compaction** is a maintenance process that automatically
-runs for all apps using :ref:`Partition Based Sync <partition-based-sync>`.
-Apps using Partition Based Sync store the entire history of data changes.
+runs for all apps using Partition-Based Sync.
+Apps using Partition-Based Sync store the entire history of data changes.
 Using compaction, the backend optimizes a
 realm's history by removing unneeded changesets. The process
 removes any instruction whose effect is later overwritten by a newer
@@ -1685,8 +1685,9 @@ instruction.
       CREATE table1.object1
       UPDATE table1.object1.x = 42
 
-.. note:: 
-   
-   :ref:`Partition Based Sync <partition-based-sync>` uses backend compaction rather 
-   than :ref:`trimming <trimming>` and 
+.. note::
+
+   :ref:`Partition Based Sync <partition-based-sync>` uses backend compaction
+   to reduce Device Sync history stored in Atlas,
+   whereas Flexible Sync uses :ref:`trimming <trimming>` and 
    :ref:`client maximum offline time <client-maximum-offline-time>`.

--- a/source/reference/partition-based-sync.txt
+++ b/source/reference/partition-based-sync.txt
@@ -1656,11 +1656,16 @@ documentation.
 Backend Compaction
 ------------------
 
-**Backend compaction** is a maintenance process that automatically
-runs for all apps using Partition-Based Sync.
-Apps using Partition-Based Sync store the entire history of data changes.
+Atlas Device Sync uses space in your app's synced Atlas cluster to store metadata
+for synchronization. This includes a history of changes to each realm.
+Atlas App Services minimizes this space usage in your Atlas cluster.
+Minimizing metadata is necessary to reduce the time and data needed for sync.
+
+Apps using Partition-Based Sync perform **backend compaction** to reduce the amount
+of metadata stored in an Atlas Cluster. Backend compaction is an  maintenance process
+that automatically runs for all Apps using Partition-Based Sync.
 Using compaction, the backend optimizes a
-realm's history by removing unneeded changesets. The process
+realm's history by removing unneeded changeset metadata. The process
 removes any instruction whose effect is later overwritten by a newer
 instruction.
 

--- a/source/sync/go-to-production/optimize-sync-atlas-usage.txt
+++ b/source/sync/go-to-production/optimize-sync-atlas-usage.txt
@@ -21,7 +21,7 @@ Overview
 Atlas Device Sync uses space in your app's synced Atlas cluster to store 
 metadata for sync. This includes a history of changes to each realm. 
 Atlas App Services minimizes this space usage in your Atlas cluster via 
-:ref:`trimming <trimming>` for Flexible Sync apps.
+:ref:`trimming <trimming>` for Apps using Flexible Sync.
 Minimizing metadata is necessary to reduce the time and data needed for sync.
 
 .. _sync-history:
@@ -38,16 +38,17 @@ App Services stores history in your synced Atlas cluster.
 .. _trimming:
 
 Trimming
-~~~~~~~~
+--------
 
 When you set a client maximum offline time in an App that uses :ref:`Flexible
 Sync <flexible-sync>`, **trimming** deletes changes older than the client
-maximum offline time. 
+maximum offline time.
 
 .. note::
 
-   Flexible Sync uses :ref:`trimming <trimming>` instead of 
-   :ref:`backend compaction <backend-compaction>`.
+   Flexible Sync uses :ref:`trimming <trimming>` to reduce Device Sync history
+   stored in Atlas, whereas Partition-Based Sync uses :ref:`backend compaction
+   <backend-compaction>`.
 
 .. _client-maximum-offline-time:
 
@@ -231,6 +232,11 @@ Summary
 -------
 
 - Device Sync uses space in your synced Atlas cluster to store change history.
-- Trimming reduces the space usage for Flexible Sync apps, but can cause client resets for clients who have not connected to the backend in more than the client maximum offline time (in days).
-- Flexible Sync apps that have disabled a client maximum offline time do not apply trimming, so clients of any age can sync without experiencing a client reset.
-- Adding additional queryable fields to a flexible sync configuration will increase storage consumed on an Atlas Cluster. Using broad queries and selecting fewer fields that support broad queries decreases storage consumed.
+- Trimming reduces the space usage for Flexible Sync apps, but can cause client resets
+  for clients who have not connected to the backend in more than
+  the client maximum offline time (in days).
+- Flexible Sync apps that have disabled a client maximum offline time do not apply trimming,
+  so clients of any age can sync without experiencing a client reset.
+- Adding additional queryable fields to a flexible sync configuration
+  will increase storage consumed on an Atlas Cluster. Using broad queries
+  and selecting fewer fields that support broad queries decreases storage consumed.

--- a/source/sync/go-to-production/optimize-sync-atlas-usage.txt
+++ b/source/sync/go-to-production/optimize-sync-atlas-usage.txt
@@ -21,8 +21,7 @@ Overview
 Atlas Device Sync uses space in your app's synced Atlas cluster to store 
 metadata for sync. This includes a history of changes to each realm. 
 Atlas App Services minimizes this space usage in your Atlas cluster via 
-:ref:`trimming <trimming>` for Flexible Sync apps or 
-:ref:`backend compaction <backend-compaction>` for Partition Based Sync apps.
+:ref:`trimming <trimming>` for Flexible Sync apps.
 Minimizing metadata is necessary to reduce the time and data needed for sync.
 
 .. _sync-history:
@@ -35,15 +34,6 @@ underlying data <changesets>` for each realm, similar to the
 :manual:`MongoDB oplog </core/replica-set-oplog/>`. App Services
 uses this history to synchronize data between the backend and clients.
 App Services stores history in your synced Atlas cluster.
-
-Optimization Methods
---------------------
-
-There are two methods for optimizing utility data synced in your cluster
-depending on whether your App uses Flexible or Partition-Based Sync:
-
-1. **Trimming**: Used for :ref:`Flexible Sync <flexible-sync>` apps.
-#. **Backend Compaction**: Used for :ref:`Partition Based Sync <partition-based-sync>` apps.
 
 .. _trimming:
 
@@ -58,46 +48,6 @@ maximum offline time.
 
    Flexible Sync uses :ref:`trimming <trimming>` instead of 
    :ref:`backend compaction <backend-compaction>`.
-
-.. _backend-compaction:
-
-Backend Compaction
-~~~~~~~~~~~~~~~~~~
-
-**Backend compaction** is a maintenance process that automatically
-runs for all apps using :ref:`Partition Based Sync <partition-based-sync>`.
-Apps using Partition Based Sync store the entire history of data changes.
-Using compaction, the backend optimizes a
-realm's history by removing unneeded changesets. The process
-removes any instruction whose effect is later overwritten by a newer
-instruction.
-
-.. example::
-
-   Consider the following realm history:
-
-   .. code-block::
-      :caption: Original History
-
-      CREATE table1.object1
-      UPDATE table1.object1.x = 4
-      UPDATE table1.object1.x = 10
-      UPDATE table1.object1.x = 42
-
-   The following history would also converge to the same state, but
-   without unneeded interim changes:
-
-   .. code-block::
-      :caption: Compacted History
-
-      CREATE table1.object1
-      UPDATE table1.object1.x = 42
-
-.. note:: 
-   
-   :ref:`Partition Based Sync <partition-based-sync>` uses backend compaction rather 
-   than :ref:`trimming <trimming>` and 
-   :ref:`client maximum offline time <client-maximum-offline-time>`.
 
 .. _client-maximum-offline-time:
 
@@ -281,7 +231,6 @@ Summary
 -------
 
 - Device Sync uses space in your synced Atlas cluster to store change history.
-- Backend compaction reduces the space usage of this history for Partition Based Sync apps.
 - Trimming reduces the space usage for Flexible Sync apps, but can cause client resets for clients who have not connected to the backend in more than the client maximum offline time (in days).
 - Flexible Sync apps that have disabled a client maximum offline time do not apply trimming, so clients of any age can sync without experiencing a client reset.
 - Adding additional queryable fields to a flexible sync configuration will increase storage consumed on an Atlas Cluster. Using broad queries and selecting fewer fields that support broad queries decreases storage consumed.

--- a/source/sync/go-to-production/optimize-sync-atlas-usage.txt
+++ b/source/sync/go-to-production/optimize-sync-atlas-usage.txt
@@ -18,10 +18,9 @@ Optimize Sync Atlas Usage
 Overview
 --------
 
-Atlas Device Sync uses space in your app's synced Atlas cluster to store 
-metadata for sync. This includes a history of changes to each realm. 
-Atlas App Services minimizes this space usage in your Atlas cluster via 
-:ref:`trimming <trimming>` for Apps using Flexible Sync.
+Atlas Device Sync uses space in your app's synced Atlas cluster to store
+metadata for sync. This includes a history of changes to each realm.
+Atlas App Services minimizes this space usage in your Atlas cluster.
 Minimizing metadata is necessary to reduce the time and data needed for sync.
 
 .. _sync-history:

--- a/source/sync/go-to-production/optimize-sync-atlas-usage.txt
+++ b/source/sync/go-to-production/optimize-sync-atlas-usage.txt
@@ -47,7 +47,7 @@ maximum offline time.
 .. note::
 
    Flexible Sync uses :ref:`trimming <trimming>` to reduce Device Sync history
-   stored in Atlas, whereas Partition-Based Sync uses :ref:`backend compaction
+   stored in Atlas. Partition-Based Sync uses :ref:`backend compaction
    <backend-compaction>`.
 
 .. _client-maximum-offline-time:


### PR DESCRIPTION
## Pull Request Info

Split up the sync optimization page into flexible sync and partition sync. keep flexible sync content on current page, and move partition-based content to the partition based sync page in reference docs.

### Jira

- https://jira.mongodb.org/browse/DOCSP-27737

### Staged Changes

- [Optimize Sync Atlas Usage](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-27737/sync/go-to-production/optimize-sync-atlas-usage/)
- [Partition-Based Sync](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-27737/reference/partition-based-sync/)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
