### PR TITLE
add missing properties to NewFunction

### DIFF
--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -6419,7 +6419,7 @@ components:
           description: |-
             An application user's account ID. If defined, endpoints will always 
             run as the specified user. Cannot be used with 
-            ``run_as_user_id_script_source``.
+            `run_as_user_id_script_source`.
         run_as_user_id_script_source:
           type: string 
           description: |-

--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -6414,6 +6414,20 @@ components:
           description: |-
             If `true`, the function executes with full privileges, bypassing rules
             on all services.
+        run_as_user_id: 
+          type: string 
+          description: |-
+            An application user's account ID. If defined, endpoints will always 
+            run as the specified user. Cannot be used with 
+            ``run_as_user_id_script_source``.
+        run_as_user_id_script_source:
+          type: string 
+          description: |-
+            The stringified source code for a [function]
+            (https://www.mongodb.com/docs/atlas/app-services/functions/#std-label-functions)
+            that returns an application user's account ID. If defined, endpoints 
+            execute the function on every request and run as the user with the 
+            ID returned from the function. Cannot be used with ``run_as_user_id``.
       required:
         - name
         - private

--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -6423,8 +6423,8 @@ components:
         run_as_user_id_script_source:
           type: string 
           description: |-
-            The stringified source code for a [function]
-            (https://www.mongodb.com/docs/atlas/app-services/functions/#std-label-functions)
+            The stringified source code for a 
+            [function](https://www.mongodb.com/docs/atlas/app-services/functions/#std-label-functions)
             that returns an application user's account ID. If defined, endpoints 
             execute the function on every request and run as the user with the 
             ID returned from the function. Cannot be used with ``run_as_user_id``.

--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -6427,7 +6427,7 @@ components:
             [function](https://www.mongodb.com/docs/atlas/app-services/functions/#std-label-functions)
             that returns an application user's account ID. If defined, endpoints 
             execute the function on every request and run as the user with the 
-            ID returned from the function. Cannot be used with ``run_as_user_id``.
+            ID returned from the function. Cannot be used with `run_as_user_id`.
       required:
         - name
         - private


### PR DESCRIPTION
## Pull Request Info

### Jira

https://jira.mongodb.org/browse/DOCSP-32131

### Staged Changes

https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/master/admin/api/v3/#tag/functions/operation/adminCreateFunction

## NOTE
The purpose of ths ticket is to update the Admin API's NewFunction properties to include the two missing ones from https://www.mongodb.com/docs/atlas/app-services/reference/config/http_endpoints/#data-api-configuration. The property names and descriptions copied from that source.