### PR TITLE
(DOCSP-31492) Private Endpoint Apps won’t connect over public internet

### DIFF
--- a/source/security/private-endpoints.txt
+++ b/source/security/private-endpoints.txt
@@ -1,8 +1,8 @@
 .. _private-endpoints:
 
-==========================
-Use a VPC Private Endpoint
-==========================
+====================================
+Use a VPC Private Endpoint (Preview)
+====================================
 
 .. contents:: On this page
    :depth: 2
@@ -22,6 +22,10 @@ Private Endpoint Limitations
 
 - You cannot use Private Endpoints with globally deployed Apps or local
   Apps deployed to Azure or GCP.
+
+- You cannot use public internet connections to access your App if you
+  have a Private Endpoint enabled. All requests must come through the
+  Private Endpoint.
 
 - If you :ref:`change your deployment model <change-deployment-models>`
   then your existing Private Endpoints will not continue to work. You


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-31492) Private Endpoint Apps won’t connect over public internet

### Staged Changes

- [Use a VPC Private Endpoint (Preview)](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/private-endpoints/security/private-endpoints/)