### PR TITLE
DOCSP-33418 Remove PBS mentions form the docs

### DIFF
--- a/source/includes/note-partition-relationships.rst
+++ b/source/includes/note-partition-relationships.rst
@@ -4,6 +4,5 @@
    :ref:`Partition-Based Sync <partition-based-sync>`, an object can only have
    a relationship with other objects *in the same partition*. The objects can 
    exist in different databases and collections (within the same cluster) as 
-   long as the partition key value matches. To understand how partitions can 
-   span multiple databases and collections, see :ref:`<sync-partitions>`.
+   long as the partition key value matches.
    

--- a/source/logs/sync.txt
+++ b/source/logs/sync.txt
@@ -93,7 +93,3 @@ Fields
       
    * - Platform Version
      - The version of the platform that sent the request.
-
-   * - Partition
-     - If using :ref:`Partition-Based Sync <partition-based-sync>`, which 
-       :ref:`partition <sync-partitions>` changed as a result of the operation.

--- a/source/reference/partition-based-sync.txt
+++ b/source/reference/partition-based-sync.txt
@@ -827,7 +827,7 @@ before and after it's modified.
 Permission Strategies
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. include:: source/includes/note-partition-relationships.rst
+.. include:: /includes/note-partition-relationships.rst
 
 You can structure your read and write permission expressions as a set of
 permission strategies that apply to your :ref:`partition strategy

--- a/source/reference/partition-based-sync.txt
+++ b/source/reference/partition-based-sync.txt
@@ -80,7 +80,9 @@ value passed in from the client application.
       } catch (err) {
         console.error("failed to open realm", err.message);
       }
-      
+
+Device Sync requires MongoDB Atlas clusters to run specific versions of MongoDB.
+Partition-Based Sync requires MongoDB 4.4.0 or greater.
 
 Key Terms
 ---------
@@ -1679,6 +1681,30 @@ terminating and re-enabling Device Sync will trigger a client reset. To learn
 more about handling client resets, read the :ref:`client reset <client-resets>`
 documentation.
 
+.. _partition-based-sync-errors:
+
+Partition-Based Sync Errors
+---------------------------
+
+The following errors may occur when your App uses :ref:`Partition-Based Sync 
+<partition-based-sync>`.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Error Name
+     - Description
+
+   * - ErrorIllegalRealmPath
+     - This error indicates that the client attempted to open a realm with a
+       partition value of the wrong type. For example, you might see the error
+       message "attempted to bind on illegal realm partition: expected partition
+       to have type objectId but found string".
+       
+       To recover from this error, ensure that the type of the partition value
+       used to open the realm matches the partition key type in your
+       Device Sync configuration.
 .. _backend-compaction:
 
 Backend Compaction

--- a/source/reference/partition-based-sync.txt
+++ b/source/reference/partition-based-sync.txt
@@ -827,6 +827,8 @@ before and after it's modified.
 Permission Strategies
 ~~~~~~~~~~~~~~~~~~~~~
 
+.. include:: source/includes/note-partition-relationships.rst
+
 You can structure your read and write permission expressions as a set of
 permission strategies that apply to your :ref:`partition strategy
 <partition-strategies>`. The following strategies outline common approaches that

--- a/source/reference/service-limitations.txt
+++ b/source/reference/service-limitations.txt
@@ -207,10 +207,8 @@ are available when you connect to MongoDB through App Services, see
 :ref:`the CRUD & Aggregation API reference
 <mongodb-crud-and-aggregation-apis>`.
 
-Device Sync requires MongoDB Atlas clusters to run specific versions of MongoDB:
-
-- Partition-Based Sync requires MongoDB 4.4.0 or greater.
-- Flexible Sync requires MongoDB 5.0.0 or greater.
+Device Sync requires MongoDB Atlas clusters to run specific versions of MongoDB.
+Flexible Sync requires MongoDB 5.0.0 or greater.
 
 .. _mongodb-service-limitations-query-options:
 

--- a/source/rules/roles.txt
+++ b/source/rules/roles.txt
@@ -28,10 +28,6 @@ applies.
 For examples of how you might configure permissions for common scenarios with
 Device Sync, see the :ref:`flexible-sync-permissions-guide`.
 
-If you're using the older Partition-Based Device Sync, roles work differently.
-To configure Partition-Based Sync permissions, see
-:ref:`partition-based-sync-permissions`.
-
 What are Permissions?
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/rules/sync-compatibility.txt
+++ b/source/rules/sync-compatibility.txt
@@ -13,10 +13,6 @@ Device Sync-Compatible Permissions
 When using :ref:`Device Sync (Flexible Mode) <sync>`, there are special
 considerations when using the permissions system.
 
-The older Partition-Based Sync uses a completely different permissions system.
-See :ref:`partition-based-rules-and-permissions` if you are using
-Partition-Based Sync.
-
 For a guide to setting up Flexible Sync with common permissions models, see the
 :ref:`flexible-sync-permissions-guide`.
 
@@ -210,6 +206,3 @@ For reference, the following changes take place in the migration:
      "insert": true,
      "delete": true,
      "search": true
-
-This does not apply to apps using Partition-Based Sync. Their permissions
-configuration remains in the Sync configuration.

--- a/source/schemas/relationships.txt
+++ b/source/schemas/relationships.txt
@@ -26,8 +26,6 @@ relationships in synced SDK data models and GraphQL operations by
 replacing the values in a source field with the foreign documents that
 they reference.
 
-.. include:: /includes/note-partition-relationships.rst
-
 Relationships are unidirectional and don't enforce uniqueness or other
 foreign key constraints. If you reference a non-existent foreign value in
 a source field, App Services automatically omits the reference from resolved

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -35,9 +35,6 @@ If you're re-enabling Device Sync after pausing or terminating it, refer to
 :ref:`Resume <resume-sync>` or :ref:`Re-Enable <re-enable-realm-sync>` Device
 Sync.
 
-If you are using the older Partition-Based Sync mode, refer to
-:ref:`alter-partition-based-sync-config`.
-
 .. tip::
 
    Device Sync pauses automatically after {+sync-inactive-app-pause-time+} 

--- a/source/sync/configure/pause-or-terminate-sync.txt
+++ b/source/sync/configure/pause-or-terminate-sync.txt
@@ -211,7 +211,6 @@ terminate and re-enable Device Sync under a few different circumstances:
 - An :manual:`oplog </core/replica-set-oplog/>` rollover
 - A paused Device Sync session on a shared tier cluster due to infrequent usage
 - Troubleshooting, at the request of MongoDB Support
-- Altering a Partition-Based Sync configuration
 - Switching between Sync modes. For instance, if you are switching from Partition-Based Sync to Flexible Sync
 - Dropping a collection you've used with Sync. For example, if you 
   have a ``Team`` collection that stores and syncs ``Team`` objects, and 

--- a/source/sync/configure/sync-settings.txt
+++ b/source/sync/configure/sync-settings.txt
@@ -19,21 +19,6 @@ Available Settings
 ------------------
 
 .. _flexible-sync:
-
-Sync Type
-~~~~~~~~~
-
-Atlas Device Sync has two sync modes: Flexible Sync and the older
-Partition-Based Sync. We recommend using Flexible Sync. For information about
-Partition-Based Sync, refer to :ref:`partition-based-sync`.
-
-Flexible Sync lets you define a query in the client and sync only the objects
-that match the query. With client-side subscriptions, client applications can:
-
-- Maintain queries
-- React to changes
-- Add, change, or delete queries
-
 .. _development-mode:
 .. _enable-development-mode:
 .. _enable-disable-development-mode:
@@ -451,8 +436,7 @@ directory of an :ref:`exported <export-app>` app:
        └── config.json
 
 For example, the following Sync configuration applies to apps using Flexible
-Sync (recommended). If you are using the older Partition-Based Sync, refer to
-:ref:`partition-based-sync-config-object`.
+Sync (recommended).
 
 .. code-block:: json
    :caption: sync/config.json

--- a/source/sync/configure/sync-settings.txt
+++ b/source/sync/configure/sync-settings.txt
@@ -24,7 +24,7 @@ Sync Type
 ~~~~~~~~~
 
 Atlas Device Sync has two sync modes: Flexible Sync and the older
-:ref:`Partition-Based Sync <partition-based-sync>`. Partition-Based Sync has 
+Partition-Based Sync. Partition-Based Sync has 
 been deprecated and is disallowed for new Sync configurations. If you have 
 an existing app that uses Partition-Based Sync, you can migrate 
 to Flexible Sync. For more information, refer to :ref:`realm-sync-migrate-modes`.

--- a/source/sync/configure/sync-settings.txt
+++ b/source/sync/configure/sync-settings.txt
@@ -19,6 +19,23 @@ Available Settings
 ------------------
 
 .. _flexible-sync:
+
+Sync Type
+~~~~~~~~~
+
+Atlas Device Sync has two sync modes: Flexible Sync and the older
+:ref:`Partition-Based Sync <partition-based-sync>`. Partition-Based Sync has 
+been deprecated and is disallowed for new Sync configurations. If you have 
+an existing app that uses Partition-Based Sync, you can migrate 
+to Flexible Sync. For more information, refer to :ref:`realm-sync-migrate-modes`.
+
+Flexible Sync lets you define a query in the client and sync only the objects
+that match the query. With client-side subscriptions, client applications can:
+
+- Maintain queries
+- React to changes
+- Add, change, or delete queries
+
 .. _development-mode:
 .. _enable-development-mode:
 .. _enable-disable-development-mode:
@@ -436,7 +453,7 @@ directory of an :ref:`exported <export-app>` app:
        └── config.json
 
 For example, the following Sync configuration applies to apps using Flexible
-Sync (recommended).
+Sync.
 
 .. code-block:: json
    :caption: sync/config.json

--- a/source/sync/error-handling/errors.txt
+++ b/source/sync/error-handling/errors.txt
@@ -80,31 +80,6 @@ errors and how to handle them. Atlas App Services reports errors in your
        specific error. For example, this might occur when you hit the storage
        limit of a free tier Atlas cluster.
 
-.. _partition-based-sync-errors:
-
-Partition-Based Sync Errors
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The following errors may occur when your App uses :ref:`Partition-Based Sync 
-<partition-based-sync>`.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 35 65
-
-   * - Error Name
-     - Description
-
-   * - ErrorIllegalRealmPath
-     - This error indicates that the client attempted to open a realm with a
-       partition value of the wrong type. For example, you might see the error
-       message "attempted to bind on illegal realm partition: expected partition
-       to have type objectId but found string".
-       
-       To recover from this error, ensure that the type of the partition value
-       used to open the realm matches the partition key type in your
-       Device Sync configuration.
-
 .. _flexible-sync-errors:
 
 Flexible Sync Errors

--- a/source/sync/get-started.txt
+++ b/source/sync/get-started.txt
@@ -30,9 +30,7 @@ Before You Start
   M0 cluster to explore and develop your app. We recommend that you use a
   dedicated tier cluster (M10 and above) for production applications. You cannot
   use sync with a :ref:`serverless instance <serverless-caveats>` or
-  :ref:`{+adf-instance+} <data-federation-caveats>`. :ref:`Partition-Based Sync
-  <partition-based-sync>`, requires a MongoDB Atlas cluster that runs MongoDB
-  version 4.4 or later.
+  :ref:`{+adf-instance+} <data-federation-caveats>`.
   
 - If you don't already have one, :ref:`create a new App
   <create-app>` linked to your Atlas cluster.
@@ -113,12 +111,6 @@ Define Data Access Patterns
 
 Once you have decided on your app's data model, you can define a data access 
 pattern and access rules for your app's data. 
-
-Choose a Sync Mode
-~~~~~~~~~~~~~~~~~~
-
-There are two Sync Modes: Flexible Sync and the older Partition-Based Sync. We
-recommend you use Flexible Sync.
 
 Client applications can query the queryable fields of a document to determine
 which objects to sync. Then, App Services applies rules and default roles to

--- a/source/sync/go-to-production/optimize-sync-atlas-usage.txt
+++ b/source/sync/go-to-production/optimize-sync-atlas-usage.txt
@@ -43,12 +43,6 @@ When you set a client maximum offline time in an App that uses :ref:`Flexible
 Sync <flexible-sync>`, **trimming** deletes changes older than the client
 maximum offline time.
 
-.. note::
-
-   Flexible Sync uses :ref:`trimming <trimming>` to reduce Device Sync history
-   stored in Atlas. Partition-Based Sync uses :ref:`backend compaction
-   <backend-compaction>`.
-
 .. _client-maximum-offline-time:
 
 Client Maximum Offline Time


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-34418
Staged changes:

- [Partition-Based Sync Mode](https://preview-mongodblindseymoore.gatsbyjs.io/atlas-app-services/DOCSP-34418/reference/partition-based-sync/#partition-strategies)
- [Sync Settings](https://preview-mongodblindseymoore.gatsbyjs.io/atlas-app-services/DOCSP-34418/sync/configure/sync-settings/)

<!--
- Write a summary of the changes and the related issue
- Include relevant motivation and context
- List any required dependencies for this change
-->

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for corresponding docs-realm updates, if any

### Release Notes

Other
- Pages throughout the docs set: Partition-Based Sync (PBS) has been removed from the App services UI. As a result, removed mentions of PBS throughout the docs and moved relevant PBS content to the Partition-Based Sync Mode reference page.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
