### PR TITLE
(DOCSP-31839): Update queryable fields for upcoming release

### DIFF
--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -124,7 +124,9 @@ Procedure
                  "state": <"enabled" | "disabled">,
                  "client_max_offline_days": <Number>,
                  "is_recovery_mode_disabled": <Boolean>,
-                 "queryable_fields_names": <Array of String Field Names>
+                 "indexed_queryable_fields_names": <Array of String Field Names>,
+                 "queryable_fields_names": <Array of String Field Names>,
+                 "collection_queryable_fields_names": <Map[String][]String>
                }
                
             For details, refer to the :ref:`sync-configuration-reference`.
@@ -190,9 +192,11 @@ Procedure
                  "flexible_sync": {
                    "state": "enabled",
                    "database_name": "<Name of Database>",
-                   "queryable_fields_names": <Array of String Field Names>,
                    "client_max_offline_days": <Number>,
-                   "is_recovery_mode_disabled": <Boolean>
+                   "is_recovery_mode_disabled": <Boolean>,
+                   "indexed_queryable_fields_names": <Array of String Field Names>,
+                   "queryable_fields_names": <Array of String Field Names>,
+                   "collection_queryable_fields_names": <Map[String][]String>
                  }
                  ...
                }

--- a/source/sync/configure/sync-settings.txt
+++ b/source/sync/configure/sync-settings.txt
@@ -405,6 +405,10 @@ Sync (recommended). If you are using the older Partition-Based Sync, refer to
      "queryable_fields_names": [
        <Array of String Field Names>
      ],
+     "indexed_queryable_fields_names": [
+      <Array of String Field Names>
+     ],
+     "collection_queryable_fields_names": <Map[String][]String>
      "permissions": "<Deprecated, Do Not Use>"
    }
 
@@ -487,8 +491,28 @@ Sync Config Object
    * - | ``queryable_fields_names``
        | Array<String>
      
-     - The :ref:`names of the fields <queryable-fields>` that your client 
-       application can query to determine which data to synchronize.
+     - The :ref:`names of the global queryable fields <queryable-fields>` 
+       that your client application can query to determine which data to 
+       synchronize. These fields are queryable across all synced collections.
+
+   * - | ``indexed_queryable_fields_names``
+       | Array<String>
+     
+     - The :ref:`names of the indexed queryable fields <fs-indexed-queryable-fields>` 
+       that your client application can query to determine which data to 
+       synchronize. Your app can have one indexed queryable field, and it
+       must be present and be the same 
+       :ref:`eligible field type <flexible-sync-eligible-field-types>`
+       in every collection.
+
+   * - | ``collection_queryable_fields_names``
+       | <Map[String][]String>
+     
+     - The :ref:`names of the collection queryable fields <queryable-field-scopes>` 
+       that your client application can query to determine which data to 
+       synchronize. Collection queryable fields are scoped to the specified
+       collection. Scoping a queryable field to a specific collection reduces
+       the amount of backing Atlas storage required to store Sync metadata.
 
    * - | ``last_disabled``
        | Number

--- a/source/sync/configure/sync-settings.txt
+++ b/source/sync/configure/sync-settings.txt
@@ -276,14 +276,17 @@ example, ``user_id == 641374b03725038381d2e1fb`` or ``store_id IN {1,2,3}``.
 You can optionally include an ``AND`` comparison as long as the indexed
 queryable field is directly compared against a constant using ``==`` or ``IN``
 at least once. For example, ``store_id IN {1,2,3} AND region=="Northeast"``
-or ``store_id == 1 AND active_promotions < 5``.
+or ``store_id == 1 AND (active_promotions < 5 OR num_employees < 10)``.
 
 *Invalid* Flexible Sync queries on an indexed queryable field include queries 
 where:
 
 - The indexed queryable field does not use ``AND`` with the rest of the query.
   For example ``store_id IN {1,2,3} OR region=="Northeast"`` is invalid
-  because it uses ``OR`` instead of ``AND``.
+  because it uses ``OR`` instead of ``AND``.  Similarly, 
+  ``store_id == 1 AND active_promotions < 5 OR num_employees < 10`` is invalid
+  because the ``AND`` only applies to the term next to it, not the entire
+  query.
 - The indexed queryable field is not used in an equality operator. For example
   ``store_id > 2 AND region=="Northeast"`` is invalid because it uses only 
   the ``>`` operator with the indexed queryable field and does not have an 

