### PR TITLE
(DOCSP-29752): C++: Omit Alpha naming references

### DIFF
--- a/source/authentication/custom-function.txt
+++ b/source/authentication/custom-function.txt
@@ -379,7 +379,7 @@ that contains your login payload data.
 
 For examples, refer to the documentation for a specific SDK:
 
-- :ref:`C++ SDK (Alpha) <cpp-login-custom-function>`
+- :ref:`C++ SDK (Beta) <cpp-login-custom-function>`
 - :ref:`Flutter SDK <flutter-login-custom-function>`
 - :ref:`Java SDK <java-login-custom-function>`
 - :ref:`Kotlin SDK <kotlin-login-custom-function>`

--- a/source/authentication/custom-function.txt
+++ b/source/authentication/custom-function.txt
@@ -379,7 +379,7 @@ that contains your login payload data.
 
 For examples, refer to the documentation for a specific SDK:
 
-- :ref:`C++ SDK (Beta) <cpp-login-custom-function>`
+- :ref:`C++ SDK <cpp-login-custom-function>`
 - :ref:`Flutter SDK <flutter-login-custom-function>`
 - :ref:`Java SDK <java-login-custom-function>`
 - :ref:`Kotlin SDK <kotlin-login-custom-function>`

--- a/source/sync/get-started.txt
+++ b/source/sync/get-started.txt
@@ -53,7 +53,7 @@ This guide focuses on configuring sync with an SDK. For in-depth documentation
 that includes details on how to install and use the Realm SDKs more generally,
 check out the SDK docs:
 
-- :ref:`C++ SDK (Beta) <cpp-intro>`
+- :ref:`C++ SDK <cpp-intro>`
 - :ref:`Flutter SDK <flutter-intro>`
 - :ref:`Java SDK <java-intro>`
 - :ref:`Kotlin SDK <kotlin-intro>`

--- a/source/sync/get-started.txt
+++ b/source/sync/get-started.txt
@@ -53,7 +53,7 @@ This guide focuses on configuring sync with an SDK. For in-depth documentation
 that includes details on how to install and use the Realm SDKs more generally,
 check out the SDK docs:
 
-- :ref:`C++ SDK (Alpha) <cpp-intro>`
+- :ref:`C++ SDK (Beta) <cpp-intro>`
 - :ref:`Flutter SDK <flutter-intro>`
 - :ref:`Java SDK <java-intro>`
 - :ref:`Kotlin SDK <kotlin-intro>`


### PR DESCRIPTION
## Pull Request Info

Note for reviewer: I was initially going to update the naming from Alpha to Beta for the upcoming release, but we mostly omit the alpha/beta verbiage here in App Services, so I opted to remove it entirely, instead, for consistency and reduced maintenance overhead. In that case, there's no need to wait to merge this.

### Jira

- https://jira.mongodb.org/browse/DOCSP-29752

### Staged Changes

- [Custom Function Authentication](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-29752/authentication/custom-function/)
- [Sync/Get Started](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-29752/sync/get-started/)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
