### PR TITLE
Add Flutter link to Re-Enable Sync section

### DIFF
--- a/source/sync/configure/pause-or-terminate-sync.txt
+++ b/source/sync/configure/pause-or-terminate-sync.txt
@@ -243,29 +243,10 @@ To re-enable Device Sync, follow the steps in the :ref:`enable-sync` guide.
 If you are re-enabling Device Sync after you have terminated it, you must 
 perform a client reset in your client applications:
 
-.. tabs-realm-sdks::
-
-   .. tab::
-      :tabid: android
-
-      Learn how to perform a :ref:`Client Reset using the Java SDK <java-client-resets>`.
-
-   .. tab::
-      :tabid: ios
-
-      Learn how to perform a :ref:`Client Reset using the Swift SDK <ios-client-resets>`.
-
-   .. tab::
-      :tabid: node
-      
-      Learn how to perform a :ref:`Client Reset using the Node SDK <node-client-resets>`.
-
-   .. tab::
-      :tabid: react-native
-
-      Learn how to perform a :ref:`Client Reset using the React Native SDK <react-native-client-resets>`.
-
-   .. tab::
-      :tabid: dotnet
-
-      Learn how to perform a :ref:`Client Reset using the .NET SDK <dotnet-client-resets>`.
+- :ref:`Perform a client reset - Flutter SDK <flutter-client-reset>`
+- :ref:`Perform a client reset - Java SDK <java-client-resets>`
+- :ref:`Perform a client reset - .NET SDK <dotnet-client-resets>`
+- :ref:`Perform a client reset - Node SDK <node-client-resets>`
+- :ref:`Perform a client reset - React Native SDK <react-native-client-resets>`
+- :ref:`Perform a client reset - Swift SDK <ios-client-resets>`
+ 


### PR DESCRIPTION
## Pull Request Info

No Jira 
- Add Flutter link to Re-Enable Sync section per [forum post](https://www.mongodb.com/community/forums/t/request-for-modifying-documentation-for-client-reset-logic-termination-of-sync/220200/2?u=dave_nielsen)
- Convert tabs to bullet list

### Staged Changes

- [Pause or Terminate Sync](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/no-jira-add-flutter-sync-link/sync/configure/pause-or-terminate-sync/#re-enable-sync)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
