### PR TITLE
DOP-3584: add redirect for weird App Services-with-spaces URL

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -258,3 +258,6 @@ raw: ${prefix}/sync/configure/permissions -> ${base}/rules/roles/
 
 ## (DOCSP-28344): Update Option for CLI Push (hide CLI V1 reference page from TOC)
 raw: ${prefix}/cli/realm-cli-reference-v1 -> ${base}/cli/realm-cli-reference-v1/index/
+
+## (DOP-3584): Redirect weird URL that doesn't exist
+raw: docs/atlas/app-servicesAtlas%20App%20Services -> ${base}/


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOP-3584

###
Output once transmogrified with mut-redirects:

```
Redirect 301 /docs/atlas/app-servicesAtlas%20App%20Services https://www.mongodb.com/docs/atlas/app-services/
```