### PR TITLE
(DOCS-16377): Data ingest does not leave objects in realms on device

### DIFF
--- a/source/sync/app-builder/stream-data-from-client-to-atlas.txt
+++ b/source/sync/app-builder/stream-data-from-client-to-atlas.txt
@@ -165,6 +165,10 @@ and you can prepare your client application to sync data unidirectionally.
       the device and automatically uploads when the network connection is 
       restored.
 
+      Atlas Device Sync completely manages the lifecycle of this data. 
+      It is maintained on the device until Data Ingest synchronization is 
+      complete, and then removed from the device.
+
       - :ref:`Stream Data to Atlas - C++ SDK <cpp-stream-data-to-atlas>`
       - :ref:`Stream Data to Atlas - .NET SDK <dotnet-data-ingest>`
       - :ref:`Stream Data to Atlas - Kotlin SDK <kotlin-stream-data-to-atlas>`

--- a/source/sync/configure/sync-settings.txt
+++ b/source/sync/configure/sync-settings.txt
@@ -365,6 +365,10 @@ the client SDKs. Currently, the following Realm SDKs support Data Ingest:
 - React Native SDK: :ref:`react-native-define-an-asymmetric-object`
 - Swift SDK: :ref:`swift-stream-data-to-atlas`
 
+Atlas Device Sync completely manages the lifecycle of this data. 
+It is maintained on the device until Data Ingest synchronization is 
+complete, and then removed from the device.
+
 Client Max Offline Time
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCS-16377

### Staged Changes

- [Stream Data from Client to Atlas](https://preview-mongodbdacharyc.gatsbyjs.io/atlas-app-services/DOCS-16377/sync/app-builder/stream-data-from-client-to-atlas/#create-asymmetric-objects-and-write-data)
- [Configure Sync - Data Ingest](https://preview-mongodbdacharyc.gatsbyjs.io/atlas-app-services/DOCS-16377/sync/configure/sync-settings/#data-ingest)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