--- a/source/sync/configure/sync-settings.txt
+++ b/source/sync/configure/sync-settings.txt
@@ -261,9 +261,8 @@ You can still change this value directly in the Atlas database.
 
 .. warning::
 
-   Avoid changing an object's indexed queryable field value when 
-   possible. It may result in dropping other updates on the same 
-   object.
+   Changing an object's indexed queryable field value through Atlas may 
+   overwrite concurrent client updates to the object.
 
 .. _fs-indexed-queryable-fields-valid-client-side-queries:
 
@@ -298,8 +297,9 @@ where:
 Consequences of Adding or Removing Queryable Fields
 ```````````````````````````````````````````````````
 
-You can :ref:`update your Sync configuration <alter-your-sync-configuration>` to
-add or remove queryable field names, but be aware of the following:
+You can :ref:`update your Sync configuration <alter-your-sync-configuration>` 
+to add or remove queryable field names while Sync is enabled, but be aware 
+of the following:
 
 When you add a queryable field, devices can only sync on that field once the
 device has caught up to the point in time in :ref:`Device Sync History
@@ -310,6 +310,11 @@ their Device Sync session dropped and must perform a :ref:`client reset
 <client-resets>`. Clients not using the removed field won't receive any errors.
 To avoid triggering a client reset when you remove the queryable field, you
 should first remove usage of that field on the client-side.
+
+If you :ref:`terminate Sync <terminating-realm-sync>` before adding or 
+removing queryable fields, these considerations do not apply. However, 
+terminating Sync does trigger a :ref:`client reset <client-resets>` for
+any client that has Synced with your App.
 
 Permissions
 ~~~~~~~~~~~
@@ -498,12 +503,13 @@ Sync Config Object
    * - | ``indexed_queryable_fields_names``
        | Array<String>
      
-     - The :ref:`names of the indexed queryable fields <fs-indexed-queryable-fields>` 
+     - The :ref:`name of the indexed queryable field <fs-indexed-queryable-fields>` 
        that your client application can query to determine which data to 
-       synchronize. Your app can have one indexed queryable field, and it
-       must be present and be the same 
-       :ref:`eligible field type <flexible-sync-eligible-field-types>`
-       in every collection.
+       synchronize. While this property is an array, we currently support
+       only one one indexed queryable field. This array may contain only one 
+       element. The indexed queryable field must be present in the schema 
+       and be the same :ref:`eligible field type <flexible-sync-eligible-field-types>`
+       in every collection you sync.
 
    * - | ``collection_queryable_fields_names``
        | <Map[String][]String>

--- a/source/sync/configure/sync-settings.txt
+++ b/source/sync/configure/sync-settings.txt
@@ -133,6 +133,8 @@ used in a subscription query are called **queryable fields**.
    as queryable fields. On the client side, you can then query for tasks 
    whose ``assignee`` or ``owner`` matches the logged-in user. 
 
+.. _queryable-field-scopes:
+
 Queryable Field Scopes
 ``````````````````````
 
