### PR TITLE
DOCSP-31445: Add links to findOneAnd...() methods

### DIFF
--- a/source/functions/mongodb/write.txt
+++ b/source/functions/mongodb/write.txt
@@ -93,6 +93,11 @@ of a single document in the ``items`` collection from ``lego`` to
 
 .. include:: /functions/mongodb/api/snippets/updateOneSetField.rst
 
+Alternatively, you can update a single document using 
+:method:`collection.findOneAndUpdate()` or 
+:method:`collection.findOneAndReplace()`. Both methods allow you to
+find, modify, and return the updated document in a single operation.
+
 .. _mongodb-update-one-or-more-documents:
 
 Update One or More Documents (``updateMany()``)
@@ -332,6 +337,10 @@ The following :ref:`function <functions>` snippet deletes one document
 in the ``items`` collection that has a ``name`` value of ``lego``:
 
 .. include:: /functions/mongodb/api/snippets/deleteOne.rst
+
+Alternatively, you can update a single document using 
+:method:`collection.findOneAndDelete()`. This method allows you to
+find, remove, and return the deleted document in a single operation.
 
 .. _mongodb-delete-one-or-more-documents:
 


### PR DESCRIPTION
## Pull Request Info

Bug bash ticket: [Write](https://www.mongodb.com/docs/atlas/app-services/functions/mongodb/write/#update) page is missing `findOneAnd...()` methods. 
> NOTE: I didn't include code examples since they're available on the linked [API Ref](https://www.mongodb.com/docs/atlas/app-services/functions/mongodb/api/#collection.findoneandupdate--) page. I can also update to make these their own sections if we think that's needed.

### Jira

- https://jira.mongodb.org/browse/DOCSP-31445

### Staged Changes

- [Write](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/BRANCH_NAME/)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
