### PR TITLE
DOCSP-34600 Mention that exp field is ignored for custom JWT

### DIFF
--- a/source/authentication/custom-jwt.txt
+++ b/source/authentication/custom-jwt.txt
@@ -4,6 +4,10 @@
 Custom JWT Authentication
 =========================
 
+.. facet::
+  :name: genre
+  :values: tutorial 
+
 .. default-domain:: mongodb
 
 .. contents:: On this page

--- a/source/authentication/custom-jwt.txt
+++ b/source/authentication/custom-jwt.txt
@@ -75,12 +75,13 @@ JWT authentication with App Services follows these general steps:
    #. App Services checks if the signature in the JWK matches the JWT's 
       signature. If so, the user is authenticated.
 
-.. note:: Access Token Expires after 30 Minutes
+.. important:: Access Token Always Expires after 30 Minutes
 
-  App Services specifies a 30 minute access token expiry even if the
+  App Services always specifies a 30-minute access token expiry even if the
   custom JWT token specifies a different expiry through the ``exp`` key. 
   App Services will check the custom JWT token ``exp`` to ensure that the token
-  is still valid before issuing the 30 minute expiry. 
+  is still valid before issuing the 30-minute expiry. For more information on 
+  App Services access tokens, refer to :ref:`manage-user-sessions`.
 
 .. _custom-jwt-authentication-configuration:
 .. _config-custom-jwt:

--- a/source/authentication/custom-jwt.txt
+++ b/source/authentication/custom-jwt.txt
@@ -71,6 +71,12 @@ JWT authentication with App Services follows these general steps:
    #. App Services checks if the signature in the JWK matches the JWT's 
       signature. If so, the user is authenticated.
 
+.. note:: Access Token Expires after 30 Minutes
+
+  App Services specifies a 30 minute access token expiry even if the
+  custom JWT token specifies a different expiry through the ``exp`` key. 
+  App Services will check the custom JWT token ``exp`` to ensure that the token
+  is still valid before issuing the 30 minute expiry. 
 
 .. _custom-jwt-authentication-configuration:
 .. _config-custom-jwt:


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-34600
Staged changes:

- [Custom JWT Authentication](https://preview-mongodblindseymoore.gatsbyjs.io/atlas-app-services/DOCSP-34600/authentication/custom-jwt/)

<!--
- Write a summary of the changes and the related issue
- Include relevant motivation and context
- List any required dependencies for this change
-->

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for corresponding docs-realm updates, if any

### Release Notes

<!--
- **Define Data Access Permissions**
  - Data Access Role Examples: Update CRUD Permissions example screenshots and
    copyable JSON
-->

- Authenticate and Manage Users/Authentication Providers/Custom JWT: Note that App services specifies a 30 minute expiry for the access token even if expiry is defined by the Custom JWT's ``exp`` key. 


### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
