### PR TITLE
(DOCSP-29278) Tested Endpoint Authentication Examples

### DIFF
--- a/examples/data-api/backend/data_sources/mongodb-atlas/default_rule.json
+++ b/examples/data-api/backend/data_sources/mongodb-atlas/default_rule.json
@@ -1,1 +1,15 @@
-{"roles":[{"name":"readAndWriteAll","apply_when":{},"document_filters":{"write":true,"read":true},"read":true,"write":true,"insert":true,"delete":true,"search":true}],"filters":[]}
+{
+  "roles": [
+    {
+      "name": "readAndWriteAll",
+      "apply_when": {},
+      "document_filters": { "write": true, "read": true },
+      "read": true,
+      "write": true,
+      "insert": true,
+      "delete": true,
+      "search": true
+    }
+  ],
+  "filters": []
+}

--- a/examples/data-api/backend/http_endpoints/data_api_config.json
+++ b/examples/data-api/backend/http_endpoints/data_api_config.json
@@ -8,6 +8,6 @@
   "validation_method": "",
   "secret_name": "",
   "fetch_custom_user_data": false,
-  "create_user_on_auth": false,
+  "create_user_on_auth": true,
   "return_type": "EJSON"
 }

--- a/examples/data-api/custom-endpoints.sh
+++ b/examples/data-api/custom-endpoints.sh
@@ -16,13 +16,7 @@ oneTimeSetUp() {
   PASSWORD="Passw0rd!"
   create_email_password_user "$app_name" "$USERNAME" "$PASSWORD"
   API_KEY=$(create_api_key_user "$app_name" "$USERNAME")
-  JWT=$(
-    npx -y jsonwebtokencli@latest \
-      --encode \
-      --algorithm HS256 \
-      --secret "7A4VvateM9s86tbkfisoLoChjGBjuJnZ" \
-      "{\"aud\":\"$CLIENT_APP_ID\",\"sub\":\"1234567890\",\"name\":\"John Doe\",\"exp\":2145916800,\"iat\":1516239022}"
-  )
+  JWT=$(create_jwt "$app_name" "$USERNAME")
 }
 
 oneTimeTearDown() {

--- a/source/data-api/authenticate.txt
+++ b/source/data-api/authenticate.txt
@@ -55,20 +55,9 @@ The Authorization header uses the following format:
 
 For example, the following request uses Bearer Authentication:
 
-.. code-block:: shell
-   :emphasize-lines: 2
-
-   curl -X POST 'https://data.mongodb-api.com/app/<AppID>/endpoint/data/v1/action/find' \
-      --header 'Authorization: Bearer <AccessToken>' \
-      --header 'Content-Type: application/json' \
-      --data-raw '{
-        "dataSource": "mongodb-atlas",
-        "database": "sample_mflix",
-        "collection": "movies",
-        "filter": {
-          "title": "The Matrix"
-        }
-      }'
+.. literalinclude:: /data-api/snippets/generated-endpoints.snippet.auth-bearer.sh
+   :language: bash
+   :emphasize-lines: 4
 
 .. include:: /includes/bearer-auth-performance.rst
 
@@ -108,21 +97,9 @@ To authenticate a Data API request as an :ref:`email/password
 <email-password-authentication>` user, include the user's credentials in
 the request's ``email`` and ``password`` headers.
 
-.. code-block:: shell
-   :emphasize-lines: 2-3
-
-   curl -X POST 'https://data.mongodb-api.com/app/<AppID>/endpoint/data/v1/action/find' \
-      --header 'email: <EmailAddress>' \
-      --header 'password: <Password>' \
-      --header 'Content-Type: application/json' \
-      --data-raw '{
-        "dataSource": "mongodb-atlas",
-        "database": "sample_mflix",
-        "collection": "movies",
-        "filter": {
-          "title": "The Matrix"
-        }
-      }'
+.. literalinclude:: /data-api/snippets/generated-endpoints.snippet.auth-emailPassword.sh
+   :language: bash
+   :emphasize-lines: 4-5
 
 API Key
 ~~~~~~~
@@ -131,20 +108,9 @@ To authenticate a Data API request with an :ref:`API Key
 <api-key-authentication>`, include the API key in the request's
 ``apiKey`` header.
 
