### PR TITLE
(DOCSP-33212): Updating an IQF value from device causes a compensating write

### DIFF
--- a/source/sync/configure/sync-settings.txt
+++ b/source/sync/configure/sync-settings.txt
@@ -310,6 +310,11 @@ if your indexed queryable field is ``store_id``, the client cannot change
 this value directly. Changing it from the client is not supported because 
 it may conflict with other updates made to the object in the same timeframe. 
 
+If you attempt to change an indexed queryable field's value on the device,
+this triggers a compensating write error. For more information about this
+error and the behavior it entails, refer to ``ErrorCompensatingWrite`` in
+the :ref:`flexible-sync-errors` documentation.
+
 You can still change this value directly in the Atlas database. 
 
 .. warning::

--- a/source/sync/configure/sync-settings.txt
+++ b/source/sync/configure/sync-settings.txt
@@ -4,6 +4,10 @@
 Sync Settings
 =============
 
+.. facet::
+   :name: genre 
+   :values: reference
+
 .. default-domain:: mongodb
 
 .. contents:: On this page

--- a/source/sync/error-handling/errors.txt
+++ b/source/sync/error-handling/errors.txt
@@ -4,6 +4,10 @@
 Sync Errors
 ===========
 
+.. facet::
+   :name: genre 
+   :values: reference
+
 .. default-domain:: mongodb
 
 .. contents:: On this page
@@ -129,11 +133,11 @@ The following errors may occur when your App uses :ref:`Flexible Sync
      - This non-fatal error occurs when a client attempts an "illegal" write.
        The following are considered illegal writes:
 
-       - Creating an object before opening a subscription
+       - Creating an object before opening a subscription.
        - Creating an object that would be outside of the client's query view.
          "Query view" includes both the client's subscriptions and the client's
          read permissions.
-       - Modifying an object that is outside of the client's query view
+       - Modifying an object that is outside of the client's query view.
        - Creating, deleting, or modifying an object or field that the client
          does not have write permissions to.
        - Modifying an object in such a way that client would no longer have

--- a/source/sync/error-handling/errors.txt
+++ b/source/sync/error-handling/errors.txt
@@ -138,6 +138,9 @@ The following errors may occur when your App uses :ref:`Flexible Sync
          does not have write permissions to.
        - Modifying an object in such a way that client would no longer have
          write permissions on that object or field after the write.
+       - Updating an object's :ref:`indexed queryable field <fs-indexed-queryable-fields>` 
+         value from a device results in a compensating write which undoes 
+         the update on the device.
          
        Because the local realm has no concept of "illegal" writes, the write
        will always succeed locally. Upon sync, the server will notice the

--- a/source/sync/error-handling/errors.txt
+++ b/source/sync/error-handling/errors.txt
@@ -138,9 +138,8 @@ The following errors may occur when your App uses :ref:`Flexible Sync
          does not have write permissions to.
        - Modifying an object in such a way that client would no longer have
          write permissions on that object or field after the write.
-       - Updating an object's :ref:`indexed queryable field <fs-indexed-queryable-fields>` 
-         value from a device results in a compensating write which undoes 
-         the update on the device.
+       - Updating an existing object's :ref:`indexed queryable field <fs-indexed-queryable-fields>` 
+         value.
          
        Because the local realm has no concept of "illegal" writes, the write
        will always succeed locally. Upon sync, the server will notice the


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-33212

Staged changes:

- [Sync Settings](https://preview-mongodbdacharyc.gatsbyjs.io/atlas-app-services/DOCSP-33212/sync/configure/sync-settings/#indexed-queryable-fields): Note that attempting to change an indexed queryable field value on device causes a compensating write error. Link to the compensating write error documentation for more information.
- [Sync Errors](https://preview-mongodbdacharyc.gatsbyjs.io/atlas-app-services/DOCSP-33212/sync/error-handling/errors/#flexible-sync-errors): Add attempting to change an indexed queryable field value to the list of conditions that can trigger a compensating write error.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for corresponding docs-realm updates, if any

### Release Notes

- **Device Sync**
  - Configure Sync/Sync Settings: Note that attempting to change an indexed queryable field value on device causes a compensating write error. Link to the compensating write error documentation for more information.
  - Handle Errors/Sync Errors: Add attempting to change an indexed queryable field value to the list of conditions that can trigger a compensating write error.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