@@ -151,9 +153,9 @@ Configure Queryable Fields
 ``````````````````````````
 
 You can automatically specify queryable fields by enabling :ref:`Development
-Mode <development-mode>`. Development Mode allows App Services to automatically
-mark fields as queryable as they are used. Queryable fields that you add
-through Development Mode become **collection queryable fields**.
+Mode <development-mode>`. Fields that appear in client queries while using 
+Development mode are automatically added as **collection queryable fields** 
+for the collection being queried.
 
 The field names you provide are arbitrary strings. If an object type has a field
 whose name matches a field name you provided (and meets other eligibility
@@ -200,10 +202,27 @@ Performance and Storage
 
 Each queryable field adds additional metadata storage to your Atlas cluster and
 may lead to degraded write performance. You should have as few queryable fields
-as needed by your application. A good rule of thumb is to have at most 10
-queryable fields. If you need to reduce storage usage or improve performance, 
-you can remove unneeded queryable fields from your App. However, be aware
-of the consequences of adding or removing queryable fields detailed below.
+as needed by your application, and scope them to the minimum number of 
+collections required.
+
+Many apps find a good balance between storage usage and query flexibility 
+with at most 10 queryable fields applying to any single collection. 
+For example, if you have 3 *global queryable fields* and 7 
+*collection queryable fields*, you have 10 queryable fields that apply to the 
+collection.
+
+If you have a field that you only want to query in one collection, but it 
+is configured as a *global queryable field*, this unnecessarily consumes 
+Atlas storage space. For example, if you have a ``user`` field in every 
+collection, but you only use it for Sync queries in one collection, scoping 
+that as a *collection queryable field* reduces storage requirements. Reducing
+the scope means that Sync does not have to maintain metadata for that field
+for the other collections where you are not querying on the ``user`` field.
+
+If you need to reduce storage usage or improve performance, you can remove 
+unneeded queryable fields from your App. However, be aware of the consequences 
+of adding or removing queryable fields. For more information, refer to 
+:ref:`consequences-of-adding-removing-queryable-fields`.
 
 For additional considerations, refer to :ref:`optimizing performance and 
 storage when using Flexible Sync <optimizing-performance-and-storage-flexible-sync>`.
@@ -215,7 +234,7 @@ Indexed Queryable Fields
 
 You can improve performance for certain types of workloads by adding an
 indexed queryable field. An **indexed queryable field** is a 
-**global queryable field** that is indexed in the history store, providing
+**global queryable field** that can be queried on more efficiently, providing
 improved Sync performance. You can designate *one* global queryable field
 as an indexed queryable field.
 
@@ -223,14 +242,28 @@ Indexing a queryable field improves performance for simple queries on a
 single field, such as ``{“store_id”: 1}`` or  
 ``{“user_id”: “641374b03725038381d2e1fb”}``.
 
+The indexed queryable field *must* appear in the schemas of all of your 
+Sync collections, and it must use the same valid data type. For example,
+if your indexed queryable field is ``store_id``, it must appear in all of
+the collections you sync, and it must be the same valid type in all the
+collections. For more information about eligible field types, refer to
+:ref:`flexible-sync-eligible-field-types`.
+
 **You Can't Change Indexed Queryable Field Values on the Client**
 
 After you configure an indexed queryable field, client devices **cannot**
 update an existing object's indexed queryable field value. For example,
 if your indexed queryable field is ``store_id``, the client cannot change 
-this value directly. You can still change this directly in the Atlas database.
-Changing it from the client is not supported because it may conflict with 
-other updates made to the object in the same timeframe.
+this value directly. Changing it from the client is not supported because 
+it may conflict with other updates made to the object in the same timeframe. 
+
+You can still change this value directly in the Atlas database. 
+
+.. warning::
+
+   Avoid changing an object's indexed queryable field value when 
+   possible. It may result in dropping other updates on the same 
+   object.
 
 .. _fs-indexed-queryable-fields-valid-client-side-queries:
 
@@ -244,7 +277,7 @@ example, ``user_id == 641374b03725038381d2e1fb`` or ``store_id IN {1,2,3}``.
 You can optionally include an ``AND`` comparison as long as the indexed
 queryable field is directly compared against a constant using ``==`` or ``IN``
 at least once. For example, ``store_id IN {1,2,3} AND region=="Northeast"``
-or ``store_id IN {1,2,3} AND store_id > 2``.
+or ``store_id == 1 AND active_promotions < 5``.
 
 *Invalid* Flexible Sync queries on an indexed queryable field include queries 
 where:
@@ -259,6 +292,8 @@ where:
 - The query is missing the indexed queryable field entirely. For example, 
   ``region=="Northeast`` or ``truepredicate`` are invalid because they do
   not contain the indexed queryable field.
+
+.. _consequences-of-adding-removing-queryable-fields:
 
 Consequences of Adding or Removing Queryable Fields
 ```````````````````````````````````````````````````

--- a/source/sync/configure/sync-settings.txt
+++ b/source/sync/configure/sync-settings.txt
@@ -512,7 +512,9 @@ Sync Config Object
        only one one indexed queryable field. This array may contain only one 
        element. The indexed queryable field must be present in the schema 
        and be the same :ref:`eligible field type <flexible-sync-eligible-field-types>`
-       in every collection you sync.
+       in every collection you sync. The indexed queryable field name must 
+       *also* appear in ``queryable_fields_names`` since this is a global
+       queryable field.
 
    * - | ``collection_queryable_fields_names``
        | <Map[String][]String>

