### PR TITLE
(DOCSP-28262): Email/Password Authentication Typo fix

### DIFF
--- a/source/authentication/email-password.txt
+++ b/source/authentication/email-password.txt
@@ -418,7 +418,7 @@ in more detail below:
 
 .. warning::
 
-   The a Realm SDK function ``callResetPasswordFunction()`` is **not**
+   The Realm SDK function ``callResetPasswordFunction()`` is **not**
    authenticated. Its password recovery is intended only for users who
    cannot otherwise log into their account. As a result, you cannot associate
    any call to this function with a specific App Services user. Returning a


### PR DESCRIPTION
## Pull Request Info

While working on the linked Jira ticket for the Kotlin SDK, I noticed this typo.

### Jira

- https://jira.mongodb.org/browse/DOCSP-28262

### Staged Changes

- [Email/Password Authentication](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-28262/authentication/email-password/)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [ ] Create Jira ticket for corresponding docs-realm update(s), if any
- [ ] Checked/updated Admin API
- [ ] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
