### PR TITLE
(DOCSP-34067) DB Trigger example has incorrect variable

### DIFF
--- a/source/triggers/database-triggers.txt
+++ b/source/triggers/database-triggers.txt
@@ -567,7 +567,7 @@ a text message to the customer with the new location of the order.
        const customers = mongodb.db("store").collection("customers");
 
        const { location } = shippingLocation.pop();
-       const customer = await customers.findOne({ _id: customer_id })
+       const customer = await customers.findOne({ _id: customerId })
        twilio.send({
          to: customer.phoneNumber,
          from: context.values.get("ourPhoneNumber"),


### PR DESCRIPTION
## Pull Request Info

On this page, in the example, I believe the line with the code referencing `await customers.findOne({_id: customer_id})` should be:
`await customers.findOne({_id: customerId })` 

### Jira

- https://jira.mongodb.org/browse/DOCSP-30467

### Staged Changes

- [Database Triggers](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-30467/triggers/database-triggers/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