-.. code-block:: shell
-   :emphasize-lines: 2
-
-   curl -X POST 'https://data.mongodb-api.com/app/<AppID>/endpoint/data/v1/action/find' \
-      --header 'apiKey: <APIKey>' \
-      --header 'Content-Type: application/json' \
-      --data-raw '{
-        "dataSource": "mongodb-atlas",
-        "database": "sample_mflix",
-        "collection": "movies",
-        "filter": {
-          "title": "The Matrix"
-        }
-      }'
+.. literalinclude:: /data-api/snippets/generated-endpoints.snippet.auth-apiKey.sh
+   :language: bash
+   :emphasize-lines: 4
 
 .. include:: /includes/dont-use-api-key-in-browsers.rst
 
@@ -155,17 +121,6 @@ To authenticate a Data API request as a :ref:`Custom JWT
 <custom-jwt-authentication>` user, include the JWT string in the
 request's ``jwtTokenString`` header.
 
-.. code-block:: shell
-   :emphasize-lines: 2
-
-   curl -X POST 'https://data.mongodb-api.com/app/<AppID>/endpoint/data/v1/action/find' \
-      --header 'jwtTokenString: <JWT>' \
-      --header 'Content-Type: application/json' \
-      --data-raw '{
-        "dataSource": "mongodb-atlas",
-        "database": "sample_mflix",
-        "collection": "movies",
-        "filter": {
-          "title": "The Matrix"
-        }
-      }'
+.. literalinclude:: /data-api/snippets/generated-endpoints.snippet.auth-jwtTokenString.sh
+   :language: bash
+   :emphasize-lines: 4

--- a/source/data-api/generated-endpoints.txt
+++ b/source/data-api/generated-endpoints.txt
@@ -561,20 +561,9 @@ using a Bearer token scheme. For more information on how to acquire and
 use an access token, see :ref:`Bearer Token Authentication
 <data-api-bearer-authentication>`.
 
-.. code-block:: shell
-   :emphasize-lines: 2
-
-   curl -X POST 'https://data.mongodb-api.com/app/<AppID>/endpoint/data/v1/action/find' \
-      --header 'Authorization: Bearer <AccessToken>' \
-      --header 'Content-Type: application/json' \
-      --data-raw '{
-        "dataSource": "mongodb-atlas",
-        "database": "sample_mflix",
-        "collection": "movies",
-        "filter": {
-          "title": "The Matrix"
-        }
-      }'
+.. literalinclude:: /data-api/snippets/generated-endpoints.snippet.auth-bearer.sh
+   :language: bash
+   :emphasize-lines: 4
 
 Alternatively, you can include valid login credentials for the user in
 the request headers.
@@ -584,51 +573,23 @@ the request headers.
    .. tab::
       :tabid: local-userpass
 
-      .. code-block:: bash
-         :emphasize-lines: 3-4
-         
-         curl -X POST \
-           https://data.mongodb-api.com/app/myapp-abcde/endpoint/data/v1/action/findOne \
-           -H 'email: <Email Address>' \
-           -H 'password: <Password>' \
-           -H 'Content-Type: application/json' \
-           --data-raw '{
-             "dataSource": "mongodb-atlas",
-             "database": "learn-data-api",
-             "collection": "hello",
-           }'
+      .. literalinclude:: /data-api/snippets/generated-endpoints.snippet.auth-emailPassword.sh
+         :language: bash
+         :emphasize-lines: 4-5
    
    .. tab::
       :tabid: api-key
 
-      .. code-block:: bash
-         :emphasize-lines: 3
-         
-         curl -X POST \
-           https://data.mongodb-api.com/app/myapp-abcde/endpoint/data/v1/action/findOne \
-           -H 'apiKey: <API Key>' \
-           -H 'Content-Type: application/json' \
-           --data-raw '{
-             "dataSource": "mongodb-atlas",
-             "database": "learn-data-api",
-             "collection": "hello",
-           }'
+      .. literalinclude:: /data-api/snippets/generated-endpoints.snippet.auth-apiKey.sh
+         :language: bash
+         :emphasize-lines: 4
    
    .. tab::
       :tabid: custom-token
 
