### PR TITLE
preImage no longer restricted to sharded clusters

### DIFF
--- a/source/triggers/database-triggers.txt
+++ b/source/triggers/database-triggers.txt
@@ -197,8 +197,7 @@ options are available:
        from immediately *before* the change was applied in the
        ``fullDocumentBeforeChange`` field. All change events except for
        **Insert** events include the document preimage. Document preimages are 
-       supported on non-sharded Atlas clusters running MongoDB 4.4+, and 
-       on sharded Atlas clusters running MongoDB 5.3 and later.
+       supported on all Atlas clusters running MongoDB 5.3 and later.
 
        .. tip:: Performance Optimization
 


### PR DESCRIPTION
## Pull Request Info

### Jira


### Staged Changes

- [PAGE_NAME](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/BRANCH_NAME/)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [ ] Create Jira ticket for corresponding docs-realm update(s), if any
- [ ] Checked/updated Admin API
- [ ] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