--- a/source/sync/configure/sync-settings.txt
+++ b/source/sync/configure/sync-settings.txt
@@ -124,26 +124,51 @@ Queryable Fields
 ~~~~~~~~~~~~~~~~
 
 When you configure Flexible Sync, you specify field names that your client
-application can query. Fields that can be used in a subscription query are
-called **queryable fields**.
-
-You can automatically specify queryable fields by enabling :ref:`Development
-Mode <development-mode>`. Development Mode allows App Services to automatically
-mark fields as queryable as they are used.
-
-Queryable fields apply across all collections in an App's Schema. You
-can use :ref:`rules and permissions <flexible-sync-rules-and-permissions>` to
-configure more granular access control on individual collections.
-
-The field names you provide are arbitrary strings. If an object type has a field
-whose name matches a field name you provided (and meets other eligibility
-criteria), that field becomes available to Device Sync to query.
+application can query in a Flexible Sync subscription. Fields that can be 
+used in a subscription query are called **queryable fields**.
 
 .. example::
 
    In a to-do list app, you might set ``assignee`` or ``owner`` 
    as queryable fields. On the client side, you can then query for tasks 
    whose ``assignee`` or ``owner`` matches the logged-in user. 
+
+Queryable Field Scopes
+``````````````````````
+
+Queryable fields apply to a scope you designate when you configure them. The
+two available scopes are:
+
+- **Global queryable fields**: scoped across all collections in an App's Schema.
+- **Collection queryable fields**: scoped to a single collection in the App.
+
+You can use :ref:`rules and permissions <flexible-sync-rules-and-permissions>` 
+to configure more granular access control on a per-collection basis. You 
+can define collection-level rules and permissions for both global and 
+collection queryable fields.
+
+Configure Queryable Fields
+``````````````````````````
+
+You can automatically specify queryable fields by enabling :ref:`Development
+Mode <development-mode>`. Development Mode allows App Services to automatically
+mark fields as queryable as they are used. Queryable fields that you add
+through Development Mode become **collection queryable fields**.
+
+The field names you provide are arbitrary strings. If an object type has a field
+whose name matches a field name you provided (and meets other eligibility
+criteria), that field becomes available to Device Sync to query.
+
+Configure Indexed Queryable Fields
+++++++++++++++++++++++++++++++++++
+
+You may only add or remove an indexed queryable field when Device Sync is 
+not enabled. If Device Sync is already running in your App, you must 
+:ref:`terminate Sync <terminating-realm-sync>`, and configure the indexed
+queryable field when you :ref:`re-enable it <re-enable-realm-sync>`.
+
+This causes :ref:`client resets <client-resets>` for any client attempting 
+to reconnect after re-enabling Sync.
 
 .. _flexible-sync-eligible-field-types:
 
@@ -154,6 +179,9 @@ Flexible Sync only supports top-level primitive fields with a scalar type as
 queryable fields. You can also include arrays of these primitives as queryable 
 fields. Flexible Sync does not support embedded objects or arrays of 
 objects as queryable fields.
+
+**Indexed queryable fields** support a subset of data types. Your indexed 
+queryable field can be one of: ``int64``, ``string``, ``ObjectId``, ``UUID``.
 
 .. seealso:: Realm Query Language - Flexible Sync Limitations
 
@@ -173,11 +201,64 @@ Performance and Storage
 Each queryable field adds additional metadata storage to your Atlas cluster and
 may lead to degraded write performance. You should have as few queryable fields
 as needed by your application. A good rule of thumb is to have at most 10
-queryable fields.
+queryable fields. If you need to reduce storage usage or improve performance, 
+you can remove unneeded queryable fields from your App. However, be aware
+of the consequences of adding or removing queryable fields detailed below.
 
-.. seealso::
+For additional considerations, refer to :ref:`optimizing performance and 
+storage when using Flexible Sync <optimizing-performance-and-storage-flexible-sync>`.
 
