### PR TITLE
DOCSP-35176: Remove caveat about nested functions with GH deployment

### DIFF
--- a/source/functions.txt
+++ b/source/functions.txt
@@ -5,7 +5,7 @@ Atlas Functions
 ===============
 
 .. meta:: 
-  :description: Atlas Functions are executable, server-side JavaScript code that define your app's behavior.
+  :description: Define Atlas Functions and call them manually or automatically to execute server-side JavaScript code.
 
 .. facet::
   :name: genre

--- a/source/functions.txt
+++ b/source/functions.txt
@@ -4,7 +4,12 @@
 Atlas Functions
 ===============
 
-.. default-domain:: mongodb
+.. meta:: 
+  :description: Atlas Functions are executable, server-side JavaScript code that define your app's behavior.
+
+.. facet::
+  :name: genre
+  :values: reference
 
 .. contents:: On this page
    :local:
@@ -236,8 +241,6 @@ or by importing the function configuration and source code with
                You can define functions inside of nested folders. Function names
                are slash-separated paths, so a function named ``utils/add`` maps
                to ``functions/utils/add.js`` in the app's configuration files.
-               Nested functions are *not* currently supported if you are using GitHub deployment.
-
 
          .. step:: Configure User Authentication
 
@@ -382,7 +385,6 @@ or by importing the function configuration and source code with
                You can define functions inside of nested folders in the
                ``functions`` directory. Use slashes in a function name to indicate
                its directory path.
-               Nested functions are *not* currently supported if you are using GitHub deployment.
 
             Once you've created the function's ``.js`` file, write the function source code, e.g.:
 


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-35176

- [Atlas Functions](https://preview-mongodbcbullinger.gatsbyjs.io/atlas-app-services/docsp-35176-nested-functions/functions/#define-a-function): Update step 2 (for UI and CLI) in Define a Function procedure to remove caveat about nested functions not supported when using GitHub deployment

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-realm work, if any

### Release Notes

- **Functions**: Update the Define a Function procedure to no longer specify nested functions are unsupported when using GitHub deployment.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
