### PR TITLE
 Backend Sync mode migration: Realm.js support 

### DIFF
--- a/source/sync/migrate-sync-modes.txt
+++ b/source/sync/migrate-sync-modes.txt
@@ -27,9 +27,8 @@ Partition-Based Sync.
 Requirements
 ------------
 
-Currently, the Swift, Kotlin, and Java client SDKs support migrating your App's
-backend from Partition-Based Sync to Flexible Sync. The .NET, Node.js, and
-React Native SDKs do not support backend Sync mode migration yet.
+The .NET SDK does not support backend Sync mode migration yet. This feature does
+not apply to clients that use the C++, Flutter, and Web SDKs.
 
 App Services App:
 
@@ -48,12 +47,12 @@ Client apps:
 
   - Realm Swift SDK v10.40.0
   - Realm Kotlin SDK v1.9.0
+  - Realm Node.js SDK v11.10.0
+  - Realm React Native SDK v11.10.0
   - Realm Java SDK 10.16.0
   
 .. TODO: Update and add these as SDKs release.
 ..   - Realm .NET SDK v11.0.0
-..   - Realm Node.js SDK v11.9.0
-..   - Realm React Native SDK v11.9.0
 
 - Have a :ref:`Client Reset Handler <client-resets>` configured.
 

--- a/source/sync/migrate-sync-modes.txt
+++ b/source/sync/migrate-sync-modes.txt
@@ -27,8 +27,7 @@ Partition-Based Sync.
 Requirements
 ------------
 
-The .NET SDK does not support backend Sync mode migration yet. This feature does
-not apply to clients that use the C++, Flutter, or Web SDKs.
+The .NET SDK does not support backend Sync mode migration yet.
 
 App Services App:
 

--- a/source/sync/migrate-sync-modes.txt
+++ b/source/sync/migrate-sync-modes.txt
@@ -28,7 +28,7 @@ Requirements
 ------------
 
 The .NET SDK does not support backend Sync mode migration yet. This feature does
-not apply to clients that use the C++, Flutter, and Web SDKs.
+not apply to clients that use the C++, Flutter, or Web SDKs.
 
 App Services App:
 


### PR DESCRIPTION
## Pull Request Info

The React Native and Node.js SDKs now support backend Sync mode migration.

- [Migrate Device Sync Modes](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/sync-migration-js/sync/migrate-sync-modes/#requirements)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)

### Animal Wearing a Hat

<img src="https://pbs.twimg.com/media/EfVyLHPXkAAkIcM?format=jpg&name=medium" width=400>