### PR TITLE
(DOCSP-31237): Warn users that nested functions are not allowed with auto GH deploy

### DIFF
--- a/source/functions.txt
+++ b/source/functions.txt
@@ -231,12 +231,10 @@ or by importing the function configuration and source code with
             :guilabel:`Name` field. This name must be distinct from all other
             functions in the application.
 
-            .. tip::
+            .. important::
 
-               You can define functions inside of nested folders. Function names
-               are slash-separated paths, so a function named ``utils/add`` maps
-               to ``functions/utils/add.js`` in the app's configuration files.
-
+               App Services does not recognize functions inside of nested 
+               folders. Function names *cannot* be slash-separated paths.
 
          .. step:: Configure User Authentication
 
@@ -376,11 +374,11 @@ or by importing the function configuration and source code with
 
                touch functions/myFunction.js
 
-            .. tip::
+            .. important::
 
-               You can define functions inside of nested folders in the
-               ``functions`` directory. Use slashes in a function name to indicate
-               its directory path.
+               All of your function source code files must be in the 
+               ``/functions`` directory. App Services does not recognize 
+               functions nested in subdirectories of ``/functions``.
 
             Once you've created the function's ``.js`` file, write the function source code, e.g.:
 

--- a/source/functions.txt
+++ b/source/functions.txt
@@ -231,10 +231,13 @@ or by importing the function configuration and source code with
             :guilabel:`Name` field. This name must be distinct from all other
             functions in the application.
 
-            .. important::
+            .. tip::
 
-               App Services does not recognize functions inside of nested 
-               folders. Function names *cannot* be slash-separated paths.
+               You can define functions inside of nested folders. Function names
+               are slash-separated paths, so a function named ``utils/add`` maps
+               to ``functions/utils/add.js`` in the app's configuration files.
+               Nested functions are *not* currently supported if you are using GitHub deployment.
+
 
          .. step:: Configure User Authentication
 
@@ -374,11 +377,12 @@ or by importing the function configuration and source code with
 
                touch functions/myFunction.js
 
-            .. important::
+            .. tip::
 
-               All of your function source code files must be in the 
-               ``/functions`` directory. App Services does not recognize 
-               functions nested in subdirectories of ``/functions``.
+               You can define functions inside of nested folders in the
+               ``functions`` directory. Use slashes in a function name to indicate
+               its directory path.
+               Nested functions are *not* currently supported if you are using GitHub deployment.
 
             Once you've created the function's ``.js`` file, write the function source code, e.g.:
 

--- a/source/reference/config/functions.txt
+++ b/source/reference/config/functions.txt
@@ -110,8 +110,7 @@ the main function that runs whenever a request calls the function.
 .. important::
    
    All of your function source code files must be in the ``/functions``
-   directory. App Services does not recognize functions nested in subdirectories of
-   ``/functions``.
+   directory. 
 
 .. code-block:: javascript
    :caption: /functions/<function name>.js


### PR DESCRIPTION
## Pull Request Info

Update docs to note that App Services does not recognize functions in nested subdirectories when using automatic GitHub deployments until https://jira.mongodb.org/browse/BAAS-13185 is complete

### Jira

- https://jira.mongodb.org/browse/DOCSP-31237

### Staged Changes

- [Functions](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/docsp-31237-nested-fxn/functions/)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