-   Learn more about :ref:`optimizing performance and storage when using Flexible Sync <optimizing-performance-and-storage-flexible-sync>`.
+.. _fs-indexed-queryable-fields:
+
+Indexed Queryable Fields
+++++++++++++++++++++++++
+
+You can improve performance for certain types of workloads by adding an
+indexed queryable field. An **indexed queryable field** is a 
+**global queryable field** that is indexed in the history store, providing
+improved Sync performance. You can designate *one* global queryable field
+as an indexed queryable field.
+
+Indexing a queryable field improves performance for simple queries on a 
+single field, such as ``{“store_id”: 1}`` or  
+``{“user_id”: “641374b03725038381d2e1fb”}``.
+
+**You Can't Change Indexed Queryable Field Values on the Client**
+
+After you configure an indexed queryable field, client devices **cannot**
+update an existing object's indexed queryable field value. For example,
+if your indexed queryable field is ``store_id``, the client cannot change 
+this value directly. You can still change this directly in the Atlas database.
+Changing it from the client is not supported because it may conflict with 
+other updates made to the object in the same timeframe.
+
+.. _fs-indexed-queryable-fields-valid-client-side-queries:
+
+**Client-Side Queries on Indexed Queryable Fields**
+
+When your app uses an indexed queryable field, client-side queries in a 
+Flexible Sync subscription *must* include the indexed queryable field using
+an ``==`` or ``IN`` comparison against a constant at least once. For
+example, ``user_id == 641374b03725038381d2e1fb`` or ``store_id IN {1,2,3}``.
+
+You can optionally include an ``AND`` comparison as long as the indexed
+queryable field is directly compared against a constant using ``==`` or ``IN``
+at least once. For example, ``store_id IN {1,2,3} AND region=="Northeast"``
+or ``store_id IN {1,2,3} AND store_id > 2``.
+
+*Invalid* Flexible Sync queries on an indexed queryable field include queries 
+where:
+
+- The indexed queryable field does not use ``AND`` with the rest of the query.
+  For example ``store_id IN {1,2,3} OR region=="Northeast"`` is invalid
+  because it uses ``OR`` instead of ``AND``.
+- The indexed queryable field is not used in an equality operator. For example
+  ``store_id > 2 AND region=="Northeast"`` is invalid because it uses only 
+  the ``>`` operator with the indexed queryable field and does not have an 
+  equality comparison.
+- The query is missing the indexed queryable field entirely. For example, 
+  ``region=="Northeast`` or ``truepredicate`` are invalid because they do
+  not contain the indexed queryable field.
 
 Consequences of Adding or Removing Queryable Fields
 ```````````````````````````````````````````````````
@@ -194,7 +275,6 @@ their Device Sync session dropped and must perform a :ref:`client reset
 <client-resets>`. Clients not using the removed field won't receive any errors.
 To avoid triggering a client reset when you remove the queryable field, you
 should first remove usage of that field on the client-side.
-
 
 Permissions
 ~~~~~~~~~~~

--- a/source/sync/error-handling/errors.txt
+++ b/source/sync/error-handling/errors.txt
@@ -130,7 +130,10 @@ The following errors may occur when your App uses :ref:`Flexible Sync
        :ref:`query operators that are supported on the server 
        <flexible-sync-rql-limitations>`. Additionally, confirm you are querying
        a :ref:`queryable field <queryable-fields>` in your Flexible Sync 
-       configuration.
+       configuration. If your query uses an indexed queryable field, ensure
+       that it meets :ref:`the requirements for valid client-side queries 
+       <fs-indexed-queryable-fields-valid-client-side-queries>` for indexed 
+       queryable fields.
 
    * - ErrorServerPermissionsChanged
      - This error indicates that server permissions for the file ident have changed

--- a/source/sync/go-to-production/optimize-sync-atlas-usage.txt
+++ b/source/sync/go-to-production/optimize-sync-atlas-usage.txt
@@ -207,8 +207,7 @@ which collections.
    number of queryable fields. You can re-use **global queryable fields** 
    across collections in order to sync objects from every collection. 
    For example, ``owner_id`` might be a field you want to query in multiple 
-   collections. By making this a **global queryable field** across 
-   collections, only one queryable field is used.
+   collections.
 
    Alternately, you may have ``owner_id`` in multiple collections, but only
    need to query on it in one collection. In this case, you might make 

--- a/source/sync/go-to-production/optimize-sync-atlas-usage.txt
+++ b/source/sync/go-to-production/optimize-sync-atlas-usage.txt
@@ -219,9 +219,11 @@ which collections.
 
    Finally, for Apps where devices want to query one specific facet of the 
    data, such as ``owner_id == user.id``, you may want to designate the 
