### PR TITLE
(DOCSP-31122) list minimum supported SDK versions needed for deployment model change

### DIFF
--- a/source/apps/change-deployment-models.txt
+++ b/source/apps/change-deployment-models.txt
@@ -32,12 +32,12 @@ and requests will fail.
 
 The following SDK versions support changing deployment models:
 
-- C++ - 0.2.0 
-- Flutter/Dart - 1.2.0
-- Kotlin - 1.10.0 
-- .NET - 11.1.0 
-- JS - 12.0.0 (pending release)
-- Swift - 10.40.0
+- **C++** - v0.2.0 
+- **Flutter** - 1.2.0
+- **Kotlin** - 1.10.0 
+- **.NET** - 11.1.0 
+- **JavaScript** - 12.0.0 (pending release)
+- **Swift** - 10.40.0
 
 .. todo sync with ENG post https://jira.mongodb.org/browse/RCORE-1346 to determine minimum versions. Until then, users have to talk to support.
 

--- a/source/apps/change-deployment-models.txt
+++ b/source/apps/change-deployment-models.txt
@@ -30,14 +30,15 @@ a version that supports changing deployment models. If you change
 deployment models before upgrading, the SDK will not be able to connect
 and requests will fail.
 
-The following SDK versions support changing deployment models:
+Minimum SDK version: 
 
-- C++ - *0.2.0* 
-- Flutter - *1.2.0*
-- Kotlin - *1.10.0*
-- .NET - *11.1.0*
-- JavaScript - *12.0.0* (pending release)
-- Swift - *10.40.0*
+- Realm C++ SDK v0.2.0
+- Realm Flutter SDK v1.2.0
+- Realm Kotlin SDK v1.10.0
+- Realm .NET SDK v11.1.0
+- Realm Node.js SDK v12.0.0 (pending release)
+- Realm React Native SDK v12.0.0 (pending release)
+- Realm Swift SDK v10.40.0
 
 .. todo sync with ENG post https://jira.mongodb.org/browse/RCORE-1346 to determine minimum versions. Until then, users have to talk to support.
 

--- a/source/apps/change-deployment-models.txt
+++ b/source/apps/change-deployment-models.txt
@@ -32,12 +32,12 @@ and requests will fail.
 
 The following SDK versions support changing deployment models:
 
-- **C++** - v0.2.0 
-- **Flutter** - 1.2.0
-- **Kotlin** - 1.10.0 
-- **.NET** - 11.1.0 
-- **JavaScript** - 12.0.0 (pending release)
-- **Swift** - 10.40.0
+- C++ - *v0.2.0* 
+- Flutter - *v1.2.0*
+- Kotlin - *v1.10.0*
+- .NET - *v11.1.0*
+- JavaScript - *v12.0.0* (pending release)
+- Swift - *v10.40.0*
 
 .. todo sync with ENG post https://jira.mongodb.org/browse/RCORE-1346 to determine minimum versions. Until then, users have to talk to support.
 

--- a/source/apps/change-deployment-models.txt
+++ b/source/apps/change-deployment-models.txt
@@ -32,14 +32,12 @@ and requests will fail.
 
 The following SDK versions support changing deployment models:
 
-- CPP - 0.2.0 Preview 
+- C++ - 0.2.0 
 - Flutter/Dart - 1.2.0
 - Kotlin - 1.10.0 
-- Dotnet - 11.1.0 
-- JS - 12.0.0 (pending)
+- .NET - 11.1.0 
+- JS - 12.0.0 (pending release)
 - Swift - 10.40.0
-
-The SDKs that support  
 
 .. todo sync with ENG post https://jira.mongodb.org/browse/RCORE-1346 to determine minimum versions. Until then, users have to talk to support.
 

--- a/source/apps/change-deployment-models.txt
+++ b/source/apps/change-deployment-models.txt
@@ -32,12 +32,12 @@ and requests will fail.
 
 The following SDK versions support changing deployment models:
 
-- C++ - *v0.2.0* 
-- Flutter - *v1.2.0*
-- Kotlin - *v1.10.0*
-- .NET - *v11.1.0*
-- JavaScript - *v12.0.0* (pending release)
-- Swift - *v10.40.0*
+- C++ - *0.2.0* 
+- Flutter - *1.2.0*
+- Kotlin - *1.10.0*
+- .NET - *11.1.0*
+- JavaScript - *12.0.0* (pending release)
+- Swift - *10.40.0*
 
 .. todo sync with ENG post https://jira.mongodb.org/browse/RCORE-1346 to determine minimum versions. Until then, users have to talk to support.
 

--- a/source/apps/change-deployment-models.txt
+++ b/source/apps/change-deployment-models.txt
@@ -30,6 +30,16 @@ a version that supports changing deployment models. If you change
 deployment models before upgrading, the SDK will not be able to connect
 and requests will fail.
 
+The following SDK versions support changing deployment models:
+- CPP - 0.2.0 Preview 
+- Flutter/Dart - 1.2.0
+- Kotlin - 1.10.0 
+- Dotnet - 11.1.0 
+- JS - 12.0.0 (pending)
+- Swift - 10.40.0
+
+The SDKs that support  
+
 .. todo sync with ENG post https://jira.mongodb.org/browse/RCORE-1346 to determine minimum versions. Until then, users have to talk to support.
 
 .. important:: Contact MongoDB Support

--- a/source/apps/change-deployment-models.txt
+++ b/source/apps/change-deployment-models.txt
@@ -31,6 +31,7 @@ deployment models before upgrading, the SDK will not be able to connect
 and requests will fail.
 
 The following SDK versions support changing deployment models:
+
 - CPP - 0.2.0 Preview 
 - Flutter/Dart - 1.2.0
 - Kotlin - 1.10.0 


### PR DESCRIPTION
## Pull Request Info

For reference, the details came from [this thread](https://mongodb.slack.com/archives/CLY6HQWUE/p1688105109330279).
 
The SDKs that support the latest changing deployment models will need to be based on Realm Core 13.13.0 or later. This includes the following SDK versions (or later):

JS - pending v12.0.0 (not yet officially released, however 12.0.0-rc.0 was released on 2023-06-29 with support)
Swift - v10.40.0 (released 2023-05-26)
Kotlin - v1.10.0 (released 2023-06-28)
Java - v10.16.0 (released 2023-06-02)
Flutter/Dart - v1.2.0 (released 2023-06-08)
Dotnet - 11.1.0 (released on 2023-06-17)
CPP - 0.2.0 Preview (released 2023-06-21)

### Jira

- https://jira.mongodb.org/browse/DOCSP-31122

### Staged Changes

- [Change Deployment Modes](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-31122/apps/change-deployment-models/)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [ ] Create Jira ticket for corresponding docs-realm update(s), if any
- [ ] Checked/updated Admin API
- [ ] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
