### PR TITLE
(DOCSP-29754) [GraphQL] Some schema title conflicts can be safely ignored

### DIFF
--- a/source/graphql.txt
+++ b/source/graphql.txt
@@ -216,6 +216,16 @@ Limitations
   {+max-graphql-relationship-depth+} resolvers, the entire operation
   fails with the error message ``"max relationship depth exceeded"``.
 
+- The GraphQL API expects collection schemas to have unique titles and
+  raises a warning if your data model contains duplicate titles.
+
+  You can safely ignore this warning if:
+
+  - The title conflicts only involve embedded objects.
+
+  - Every schema with a given title uses an identical definition,
+    including relationships.
+
 - The GraphQL API does not currently support relationships for fields
   inside arrays of embedded objects. You can use a :ref:`custom resolver
   <graphql-custom-resolvers>` to manually look up and resolve embedded


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-29754) [GraphQL] Some schema title conflicts can be safely ignored

### Staged Changes

- [GraphQL API > Limitations](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/gql-titles/graphql/#limitations)