-      .. code-block:: bash
-         :emphasize-lines: 3
-         
-         curl -X POST \
-           https://data.mongodb-api.com/app/myapp-abcde/endpoint/data/v1/action/findOne \
-           -H 'jwtTokenString: <Custom JSON Web Token>' \
-           -H 'Content-Type: application/json' \
-           --data-raw '{
-             "dataSource": "mongodb-atlas",
-             "database": "learn-data-api",
-             "collection": "hello",
-           }'
+      .. literalinclude:: /data-api/snippets/generated-endpoints.snippet.auth-jwtTokenString.sh
+         :language: bash
+         :emphasize-lines: 4
 
 .. include:: /includes/dont-use-api-key-in-browsers.rst
 

--- a/source/data-api/snippets/generated-endpoints.snippet.auth-apiKey.sh
+++ b/source/data-api/snippets/generated-endpoints.snippet.auth-apiKey.sh
@@ -1,0 +1,12 @@
+curl -s "https://data.mongodb-api.com/app/myapp-abcde/endpoint/data/v1/action/findOne" \
+  -X POST \
+  -H "Accept: application/json" \
+  -H "apiKey: TpqAKQgvhZE4r6AOzpVydJ9a3tB1BLMrgDzLlBLbihKNDzSJWTAHMVbsMoIOpnM6" \
+  -d '{
+    "dataSource": "mongodb-atlas",
+    "database": "sample_mflix",
+    "collection": "movies",
+    "filter": {
+      "title": "The Matrix"
+    }
+  }'

--- a/source/data-api/snippets/generated-endpoints.snippet.auth-bearer.sh
+++ b/source/data-api/snippets/generated-endpoints.snippet.auth-bearer.sh
@@ -1,0 +1,12 @@
+curl -s "https://data.mongodb-api.com/app/myapp-abcde/endpoint/data/v1/action/findOne" \
+  -X POST \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -d '{
+    "dataSource": "mongodb-atlas",
+    "database": "sample_mflix",
+    "collection": "movies",
+    "filter": {
+      "title": "The Matrix"
+    }
+  }'

--- a/source/data-api/snippets/generated-endpoints.snippet.auth-emailPassword.sh
+++ b/source/data-api/snippets/generated-endpoints.snippet.auth-emailPassword.sh
@@ -1,0 +1,13 @@
+curl -s "https://data.mongodb-api.com/app/myapp-abcde/endpoint/data/v1/action/findOne" \
+  -X POST \
+  -H "Accept: application/json" \
+  -H "email: bob@example" \
+  -H "password: Pa55w0rd!" \
+  -d '{
+    "dataSource": "mongodb-atlas",
+    "database": "sample_mflix",
+    "collection": "movies",
+    "filter": {
+      "title": "The Matrix"
+    }
+  }'

--- a/source/data-api/snippets/generated-endpoints.snippet.auth-jwtTokenString.sh
+++ b/source/data-api/snippets/generated-endpoints.snippet.auth-jwtTokenString.sh
@@ -1,0 +1,12 @@
+curl -s "https://data.mongodb-api.com/app/myapp-abcde/endpoint/data/v1/action/findOne" \
+  -X POST \
+  -H "Accept: application/json" \
+  -H "jwtTokenString: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJteWFwcC1hYmNkZSIsInN1YiI6IjEyMzQ1Njc4OTAiLCJuYW1lIjoiSm9obiBEb2UiLCJleHAiOjIxNDU5MTY4MDB9.E4fSNtYc0t5XCTv3S8W89P9PKLftC4POLRZdN2zOICI" \
+  -d '{
+    "dataSource": "mongodb-atlas",
+    "database": "sample_mflix",
+    "collection": "movies",
+    "filter": {
+      "title": "The Matrix"
+    }
+  }'


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-29278) Tested Endpoint Authentication Examples

### Staged Changes

- [Data API > Generated Endpoints > Authenticate the Request](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/data-api-auth/data-api/generated-endpoints/#std-label-data-api-authenticate)
- [Data API > Authenticate Data API Requests](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/data-api-auth/data-api/authenticate/)
