### PR TITLE
DOCSP-30623 Restart sync after updating custom user data

### DIFF
--- a/source/includes/define-custom-user-data.rst
+++ b/source/includes/define-custom-user-data.rst
@@ -40,4 +40,20 @@ To enable Custom User Data in the App Services UI, follow these steps:
     As a result, you must restart the sync session after updating custom user data
     to avoid a :ref:`compensating write error <flexible-sync-errors>`. 
     To restart the sync session, :ref:`pause <pause-sync>` and :ref:`resume <resume-sync>` sync.
-    
+    For more information on pausing and resuming sync from the client SDKs, see your preferred SDK:
+
+   - :ref:`Pause or resume a Device Sync session - Flutter SDK
+     <flutter-pause-resume-sync>`
+   - :ref:`Pause or resume a Device Sync session - Kotlin SDK 
+     <kotlin-pause-resume-sync>`
+   - :ref:`Pause or resume a Device Sync session - Java SDK
+     <java-pause-or-resume-a-sync-session>`
+   - :ref:`Pause or resume a Device Sync session - .Net SDK
+     <dotnet-pause-or-resume-a-sync-session>`
+   - :ref:`Pause or resume a Device Sync session - Node SDK
+     <node-pause-or-resume-a-sync-session>`
+   - :ref:`Pause or resume a Device Sync session - React Native SDK
+     <react-native-pause-or-resume-a-sync-session>`
+   - :ref:`Pause or resume a Device Sync session - Swift SDK
+     <ios-suspend-or-resume-a-sync-session>`
+       

--- a/source/includes/define-custom-user-data.rst
+++ b/source/includes/define-custom-user-data.rst
@@ -39,6 +39,5 @@ To enable Custom User Data in the App Services UI, follow these steps:
     The sync server caches custom user data for the duration of the session.
     As a result, you must restart the sync session after updating custom user data
     to avoid a :ref:`compensating write error <flexible-sync-errors>`. 
-    To do so, :ref:`pause <pause-sync>` and :ref:`resume <resume-sync>` sync 
-    to restart the sync session.
+    To restart the sync session, :ref:`pause <pause-sync>` and :ref:`resume <resume-sync>` sync.
     

--- a/source/includes/define-custom-user-data.rst
+++ b/source/includes/define-custom-user-data.rst
@@ -42,18 +42,18 @@ To enable Custom User Data in the App Services UI, follow these steps:
     To restart the sync session, :ref:`pause <pause-sync>` and :ref:`resume <resume-sync>` sync.
     For more information on pausing and resuming sync from the client SDKs, see your preferred SDK:
 
-   - :ref:`Pause or resume a Device Sync session - Flutter SDK
-     <flutter-pause-resume-sync>`
-   - :ref:`Pause or resume a Device Sync session - Kotlin SDK 
-     <kotlin-pause-resume-sync>`
-   - :ref:`Pause or resume a Device Sync session - Java SDK
-     <java-pause-or-resume-a-sync-session>`
-   - :ref:`Pause or resume a Device Sync session - .Net SDK
-     <dotnet-pause-or-resume-a-sync-session>`
-   - :ref:`Pause or resume a Device Sync session - Node SDK
-     <node-pause-or-resume-a-sync-session>`
-   - :ref:`Pause or resume a Device Sync session - React Native SDK
-     <react-native-pause-or-resume-a-sync-session>`
-   - :ref:`Pause or resume a Device Sync session - Swift SDK
-     <ios-suspend-or-resume-a-sync-session>`
+    - :ref:`Pause or resume a Device Sync session - Flutter SDK
+      <flutter-pause-resume-sync>`
+    - :ref:`Pause or resume a Device Sync session - Kotlin SDK 
+      <kotlin-pause-resume-sync>`
+    - :ref:`Pause or resume a Device Sync session - Java SDK
+      <java-pause-or-resume-a-sync-session>`
+    - :ref:`Pause or resume a Device Sync session - .Net SDK
+      <dotnet-pause-or-resume-a-sync-session>`
+    - :ref:`Pause or resume a Device Sync session - Node SDK
+      <node-pause-or-resume-a-sync-session>`
+    - :ref:`Pause or resume a Device Sync session - React Native SDK
+      <react-native-pause-or-resume-a-sync-session>`
+    - :ref:`Pause or resume a Device Sync session - Swift SDK
+      <ios-suspend-or-resume-a-sync-session>`
        

--- a/source/includes/define-custom-user-data.rst
+++ b/source/includes/define-custom-user-data.rst
@@ -39,7 +39,7 @@ To enable Custom User Data in the App Services UI, follow these steps:
     The sync server caches custom user data for the duration of the session.
     As a result, you must restart the sync session after updating custom user data
     to avoid a :ref:`compensating write error <flexible-sync-errors>`. 
-    To restart the sync session, :ref:`pause <pause-sync>` and :ref:`resume <resume-sync>` sync.
+    To restart the sync session, pause and resume all open Sync Sessions in the client application.
     For more information on pausing and resuming sync from the client SDKs, see your preferred SDK:
 
     - :ref:`Pause or resume a Device Sync session - Flutter SDK

--- a/source/includes/define-custom-user-data.rst
+++ b/source/includes/define-custom-user-data.rst
@@ -33,3 +33,12 @@ To enable Custom User Data in the App Services UI, follow these steps:
        leads to unexpected results.
      
 #. Save and deploy the changes.
+
+   .. note:: Restart the Sync Session after Updating Custom User Data
+
+    The sync server caches custom user data for the duration of the session.
+    As a result, you must restart the sync session after updating custom user data
+    to avoid a :ref:`compensating write error <flexible-sync-errors>`. 
+    To do so, :ref:`pause <pause-sync>` and :ref:`resume <resume-sync>` sync 
+    to restart the sync session.
+    


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-30623

### Staged Changes

- [Device Sync Permissions Guide note at bottom of each "Enable & Configure Custom User Data" sections](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-30623/sync/app-builder/device-sync-permissions-guide/#enable---configure-custom-user-data-1)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [ ] Create Jira ticket for corresponding docs-realm update(s), if any
- [ ] Checked/updated Admin API
- [ ] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
