### PR TITLE
(DOCSP-34585): Clarify details about the different ways of connecting with Edge Server

### DIFF
--- a/source/edge-server/connect.txt
+++ b/source/edge-server/connect.txt
@@ -4,6 +4,10 @@
 Connect to an Edge Server
 =========================
 
+.. facet::
+   :name: genre 
+   :values: tutorial
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -161,3 +165,37 @@ modifications you can make to the :github:`Swift template app
          In a console app, delete the ``mongodb-realm`` directory. If you're
          using an iOS or Android simulator or device, uninstall and reinstall
          the app.
+
+.. _edge-server-wireprotocol-connect:
+
+Connect to the Edge Server with a MongoDB URI
+---------------------------------------------
+
+You can connect to the Edge Server using standard MongoDB Drivers and tools.
+Clients use a specialized MongoDB URI connection string to connect to 
+Edge Server and send requests.
+
+The wire protocol server is on by default. You can connect to it via the 
+host machine using this MongoDB URI:
+
+.. code:: console
+
+   mongodb://EDGE_SERVER_HOSTNAME:27021
+
+The ``EDGE_SERVER_HOSTNAME`` is the public DNS of your Edge Server host. 
+For more information, refer to :ref:`edge-server-install-and-configure`.
+
+You must make port 27021 accessible to the client through port mapping or
+firewall rules.
+
+.. example::
+
+   A wire protocol connection URI for an Edge Server hosted on Amazon EC2 
+   might look similar to:
+
+   .. code:: console
+
+      mongodb://ec2-13-58-70-88.us-east-2.compute.amazonaws.com:27021
+
+For information about the supported MongoDB APIs, refer to 
+:ref:`edge-server-mongodb`.

--- a/source/edge-server/connect.txt
+++ b/source/edge-server/connect.txt
@@ -18,15 +18,26 @@ Once the Edge Server is :ref:`configured <edge-server-configure>` and
 :ref:`running <start-and-stop-edge-server>`, you can connect to it from 
 a client application.
 
+There are two ways you can connect to the Edge Server from a client:
+
+- Using the Device SDKs
+- Using MongoDB Drivers and tools
+
+When you connect to Edge Server using a Device SDK, Device Sync automatically
+synchronizes data across devices and with the Edge server. If you connect
+to Edge Server using MongoDB Drivers or tools, you can perform CRUD operations 
+with a subset of supported MongoDB APIs.
+
 .. _edge-server-connect-from-client:
 
-Connect to the Edge Server from a Client
-----------------------------------------
+Connect to the Edge Server from the Device SDK
+----------------------------------------------
 
-To connect to the Edge Server from a client, your app must:
+To connect to the Edge Server from a Device SDK client, your app must:
 
-- Set the Sync URL to the public-accessible DNS address you set in the 
-  Edge Server :ref:`config's <edge-server-install-and-configure>` ``hostname`` 
+- Set the Sync URL on the App configuration to the public-accessible DNS 
+  address you set in the Edge Server 
+  :ref:`config's <edge-server-install-and-configure>` ``hostname`` 
   field.
 - If TLS is not enabled, use HTTP over port 80.
 
@@ -36,6 +47,18 @@ To connect to the Edge Server from a client, your app must:
    with HTTP over port 80 for simplicity. Before moving to production, 
    you can coordinate with your Product or Account Representative to configure
    HTTPS with a self-signed certificate.
+
+For information about customizing the App configuration, refer to the 
+documentation for your preferred SDK:
+
+- C++ SDK: :ref:`cpp-connect-to-backend`
+- Flutter SDK: :ref:`flutter-connect-to-backend`
+- Java SDK: :ref:`java-init-appclient`
+- Kotlin SDK: :ref:`kotlin-connect-to-backend`
+- .NET SDK: :ref:`dotnet-init-appclient`
+- Node.js SDK: :ref:`node-connect-to-mongodb-realm-backend-app`
+- React Native SDK: :ref:`react-native-connect-to-mongodb-realm-backend-app`
+- Swift SDK: :ref:`ios-init-appclient`
 
 Example: SwiftUI Template App
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -197,5 +220,5 @@ firewall rules.
 
       mongodb://ec2-13-58-70-88.us-east-2.compute.amazonaws.com:27021
 
-For information about the supported MongoDB APIs, refer to 
-:ref:`edge-server-mongodb`.
+Edge Server currently supports a subset of the MongoDB APIs. For information 
+about the supported APIs, refer to :ref:`edge-server-mongodb`.

--- a/source/edge-server/connect.txt
+++ b/source/edge-server/connect.txt
@@ -24,7 +24,7 @@ There are two ways you can connect to the Edge Server from a client:
 - Using MongoDB Drivers and tools
 
 When you connect to Edge Server using a Device SDK, Device Sync automatically
-synchronizes data across devices and with the Edge server. If you connect
+synchronizes data across devices and with the Edge Server. If you connect
 to Edge Server using MongoDB Drivers or tools, you can perform CRUD operations 
 with a subset of supported MongoDB APIs.
 

--- a/source/edge-server/mongodb.txt
+++ b/source/edge-server/mongodb.txt
@@ -4,6 +4,10 @@
 Edge Server MongoDB API Support
 ===============================
 
+.. facet::
+   :name: genre 
+   :values: reference
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -15,37 +19,11 @@ which allows you to access your Atlas data on the Edge using standard
 MongoDB drivers and tools. 
 
 Clients use a specialized MongoDB URI connection string to connect and 
-send requests.
+send requests. For more information about how to connect to the Edge Server
+using a MongoDB connection string, refer to :ref:`edge-server-wireprotocol-connect`.
 
 Edge Server currently supports a subset of the MongoDB APIs over the 
 wire protocol.
-
-.. _edge-server-wireprotocol-connect:
-
-Connect to the Edge Server
---------------------------
-
-The wire protocol server is on by default. You can connect to it via the 
-host machine using this MongoDB URI:
-
-.. code:: console
-
-   mongodb://EDGE_SERVER_HOSTNAME:27021
-
-The ``EDGE_SERVER_HOSTNAME`` is the public DNS of your Edge Server host. 
-For more information, refer to :ref:`edge-server-install-and-configure`.
-
-You must make port 27021 accessible to the client through port mapping or
-firewall rules.
-
-.. example::
-
-   A wire protocol connection URI for an Edge Server hosted on Amazon EC2 
-   might look similar to:
-
-   .. code:: console
-
-      mongodb://ec2-13-58-70-88.us-east-2.compute.amazonaws.com:27021
 
 CRUD APIs
 ---------


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-34585

Staged changes:

- [Connect to an Edge Server](https://preview-mongodbdacharyc.gatsbyjs.io/atlas-app-services/DOCSP-34585/edge-server/connect/): Move the "connect" section from the Use MongoDB APIs with Edge Server page so all the connection info is together. Add details about the different ways you can connect - via Device SDK or the MongoDB connection URI.
- [Use MongoDB APIs with Edge Server](https://preview-mongodbdacharyc.gatsbyjs.io/atlas-app-services/DOCSP-34585/edge-server/mongodb/): Remove the "Connect" section, add a link to its new location on the "Connect" page.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for corresponding docs-realm updates, if any

### Release Notes

- **Edge Server**
  - Connect to Edge Server: Move the "connect" section from the "Use MongoDB APIs with Edge Server" page. Add details about the different ways you can connect - via Device SDK or the MongoDB connection URI.
  - Use MongoDB APIs with Edge Server: Remove the "connect" section. Link to its new location on the "Connect to Edge Server" page.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
