### PR TITLE
(DOCSP-32691) [BAAS] Support disabling graphql introspection in the backend

### DIFF
--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -4421,7 +4421,41 @@ paths:
                                 type: integer
                               column:
                                 type: integer
-
+  /groups/{groupId}/apps/{appId}/graphql/config:
+    parameters:
+      - "$ref": "#/components/parameters/GroupId"
+      - "$ref": "#/components/parameters/AppId"
+    get:
+      tags:
+        - graphql
+      operationId: adminGetGraphQLConfig
+      summary: Get GraphQL API Configuration
+      description: Get your app's [GraphQL API](https://www.mongodb.com/docs/atlas/app-services/graphql/) configuration.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GraphQLConfig"
+    put:
+      tags:
+        - graphql
+      operationId: adminUpdateGraphQLConfig
+      summary: Update GraphQL API Configuration
+      description: Update your app's [GraphQL API](https://www.mongodb.com/docs/atlas/app-services/graphql/) configuration.
+      requestBody:
+        description: A valid [GraphQL API configuration object](https://www.mongodb.com/docs/atlas/app-services/reference/config/graphql#std-label-appconfig-graphql).
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/GraphQLConfig"
+      responses:
+        "204":
+          description: Updated
+        "400":
+          description: Cannot Set `use_natural_pluralization` to `false`
   /groups/{groupId}/apps/{appId}/graphql/custom_resolvers:
     parameters:
       - "$ref": "#/components/parameters/GroupId"
@@ -6999,6 +7033,27 @@ components:
         collection:
           type: string
           description: The collection name.
+    GraphQLConfig:
+      type: object
+      properties:
+        use_natural_pluralization:
+          type: boolean
+          description: |-
+            If `true`, generated schema type names use common English
+            pluralization whenever possible.
+
+            If `false`, or if a natural pluralization cannot be
+            determined, then plural types use the singular type
+            name with an `"s"` appended to the end.
+
+            **You cannot change this value after you create your App.
+            This value is `true` for all new Apps.**
+        disable_schema_introspection:
+          type: boolean
+          description:
+            If `true`, the GraphQL API blocks [introspection
+            queries](https://graphql.org/learn/introspection/) from
+            clients.
     CustomResolver:
       type: object
       required:

--- a/source/reference/config/graphql.txt
+++ b/source/reference/config/graphql.txt
@@ -30,7 +30,8 @@ Service Configuration
    :caption: graphql/config.json
    
    {
-     "use_natural_pluralization": <Boolean>
+     "use_natural_pluralization": <Boolean>,
+     "disable_schema_introspection": <Boolean>
    }
 
 .. list-table::
@@ -48,10 +49,12 @@ Service Configuration
        and pass the property into the body of the request. The value 
        cannot be changed to ``false`` once the app is created.
 
-       If ``true``, Atlas App Services uses the common English pluralization of a type name whenever possible. 
-       
-       If ``false``, or if App Services cannot determine a natural pluralization, the default plural type is the 
-       singular type with an ``"s"`` appended to the end.
+       If ``true``, generated schema type names use common English
+       pluralization whenever possible.
+
+       If ``false``, or if a natural pluralization cannot be determined,
+       then plural types use the singular type name with an ``"s"``
+       appended to the end.
        
        .. example::
           
@@ -60,6 +63,18 @@ Service Configuration
 
           - Natural: "mice"
           - Default: "mouses"
+
+   * - | ``disable_schema_introspection``
+       | Boolean
+     - This value is ``false`` by default for new apps.
+
+       If ``true``, the GraphQL API blocks :graphql:`introspection
+       queries <learn/introspection/>` from clients.
+
+       This setting is useful for production Apps that do not want to
+       expose their GraphQL schema to the public. When introspection is
+       disabled, clients like GraphiQL cannot show docs for the API
+       schema or autocomplete queries and mutations.
 
 .. _appconfig-custom-resolver:
 


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-32691) [BAAS] Support disabling graphql introspection in the backend

### Staged Changes

- [Reference > Config > GraphQL](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/introspection/reference/config/graphql/)
- [Admin API > GraphQL Config Endpoints](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/introspection/admin/api/v3/#operation/adminGetGraphQLConfig)