### PR TITLE
(DOCSP-29586) Add links to API Key docs to show how to create user API keys

### DIFF
--- a/source/authentication/api-key.txt
+++ b/source/authentication/api-key.txt
@@ -184,7 +184,12 @@ Realm SDK Examples
 ------------------
 
 For code examples that demonstrate how to register and log in using
-API Key authentication, see the documentation for the Realm SDKs:
+API Key authentication, see the documentation for the Realm SDKs.
+
+Log In With an API Key
+~~~~~~~~~~~~~~~~~~~~~~
+
+The Realm SDK can log in with an existing server or user API key.
 
 - :ref:`C++ SDK <cpp-login-api-key>`
 - :ref:`Flutter SDK <flutter-login-api-key>`
@@ -195,3 +200,18 @@ API Key authentication, see the documentation for the Realm SDKs:
 - :ref:`React Native SDK <react-native-login-api-key>`
 - :ref:`Swift SDK <ios-login-api-key>`
 - :ref:`Web SDK <web-login-api-key>`
+
+Create a User API Key
+~~~~~~~~~~~~~~~~~~~~~
+
+The Realm SDK can create a new user API key for an existing user account.
+
+- :ref:`Flutter SDK <flutter-login-api-key>`
+- :ref:`Java SDK <java-manage-user-api-keys>`
+- :ref:`Kotlin SDK <kotlin-manage-user-api-keys>`
+- :ref:`.NET SDK <dotnet-manage-user-api-keys>`
+- :ref:`Node SDK <node-manage-user-api-keys>`
+- :ref:`React Native SDK <react-native-manage-user-api-keys>`
+- :ref:`Swift SDK <ios-manage-user-api-keys>`
+- :ref:`Web SDK <web-create-manage-api-keys>`
+- *Not yet available for the C++ SDK*


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-29586) Add links to API Key docs to show how to create user API keys

### Staged Changes

- [API Key Authentication > Realm SDK Examples](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/api-key-sdk/authentication/api-key/#realm-sdk-examples)
