### PR TITLE
(DOCSP-31382) Extend HTTP/3rd Party Service Deprecation

### DIFF
--- a/source/includes/note-third-party-services-deprecation.rst
+++ b/source/includes/note-third-party-services-deprecation.rst
@@ -8,7 +8,7 @@
    <https-endpoints>` with no change in behavior. You should
    :ref:`migrate <convert-webhooks-to-endpoints>` existing Webhooks.
 
-   Existing services will continue to work until **1 Aug 2023**.
+   Existing services will continue to work until **November 1, 2024**.
 
    Because third party services and push notifications are now deprecated, they have
    been removed by default from the App Services UI. If you need to manage an existing third party
@@ -21,4 +21,3 @@
    - Enable the toggle switch next to 
      :guilabel:`Temporarily Re-Enable 3rd Party Services`, and then save your 
      changes.
-


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-31382) Extend HTTP/3rd Party Service Deprecation

### Staged Changes

- [Third-Party Services [Deprecated]](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/service-deprecation/reference/services/)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [ ] Create Jira ticket for corresponding docs-realm update(s), if any
- [ ] Checked/updated Admin API
- [ ] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
