### PR TITLE
(DOCSP-29672) JWT exp does not control refresh token expiration

### DIFF
--- a/source/authentication/custom-jwt.txt
+++ b/source/authentication/custom-jwt.txt
@@ -888,12 +888,15 @@ table explains each field and the value expected:
      - <your name>
    
    * - ``iat``
-     - "Issued At" is a Unix epoch timestamp of when the token was issued. 
-     - The current date-time in seconds since Unix epoch. 
+     - "Issued At" is a Unix epoch timestamp of when the token was issued.
+     - The current date-time in seconds since Unix epoch.
    
    * - ``exp``
-     - The date-time when this token will expire. 
-     - A future date-time (in seconds since Unix epoch) for when you want the token to expire. Depending on your business needs, this can be any duration.
+     - The date-time when this token expires.
+     - A specific time defined in seconds since January 1, 1970 (i.e.
+       the Unix epoch). Before this time the JWT is valid. After this
+       time, the JWT is expired. The Custom JWT provider rejects any
+       login attempt that includes an expired JWT.
    
    * - ``aud``
      - The audience (consumer) of the token.

--- a/source/authentication/custom-jwt.txt
+++ b/source/authentication/custom-jwt.txt
@@ -894,7 +894,7 @@ table explains each field and the value expected:
    * - ``exp``
      - The date-time when this token expires.
      - A specific time defined in seconds since January 1, 1970 (i.e.
-       the Unix epoch). Before this time the JWT is valid. After this
+       the Unix epoch). Before this time, the JWT is valid. After this
        time, the JWT is expired. The Custom JWT provider rejects any
        login attempt that includes an expired JWT.
    

--- a/source/users/sessions.txt
+++ b/source/users/sessions.txt
@@ -312,8 +312,9 @@ By default, refresh tokens expire 60 days after they are issued. You can
 configure this time for your App's refresh tokens to be anywhere between
 30 minutes and 180 days.
 
-Anonymous user refresh tokens do not expire. However, Anonymous user
-accounts are automatically deleted after 90 days of inactivity.
+Anonymous user refresh tokens have a long expiration time and
+effectively do not expire. Instead, Anonymous user accounts are
+automatically deleted 90 days after they are created.
 
 You can configure the refresh token expiration time for all sessions in
 an App from the Admin UI or Admin API.

--- a/source/users/sessions.txt
+++ b/source/users/sessions.txt
@@ -310,13 +310,10 @@ Configure Refresh Token Expiration
 
 By default, refresh tokens expire 60 days after they are issued. You can
 configure this time for your App's refresh tokens to be anywhere between
-30 minutes and 180 days. There are two exceptions:
+30 minutes and 180 days.
 
-- Anonymous user refresh tokens do not expire, though anonymous user
-  accounts are deleted after 90 days of inactivity.
-
-- Custom JWT refresh token expiration is determined by the ``exp`` value
-  of the user's JWT.
+Anonymous user refresh tokens do not expire. However, Anonymous user
+accounts are automatically deleted after 90 days of inactivity.
 
 You can configure the refresh token expiration time for all sessions in
 an App from the Admin UI or Admin API.


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-29672) JWT exp does not control refresh token expiration

### Staged Changes

- [Authenticate & Manage Users > Manage User Sessions](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/jwt-exp/users/sessions/)
- [Authenticate & Manage Users > Custom JWT Auth](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/jwt-exp/authentication/custom-jwt/)
