### PR TITLE
Backend Sync mode migration: SDK support update

### DIFF
--- a/source/sync/migrate-sync-modes.txt
+++ b/source/sync/migrate-sync-modes.txt
@@ -27,8 +27,8 @@ Partition-Based Sync.
 Requirements
 ------------
 
-Currently, the Kotlin SDK supports migrating your App's backend from
-Partition-Based Sync to Flexible Sync. The Java, .NET, Swift, Node.js, and
+Currently, the Swift and Kotlin SDKs support migrating your App's backend from
+Partition-Based Sync to Flexible Sync. The Java, .NET, Node.js, and
 React Native SDKs do not support backend Sync mode migration yet.
 
 App Services App:
@@ -46,10 +46,10 @@ Client apps:
 
 - Minimum SDK version:
 
+  - Realm Swift SDK v10.40.0
   - Realm Kotlin SDK v1.9.0
   
 .. TODO: Update and add these as SDKs release.
-..   - Realm Swift SDK v10.39.0
 ..   - Realm .NET SDK v11.0.0
 ..   - Realm Node.js SDK v11.9.0
 ..   - Realm React Native SDK v11.9.0


### PR DESCRIPTION
## Pull Request Info

At launch, not all of the Realm client SDKs support backend Sync mode migration.
As they create releases that do support the feature, I'm adding them to the list of supported SDKs.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
