### PR TITLE
Backend Sync mode migration: Java SDK support

### DIFF
--- a/source/sync/migrate-sync-modes.txt
+++ b/source/sync/migrate-sync-modes.txt
@@ -27,8 +27,8 @@ Partition-Based Sync.
 Requirements
 ------------
 
-Currently, the Swift and Kotlin client SDKs support migrating your App's backend from
-Partition-Based Sync to Flexible Sync. The Java, .NET, Node.js, and
+Currently, the Swift, Kotlin, and Java client SDKs support migrating your App's
+backend from Partition-Based Sync to Flexible Sync. The .NET, Node.js, and
 React Native SDKs do not support backend Sync mode migration yet.
 
 App Services App:
@@ -48,6 +48,7 @@ Client apps:
 
   - Realm Swift SDK v10.40.0
   - Realm Kotlin SDK v1.9.0
+  - Realm Java SDK 10.16.0
   
 .. TODO: Update and add these as SDKs release.
 ..   - Realm .NET SDK v11.0.0


### PR DESCRIPTION
## Pull Request Info

The Java client SDK now supports backend Sync mode migration.

[Migrate Device Sync Modes](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/sync-migration-java/sync/migrate-sync-modes/#requirements)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
