### PR TITLE
DOCSP-34580: Update --location flag in template app documentation

### DIFF
--- a/source/apps/copy.txt
+++ b/source/apps/copy.txt
@@ -83,7 +83,7 @@ Procedure
                   {+cli-bin+} app create \
                     --name "myapp-copy" \
                     --deployment-model "LOCAL" \
-                    --location "US-OR"
+                    --provider-region "aws-us-west-2"
 
          .. step:: Migrate Secrets to the New App
 
@@ -126,7 +126,7 @@ Procedure
 
          .. step:: Create a New Configuration Directory
 
-            Create a new direcotry to store the copied App's
+            Create a new directory to store the copied App's
             configuration files. You can create a new repository for the
             copied App or keep both Apps' configurations in the same
             repository using branches or subdirectories.
@@ -156,11 +156,11 @@ Procedure
                   # Navigate to the new App's directory
                   cd myapp-copy
                   # Create the new App. The create command saves the new
-                  # App's configiration file directory in the current directory
+                  # App's configuration file directory in the current directory
                   {+cli-bin+} app create \
                     --name "myapp-copy" \
                     --deployment-model "LOCAL" \
-                    --location "US-OR"
+                    --provider-region "aws-us-west-2"
                   cp -r myapp-copy/* .
                   rm -rf myapp-copy
                   # Navigate back to the root of the repo

--- a/source/apps/create.txt
+++ b/source/apps/create.txt
@@ -167,8 +167,10 @@ Procedure
                    - ``GLOBAL``
                    - ``LOCAL``
 
-               * - ``--location``
-                 - Defines the App's :ref:`deployment region <deployment-region>`.
+               * - ``--provider-region``
+                 - Defines the App's deployment region.
+                 
+                   For a list of available regions, see :ref:`<deployment-regions>`.
 
                * - ``--environment``
                  - Sets the App's :ref:`environment tag <app-environment>`.

--- a/source/tutorial/dotnet.txt
+++ b/source/tutorial/dotnet.txt
@@ -119,7 +119,6 @@ on it.
            --name MyTutorialApp \
            --template maui.todo.flex \
             --deployment-model global \
-            --location us-va \
             --environment development
 
       The command creates a new directory in your current path with the

--- a/source/tutorial/dotnet.txt
+++ b/source/tutorial/dotnet.txt
@@ -118,8 +118,8 @@ on it.
          {+cli-bin+} app create \
            --name MyTutorialApp \
            --template maui.todo.flex \
-            --deployment-model global \
-            --environment development
+           --deployment-model global \
+           --environment development
 
       The command creates a new directory in your current path with the
       same name as the value of the ``--name`` flag.

--- a/source/tutorial/flutter.txt
+++ b/source/tutorial/flutter.txt
@@ -120,7 +120,6 @@ on it.
            --name MyTutorialApp \
            --template flutter.todo.flex \
             --deployment-model global \
-            --location us-va \
             --environment development
 
       The command creates a new directory in your current path with the

--- a/source/tutorial/flutter.txt
+++ b/source/tutorial/flutter.txt
@@ -119,8 +119,8 @@ on it.
          {+cli-bin+} app create \
            --name MyTutorialApp \
            --template flutter.todo.flex \
-            --deployment-model global \
-            --environment development
+           --deployment-model global \
+           --environment development
 
       The command creates a new directory in your current path with the
       same name as the value of the ``--name`` flag.

--- a/source/tutorial/kotlin.txt
+++ b/source/tutorial/kotlin.txt
@@ -113,8 +113,8 @@ on it.
          {+cli-bin+} app create \
            --name MyTutorialApp \
            --template kotlin.todo.flex \
-            --deployment-model global \
-            --environment development
+           --deployment-model global \
+           --environment development
 
       The command creates a new directory in your current path with the
       same name as the value of the ``--name`` flag.

--- a/source/tutorial/kotlin.txt
+++ b/source/tutorial/kotlin.txt
@@ -114,7 +114,6 @@ on it.
            --name MyTutorialApp \
            --template kotlin.todo.flex \
             --deployment-model global \
-            --location us-va \
             --environment development
 
       The command creates a new directory in your current path with the

--- a/source/tutorial/react-native.txt
+++ b/source/tutorial/react-native.txt
@@ -113,7 +113,6 @@ on it.
            --name MyTutorialApp \
            --template react-native.todo.flex \
             --deployment-model global \
-            --location us-va \
             --environment development
 
       The command creates a new directory in your current path with the

--- a/source/tutorial/react-native.txt
+++ b/source/tutorial/react-native.txt
@@ -112,8 +112,8 @@ on it.
          {+cli-bin+} app create \
            --name MyTutorialApp \
            --template react-native.todo.flex \
-            --deployment-model global \
-            --environment development
+           --deployment-model global \
+           --environment development
 
       The command creates a new directory in your current path with the
       same name as the value of the ``--name`` flag.

--- a/source/tutorial/swiftui.txt
+++ b/source/tutorial/swiftui.txt
@@ -115,7 +115,6 @@ on it.
            --name MyTutorialApp \
            --template swiftui.todo.flex \
             --deployment-model global \
-            --location us-va \
             --environment development
 
       The command creates a new directory in your current path with the

--- a/source/tutorial/swiftui.txt
+++ b/source/tutorial/swiftui.txt
@@ -114,8 +114,8 @@ on it.
          {+cli-bin+} app create \
            --name MyTutorialApp \
            --template swiftui.todo.flex \
-            --deployment-model global \
-            --environment development
+           --deployment-model global \
+           --environment development
 
       The command creates a new directory in your current path with the
       same name as the value of the ``--name`` flag.


### PR DESCRIPTION
## Pull Request Info

This PR: 

- Removes the `--location` flag from the template app documentation examples
- Replaces the flag with the new `--provider-region` in the appservices-cli documentation 
- Leaves the `--location` flag in the deprecated realm-cli documentation

### Jira

- https://jira.mongodb.org/browse/DOCSP-34580

### Staged Changes
- Get Started:
  - [.NET Tutorial](https://preview-mongodbcbullinger.gatsbyjs.io/atlas-app-services/docsp-34580/tutorial/dotnet/#start-with-the-template)
  - [Flutter Tutorial](https://preview-mongodbcbullinger.gatsbyjs.io/atlas-app-services/docsp-34580/tutorial/flutter/#start-with-the-template)
  - [Kotlin Tutorial](https://preview-mongodbcbullinger.gatsbyjs.io/atlas-app-services/docsp-34580/tutorial/kotlin/#start-with-the-template)
  - [RN Tutorial](https://preview-mongodbcbullinger.gatsbyjs.io/atlas-app-services/docsp-34580/tutorial/react-native/#start-with-the-template-app)
  - [SwiftUI Tutorial](https://preview-mongodbcbullinger.gatsbyjs.io/atlas-app-services/docsp-34580/tutorial/swiftui/#start-with-the-template)
- Develop & Deploy Apps:
  - [Create an App](https://preview-mongodbcbullinger.gatsbyjs.io/atlas-app-services/docsp-34580/apps/create/#run-the-app-creation-command)
  - [Copy an App](https://preview-mongodbcbullinger.gatsbyjs.io/atlas-app-services/docsp-34580/apps/copy/#create-a-new-app)

### Reminder Checklist

You might need to also update some corresponding pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-realm update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)

### Release Notes

- Get Started 
  - [All Tutorials]: Remove the `--location` flag from the App Services CLI procedure in the 'Start with the Template' section.
- Develop & Deploy Apps
  - Create an App: Update App Services CLI procedure to use the new `--provider-region` flag instead of `--location` flag.
  - Copy an App: Update App Services CLI example to use the new `--provider-region` flag instead of `--location` flag. 