-   field an **indexed queryable field**. Indexed queryable fields provide 
-   more efficient storage and performance for Apps where the client only
-   needs data for a small subset - or just one - store or user, for example.
+   field an **indexed queryable field**. Indexed queryable fields provide more 
+   efficient performance for Apps where the client only needs to sync on a 
+   small subset of their data - a group of stores or a single user, for 
+   example.
+   
    You can have one indexed queryable field per App. An indexed queryable
    field is a **global queryable field** that must be present and use the 
    same eligible data type in each collection you sync.

--- a/source/sync/go-to-production/optimize-sync-atlas-usage.txt
+++ b/source/sync/go-to-production/optimize-sync-atlas-usage.txt
@@ -204,11 +204,26 @@ which collections.
 .. example::
 
    Your app may contain 20 or 30 collections, but you want to minimize the
-   number of queryable fields. You can re-use queryable fields across
-   collections in order to sync objects from every collection. For example,
-   "owner_id" might be a field you want to query in multiple collections, but by
-   having the same field name across collections, only one queryable field is
-   used.
+   number of queryable fields. You can re-use **global queryable fields** 
+   across collections in order to sync objects from every collection. 
+   For example, ``owner_id`` might be a field you want to query in multiple 
+   collections. By making this a **global queryable field** across 
+   collections, only one queryable field is used.
+
+   Alternately, you may have ``owner_id`` in multiple collections, but only
+   need to query on it in one collection. In this case, you might make 
+   ``owner_id`` a **collection queryable field**. This means Sync only has to
+   maintain metadata about this field for one collection, instead of storing
+   metadata for all of the collections where you're not querying on this 
+   field.
+
+   Finally, for simple equality queries, such as ``owner_id == user.id``,
+   you may want to designate the field an **indexed queryable field**. You 
+   can have one indexed queryable field per App. This is a special type
+   of **global queryable field** that can be queried more efficiently.
+
+   For more information, refer to :ref:`queryable-field-scopes` and 
+   :ref:`fs-indexed-queryable-fields`.
 
 For best performance, open a synced realm with a broad query. Then, add 
 more refined queries to expose targeted sets of data in the client 

--- a/source/sync/go-to-production/optimize-sync-atlas-usage.txt
+++ b/source/sync/go-to-production/optimize-sync-atlas-usage.txt
@@ -217,10 +217,14 @@ which collections.
    metadata for all of the collections where you're not querying on this 
    field.
 
-   Finally, for simple equality queries, such as ``owner_id == user.id``,
-   you may want to designate the field an **indexed queryable field**. You 
-   can have one indexed queryable field per App. This is a special type
-   of **global queryable field** that can be queried more efficiently.
+   Finally, for Apps where devices want to query one specific facet of the 
+   data, such as ``owner_id == user.id``, you may want to designate the 
+   field an **indexed queryable field**. Indexed queryable fields provide 
+   more efficient storage and performance for Apps where the client only
+   needs data for a small subset - or just one - store or user, for example.
+   You can have one indexed queryable field per App. An indexed queryable
+   field is a **global queryable field** that must be present and use the 
+   same eligible data type in each collection you sync.
 
    For more information, refer to :ref:`queryable-field-scopes` and 
    :ref:`fs-indexed-queryable-fields`.


### PR DESCRIPTION
## Pull Request Info

This functionality is pending release, and should not be merged until the App Services release currently targeted for Sept 4.

Before merging:

- [x] Confirm the new Sync configuration object structure from the CLI/Admin API and update the [Enable Sync procedure](https://www.mongodb.com/docs/atlas/app-services/sync/configure/enable-sync/#procedure)
- [x] Update the Sync configuration file reference and table from the [Sync Settings page](https://www.mongodb.com/docs/atlas/app-services/sync/configure/sync-settings/#std-label-appconfig-sync)

I split out a separate ticket to update the Admin API Sync endpoint as it is currently missing FS info entirely.

The corresponding [SDK docs PR is 2977](https://github.com/mongodb/docs-realm/pull/2977).

### Jira

- https://jira.mongodb.org/browse/DOCSP-31839

### Staged Changes

- [Sync Settings/Queryable Fields](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-31839/sync/configure/sync-settings/#queryable-fields)
- [Sync Errors](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/DOCSP-31839/sync/error-handling/errors/#flexible-sync-errors)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
