### PR TITLE
Add links to new SDK docs on migrating Sync modes

### DIFF
--- a/source/sync/migrate-sync-modes.txt
+++ b/source/sync/migrate-sync-modes.txt
@@ -344,7 +344,7 @@ object model's name. For example, a ``Person`` object model's subscription
 name would be ``flx_migrated_Person``.
 
 You can keep the automatically-generated subscriptions if you don't want to
-remove and recreate them. But you should consider that because these 
+remove and recreate them. But because these subscriptions aren't created in your client code, they may make it harder for you to maintain and extend client code.
 subscriptions aren't created in your client code, they may make it harder to
 maintain and extend client code. 
 

--- a/source/sync/migrate-sync-modes.txt
+++ b/source/sync/migrate-sync-modes.txt
@@ -343,28 +343,28 @@ generated subscriptions use a specific naming format: ``flx_migrated_`` + your
 object model's name. For example, a ``Person`` object model's subscription
 name would be ``flx_migrated_Person``.
 
-Refer to the SDK documentation for details about adding and removing
-subscriptions:
-
-- Java SDK
-   :ref:`Flexible Sync - Java SDK <java-flexible-sync>`
-
-- Kotlin SDK
-   :ref:`Subscribe to Queryable Fields - Kotlin SDK <kotlin-subscriptions>`
-
-- .NET SDK
-   :ref:`Manage Flexible Sync Subscriptions - .NET SDK <dotnet-flexible-sync>`
-
-- Node.js SDK
-   :ref:`Flexible Sync - Node.js SDK <node-flexible-sync>`
-
-- React Native SDK
-   :ref:`Flexible Sync - React Native SDK <react-native-flexible-sync>`
-
-- Swift SDK
-   :ref:`Manage Flexible Sync Subscriptions - Swift SDK <swift-manage-flexible-sync-subscriptions>`
-
 You can keep the automatically-generated subscriptions if you don't want to
 remove and recreate them. But you should consider that because these 
 subscriptions aren't created in your client code, they may make it harder to
 maintain and extend client code. 
+
+For more information about updating client code after migrating from 
+Partition-Based Sync to Flexible Sync, refer to:
+
+- Java SDK
+   :ref:`Migrate from Partition-Based Sync to Flexible Sync - Java SDK <java-migrate-pbs-to-fs>`
+
+- Kotlin SDK
+   :ref:`Migrate from Partition-Based Sync to Flexible Sync - Kotlin SDK <kotlin-migrate-pbs-to-fs>`
+
+- .NET SDK
+   :ref:`Migrate from Partition-Based Sync to Flexible Sync - .NET SDK <dotnet-migrate-pbs-to-fs>`
+
+- Node.js SDK
+   :ref:`Migrate from Partition-Based Sync to Flexible Sync - Node.js SDK <node-migrate-pbs-to-fs>`
+
+- React Native SDK
+   :ref:`Migrate from Partition-Based Sync to Flexible Sync - React Native SDK <react-native-migrate-pbs-to-fs>`
+
+- Swift SDK
+   :ref:`Migrate from Partition-Based Sync to Flexible Sync - Swift SDK <ios-migrate-pbs-to-fs>`


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-31743

### Staged Changes

- [Migrate Device Sync Modes](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-31743/sync/migrate-sync-modes/#migrate-client-app-to-flexible-sync): Update links in "Migrate Client App to Flexible Sync" section from FS subscription management to new dedicated destination

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
