### PR TITLE
(DOCSP-29192): SwiftUI Tutorial: Fix outdated realmApp naming

### DIFF
--- a/source/tutorial/swiftui.txt
+++ b/source/tutorial/swiftui.txt
@@ -161,9 +161,9 @@ Explore the Template App
              from the ``Realm.plist``. This is pre-populated with the 
              ``appId`` for your Template App.
 
-         * - ``realmApp.swift``
+         * - ``App.swift``
            - This file uses the values from ``AppConfig.swift`` to initialize
-             the ``realmApp``. The ``realmApp`` is how your app communicates 
+             the ``RealmSwift.App``. The ``App`` is how your app communicates 
              with the App Services backend. This provides access to login and 
              authentication. This file also contains the error handler that 
              listens for Device Sync errors.
@@ -172,7 +172,7 @@ Explore the Template App
              see: :ref:`Connect to an Atlas App Services Backend <ios-init-appclient>`.
 
              This file is also the entrypoint to the SwiftUI app. We pass the 
-             ``realmApp`` to the ``ContentView`` that observes the app state 
+             ``App`` to the ``ContentView`` that observes the app state 
              for user authentication state.
 
       In this tutorial, you'll be working in the following files:


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-29192

### Staged Changes

- [SwiftUI Tutorial](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-29192/tutorial/swiftui/)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
