### PR TITLE
(DOCSP-30142): Tiered Device Sync: Use the 'latest' URL in distribution details

### DIFF
--- a/source/includes/important-stop-tiered-sync-server.rst
+++ b/source/includes/important-stop-tiered-sync-server.rst
@@ -3,5 +3,5 @@
    After you start the Tiered Sync server, it connects to the App Services App
    every few minutes to check for updates, even when no client application is
    connected. If you are running a demo or otherwise working on a PoC, remember
-   to stop the Tiered Sync server using ``make stop`` when you're done using it. 
+   to stop the Tiered Sync server using ``make down`` when you're done using it. 
    Otherwise, you'll continue using the host's compute and Device Sync time.

--- a/source/sync/app-builder/tiered-device-sync/index.txt
+++ b/source/sync/app-builder/tiered-device-sync/index.txt
@@ -113,7 +113,7 @@ Set up and run the Tiered Sync server on the host.
 
    .. step:: Get the Tiered Sync Server Code
 
-      Use ``wget`` to get the latest Tiered Sync server code as a ``.tar`` file:
+      Use ``wget`` to get the current Tiered Sync server code as a ``.tar`` file:
 
       .. code-block:: shell
 

--- a/source/sync/app-builder/tiered-device-sync/index.txt
+++ b/source/sync/app-builder/tiered-device-sync/index.txt
@@ -113,11 +113,11 @@ Set up and run the Tiered Sync server on the host.
 
    .. step:: Get the Tiered Sync Server Code
 
-      Use ``wget`` to get the Tiered Sync server code:
+      Use ``wget`` to get the latest Tiered Sync server code as a ``.tar`` file:
 
       .. code-block:: shell
 
-         wget https://tiered-sync-package.s3.amazonaws.com/4b4e891e5990189d214d74b788ac1d2a761a08ae-tiered_sync.tgz
+         wget https://realm.mongodb.com/api/client/v2.0/tiered-sync/package/latest
 
       Unzip the tar to get the files.
 

--- a/source/sync/app-builder/tiered-device-sync/index.txt
+++ b/source/sync/app-builder/tiered-device-sync/index.txt
@@ -117,7 +117,7 @@ Set up and run the Tiered Sync server on the host.
 
       .. code-block:: shell
 
-         wget https://realm.mongodb.com/api/client/v2.0/tiered-sync/package/latest
+         wget --content-disposition https://realm.mongodb.com/api/client/v2.0/tiered-sync/package/latest
 
       Unzip the tar to get the files.
 


### PR DESCRIPTION
## Pull Request Info

DO NOT MERGE until this release lands, currently scheduled for June 7.

### Jira

- https://jira.mongodb.org/browse/DOCSP-30142

### Staged Changes

- [Tiered Device Sync Guide](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-30142/sync/app-builder/tiered-device-sync/index/#get-the-tiered-sync-server-code)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
