### PR TITLE
DOCSP-32114: Add Kotlin link to Define User Metadata page

### DIFF
--- a/source/users/custom-metadata.txt
+++ b/source/users/custom-metadata.txt
@@ -719,5 +719,6 @@ SDKs:
 
 - :ref:`Flutter SDK <flutter-user-metadata>`
 - :ref:`.NET SDK <dotnet-user-metadata>`
+- :ref:`Kotlin SDK <kotlin-user-metadata>`
 - :ref:`Node SDK <node-user-metadata>`
 - :ref:`Swift SDK <ios-user-metadata>`


### PR DESCRIPTION
## Pull Request Info

Update corresponding App Services page with link to User Metadata - Kotlin SDK page added in https://github.com/mongodb/docs-realm/pull/2944

### Jira

- https://jira.mongodb.org/browse/DOCSP-32114

### Staged Changes

- [Define Custom User Metadata](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/docsp-32114-kotlin-user-metadata/users/custom-metadata/#access-user-metadata-from-a-client-application)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any - see [DOCSP-30334](https://jira.mongodb.org/browse/DOCSP-30334)
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
