### PR TITLE
(DOCSP-35269): Update Realm base URL to new App Services base URL

### DIFF
--- a/examples/data-api/utils.sh
+++ b/examples/data-api/utils.sh
@@ -1,7 +1,7 @@
 client_api_login() {
   local app_id="$1"
   local provider="$2"
-  local client_api_base_url="https://realm.mongodb.com/api/client/v2.0/app/$app_id"
+  local client_api_base_url="https://services.cloud.mongodb.com/api/client/v2.0/app/$app_id"
   local client_api_login_url="$client_api_base_url/auth/providers/$provider/login"
   case $provider in
     "anon-user")

--- a/source/activity/view-logs.txt
+++ b/source/activity/view-logs.txt
@@ -168,7 +168,7 @@ Logging endpoint with no additional parameters:
 .. code-block:: javascript
    :emphasize-lines: 20
 
-   const ADMIN_API_BASE_URL = "https://realm.mongodb.com/api/admin/v3.0";
+   const ADMIN_API_BASE_URL = "https://services.cloud.mongodb.com/api/admin/v3.0";
    exports = async function() {
      // Get values that you need for requests
      const projectId = "<Atlas Project ID>";
@@ -209,7 +209,7 @@ fields:
 .. code-block:: javascript
    :emphasize-lines: 16-17, 23
 
-   const ADMIN_API_BASE_URL = "https://realm.mongodb.com/api/admin/v3.0";
+   const ADMIN_API_BASE_URL = "https://services.cloud.mongodb.com/api/admin/v3.0";
    exports = async function() {
      // Get values that you need for requests
      const projectId = "<Atlas Project ID>";
@@ -263,7 +263,7 @@ entries.
 .. code-block:: javascript
    :emphasize-lines: 13-16, 39
 
-   const ADMIN_API_BASE_URL = "https://realm.mongodb.com/api/admin/v3.0";
+   const ADMIN_API_BASE_URL = "https://services.cloud.mongodb.com/api/admin/v3.0";
    exports = async function() {
      // Get values that you need for requests
      const projectId = "<Atlas Project ID>";

--- a/source/apps/change-deployment-models.txt
+++ b/source/apps/change-deployment-models.txt
@@ -188,7 +188,7 @@ Procedure
             .. code-block:: sh
 
                curl -X PUT \
-                 https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/deployment_migration \
+                 https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/deployment_migration \
                  -H 'Content-Type: application/json' \
                  -H 'Authorization: Bearer <AccessToken>' \
                  -d '{
@@ -206,7 +206,7 @@ Procedure
             .. code-block:: sh
                
                curl -X GET \
-                 https://realm.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/deployment_migration \
+                 https://services.cloud.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/deployment_migration \
                  -H 'Authorization: Bearer <AccessToken>'
 
          .. include:: /includes/step-deployment-region-migration-cleanup.rst

--- a/source/apps/cicd.txt
+++ b/source/apps/cicd.txt
@@ -161,7 +161,7 @@ in with that profile:
      public_api_key: "<MongoDB Atlas Public API Key>"
      private_api_key: "<MongoDB Atlas Private API Key>"
      atlas_base_url: "https://cloud.mongodb.com"
-     realm_base_url: "https://realm.mongodb.com"
+     realm_base_url: "https://services.cloud.mongodb.com"
      telemetry_mode: ""
 
 .. code-block:: bash

--- a/source/apps/create.txt
+++ b/source/apps/create.txt
@@ -220,7 +220,7 @@ Procedure
             .. code-block:: shell
 
                curl -X POST \
-                 https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps \
+                 https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps \
                  --header 'Authorization:  Bearer <access_token>' \
                  --data '{ "name": "<App Name>" }'
 
@@ -238,7 +238,7 @@ Procedure
               .. code-block:: shell
 
                  curl -X POST \
-                   https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps \
+                   https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps \
                    -H 'Authorization:  Bearer <access_token>' \
                    -d '{
                      "name": "<App Name>",

--- a/source/apps/delete.txt
+++ b/source/apps/delete.txt
@@ -131,7 +131,7 @@ Procedure
 
             .. code-block:: shell
 
-               curl --request DELETE 'https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}' \
+               curl --request DELETE 'https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}' \
                  --header 'Authorization:  Bearer <access_token>' \
                  --header 'Content-Type: application/json'
 

--- a/source/apps/environment.txt
+++ b/source/apps/environment.txt
@@ -256,7 +256,7 @@ Procedure
             .. code-block:: bash
 
                curl -X GET \
-                 https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/environment_values/{environmentValueId} \
+                 https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/environment_values/{environmentValueId} \
                  -H 'Authorization: Bearer <access_token>' \
                  -d '{
                    "name": "myEnvironmentValue",
@@ -278,6 +278,6 @@ Procedure
             .. code-block:: bash
 
                curl -X PUT \
-                 https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/environment \
+                 https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/environment \
                  -H 'Authorization: Bearer <access_token>' \
                  -d '{ "environment": "production" }'

--- a/source/apps/export.txt
+++ b/source/apps/export.txt
@@ -168,7 +168,7 @@ Procedure
             .. code-block:: shell
 
                curl -X GET \
-                 https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/export \
+                 https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/export \
                  -H 'Authorization: Bearer <access_token>' \
                  -H 'Content-Type: application/json' \
                  --output ./exported-app.zip
@@ -179,7 +179,7 @@ Procedure
 
             .. code-block:: text
 
-               https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/export?deployment={deploymentId}
+               https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/export?deployment={deploymentId}
 
             If the request is successful, the endpoint returns a ``200``
             response that contains a ``.zip`` directory of your

--- a/source/apps/metadata.txt
+++ b/source/apps/metadata.txt
@@ -78,7 +78,7 @@ or App Services CLI to find it programmatically.
          .. input::
             :language: bash
 
-            curl https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps \
+            curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps \
               --header 'Authorization: Bearer <access_token>'
 
          .. output::

--- a/source/apps/rollback.txt
+++ b/source/apps/rollback.txt
@@ -110,7 +110,7 @@ Procedure
                   :language: bash
 
                   curl -X GET \
-                    https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/deployments \
+                    https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/deployments \
                     -H 'Authorization: Bearer <access_token>'
 
                .. output::
@@ -158,5 +158,5 @@ Procedure
             .. code-block:: bash
 
                curl -X GET \
-                 https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/deployments/{deploymentId}/redeploy \
+                 https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/deployments/{deploymentId}/redeploy \
                  -H 'Authorization: Bearer <access_token>'

--- a/source/apps/update.txt
+++ b/source/apps/update.txt
@@ -183,7 +183,7 @@ Procedure
 
             .. code-block:: shell
 
-               curl -X POST 'https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/drafts' \
+               curl -X POST 'https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/drafts' \
                  -H 'Content-Type: application/json' \
                  -H 'Authorization: Bearer <access_token>'
 
@@ -197,7 +197,7 @@ Procedure
 
                .. code-block:: shell
 
-                  curl -X DELETE 'https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/drafts/{draftId}' \
+                  curl -X DELETE 'https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/drafts/{draftId}' \
                     -H 'Authorization: Bearer <access_token>'
 
          .. step:: Make Changes to Your Application
@@ -225,7 +225,7 @@ Procedure
             .. code-block:: shell
 
                curl -X POST \
-                 'https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/drafts/{draftId}/deployment' \
+                 'https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/drafts/{draftId}/deployment' \
                  --header 'Content-Type: application/json' \
                  --header 'Authorization: Bearer <access_token>' \
 
@@ -332,7 +332,7 @@ drafts with the Admin API.
       .. code-block:: bash
          :emphasize-lines: 5
 
-         curl -X PATCH https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/deploy/config \
+         curl -X PATCH https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/deploy/config \
            -H 'Authorization: Bearer <access_token>' \
            -H 'Content-Type: application/json' \
            -d '{

--- a/source/authentication/custom-jwt-firebase-config-admin-api-template.sh
+++ b/source/authentication/custom-jwt-firebase-config-admin-api-template.sh
@@ -1,4 +1,4 @@
-curl "https://realm.mongodb.com/api/admin/v3.0/groups/$PROJECT_ID/apps/$APP_ID/auth_providers" \
+curl "https://services.cloud.mongodb.com/api/admin/v3.0/groups/$PROJECT_ID/apps/$APP_ID/auth_providers" \
   -X "POST" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H "Content-Type: application/json" \

--- a/source/authentication/custom-jwt-okta-config-admin-api-template.sh
+++ b/source/authentication/custom-jwt-okta-config-admin-api-template.sh
@@ -1,4 +1,4 @@
-curl "https://realm.mongodb.com/api/admin/v3.0/groups/$PROJECT_ID/apps/$APP_ID/auth_providers" \
+curl "https://services.cloud.mongodb.com/api/admin/v3.0/groups/$PROJECT_ID/apps/$APP_ID/auth_providers" \
   -X "POST" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H "Content-Type: application/json" \

--- a/source/authentication/google.txt
+++ b/source/authentication/google.txt
@@ -108,7 +108,7 @@ credentials, and configuring the provider to connect with the project.
 
             .. code-block:: none
 
-               https://realm.mongodb.com
+               https://services.cloud.mongodb.com
 
             For :guilabel:`Authorized Redirect URIs`, enter the App Services
             authentication callback URL that corresponds to the

--- a/source/edge-server/configure.txt
+++ b/source/edge-server/configure.txt
@@ -166,7 +166,7 @@ Set up and run the Edge Server on the host.
 
       .. code-block:: shell
 
-         wget --content-disposition https://realm.mongodb.com/api/client/v2.0/tiered-sync/package/latest
+         wget --content-disposition https://services.cloud.mongodb.com/api/client/v2.0/tiered-sync/package/latest
 
       Unzip the tar to get the files.
 

--- a/source/graphql/authenticate.txt
+++ b/source/graphql/authenticate.txt
@@ -57,7 +57,7 @@ For example, the following request uses Bearer Authentication:
 .. code-block:: shell
    :emphasize-lines: 2
 
-   curl -X POST 'https://realm.mongodb.com/api/client/v2.0/app/<AppID>/graphql' \
+   curl -X POST 'https://services.cloud.mongodb.com/api/client/v2.0/app/<AppID>/graphql' \
       --header 'Authorization: Bearer <AccessToken>' \
       --header 'Content-Type: application/json' \
       --data-raw '{
@@ -105,7 +105,7 @@ the request's ``email`` and ``password`` headers.
 .. code-block:: shell
    :emphasize-lines: 2-3
 
-   curl -X POST 'https://realm.mongodb.com/api/client/v2.0/app/<AppID>/graphql' \
+   curl -X POST 'https://services.cloud.mongodb.com/api/client/v2.0/app/<AppID>/graphql' \
       --header 'email: <EmailAddress>' \
       --header 'password: <Password>' \
       --header 'Content-Type: application/json' \
@@ -123,7 +123,7 @@ To authenticate a GraphQL request with an :ref:`API Key
 .. code-block:: shell
    :emphasize-lines: 2
 
-   curl -X POST 'https://realm.mongodb.com/api/client/v2.0/app/<AppID>/graphql' \
+   curl -X POST 'https://services.cloud.mongodb.com/api/client/v2.0/app/<AppID>/graphql' \
       --header 'apiKey: <APIKey>' \
       --header 'Content-Type: application/json' \
       --data-raw '{
@@ -142,7 +142,7 @@ request's ``jwtTokenString`` header.
 .. code-block:: shell
    :emphasize-lines: 2
 
-   curl -X POST 'https://realm.mongodb.com/api/client/v2.0/app/<AppID>/graphql' \
+   curl -X POST 'https://services.cloud.mongodb.com/api/client/v2.0/app/<AppID>/graphql' \
       --header 'jwtTokenString: <JWT>' \
       --header 'Content-Type: application/json' \
       --data-raw '{

--- a/source/graphql/cli.txt
+++ b/source/graphql/cli.txt
@@ -37,7 +37,7 @@ Run a Query
       
       .. code-block:: shell
          
-         gq https://realm.mongodb.com/api/client/v2.0/app/<Your App ID>/graphql \
+         gq https://services.cloud.mongodb.com/api/client/v2.0/app/<Your App ID>/graphql \
              -H 'Authorization: Bearer <Valid Access Token>' \
              -q 'query AllMoviesFromYear($year: Int!) { movies(query: { year: $year }) { title year runtime } }' \
              -v 'year=2000'
@@ -47,7 +47,7 @@ Run a Query
       
       .. code-block:: shell
          
-         curl https://realm.mongodb.com/api/client/v2.0/app/<Your App ID>/graphql \
+         curl https://services.cloud.mongodb.com/api/client/v2.0/app/<Your App ID>/graphql \
            -X POST \
            -H 'Authorization: Bearer <Valid Access Token>' \
            -d '{ "query": "query AllMoviesFromYear($year: Int!) { movies(query: { year: $year }) { title year runtime } }",
@@ -63,7 +63,7 @@ Run a Mutation
       
       .. code-block:: shell
 
-         gq https://realm.mongodb.com/api/client/v2.0/app/<Your App ID>/graphql \
+         gq https://services.cloud.mongodb.com/api/client/v2.0/app/<Your App ID>/graphql \
              -H 'Authorization: Bearer <Valid Access Token>' \
              -q 'mutation UpdateMovieTitle($oldTitle: String!, $newTitle: String!) { updateOneMovie(query: { title: $oldTitle } set: { title: $newTitle }) { title year } }'
              -v 'oldTitle=The Matrix Reloaded'
@@ -74,7 +74,7 @@ Run a Mutation
       
       .. code-block:: shell
          
-         curl https://realm.mongodb.com/api/client/v2.0/app/<Your App ID>/graphql \
+         curl https://services.cloud.mongodb.com/api/client/v2.0/app/<Your App ID>/graphql \
            -X POST \
            -H 'Authorization: Bearer <Valid Access Token>' \
            -d '{ "query": "mutation UpdateMovieTitle($oldTitle: String!, $newTitle: String!) { updateOneMovie(query: { title: $oldTitle } set: { title: $newTitle }) { title year } }",

--- a/source/includes/api-authenticate-instructions.rst
+++ b/source/includes/api-authenticate-instructions.rst
@@ -4,7 +4,7 @@ key pair:
 .. code-block:: shell
 
    curl -X POST \
-     https://realm.mongodb.com/api/admin/v3.0/auth/providers/mongodb-cloud/login \
+     https://services.cloud.mongodb.com/api/admin/v3.0/auth/providers/mongodb-cloud/login \
      -H 'Content-Type: application/json' \
      -H 'Accept: application/json' \
      -d '{

--- a/source/includes/deployment-region-auth-callback-urls.rst
+++ b/source/includes/deployment-region-auth-callback-urls.rst
@@ -8,46 +8,46 @@
    * - | **Global**
      - .. code-block:: text
 
-          https://realm.mongodb.com/api/client/v2.0/auth/callback 
+          https://services.cloud.mongodb.com/api/client/v2.0/auth/callback 
 
    * - | **Virginia**
        | (``us-east-1``)
      - .. code-block:: text
 
-          https://us-east-1.aws.realm.mongodb.com/api/client/v2.0/auth/callback
+          https://us-east-1.aws.services.cloud.mongodb.com/api/client/v2.0/auth/callback
 
    * - | **Oregon**
        | (``us-west-2``)
      - .. code-block:: text
 
-          https://us-west-2.aws.realm.mongodb.com/api/client/v2.0/auth/callback
+          https://us-west-2.aws.services.cloud.mongodb.com/api/client/v2.0/auth/callback
 
    * - | **Ireland**
        | (``eu-west-1``)
      - .. code-block:: text
 
-          https://eu-west-1.aws.realm.mongodb.com/api/client/v2.0/auth/callback
+          https://eu-west-1.aws.services.cloud.mongodb.com/api/client/v2.0/auth/callback
 
    * - | **Frankfurt**
        | (``eu-central-1``)
      - .. code-block:: text
 
-          https://eu-central-1.aws.realm.mongodb.com/api/client/v2.0/auth/callback
+          https://eu-central-1.aws.services.cloud.mongodb.com/api/client/v2.0/auth/callback
 
    * - | **Mumbai**
        | (``ap-south-1``)
      - .. code-block:: text
 
-          https://ap-south-1.aws.realm.mongodb.com/api/client/v2.0/auth/callback
+          https://ap-south-1.aws.services.cloud.mongodb.com/api/client/v2.0/auth/callback
 
    * - | **Singapore**
        | (``ap-southeast-1``)
      - .. code-block:: text
 
-          https://ap-southeast-1.aws.realm.mongodb.com/api/client/v2.0/auth/callback
+          https://ap-southeast-1.aws.services.cloud.mongodb.com/api/client/v2.0/auth/callback
 
    * - | **Sydney**
        | (``ap-southeast-2``)
      - .. code-block:: text
 
-          https://ap-southeast-2.aws.realm.mongodb.com/api/client/v2.0/auth/callback
+          https://ap-southeast-2.aws.services.cloud.mongodb.com/api/client/v2.0/auth/callback

--- a/source/includes/template-app-custom-user-data-workaround.rst
+++ b/source/includes/template-app-custom-user-data-workaround.rst
@@ -2,7 +2,7 @@
 generator does not copy the custom user data configuration to the new app
 correctly. You can fix this as follows: the ``{+cli-bin+} apps create`` command
 should have output some JSON about the app you just created. From this JSON,
-copy the "url" value (something like ``https://realm.mongodb.com/groups/...``)
+copy the "url" value (something like ``https://services.cloud.mongodb.com/groups/...``)
 and visit that URL in your browser. Log in if prompted. From the app dashboard,
 in the left-hand panel, click :guilabel:`App Users`. Click :guilabel:`Custom
 User Data`. Ensure :guilabel:`Enable Custom User Data` is ``ON``. If it was not

--- a/source/index.txt
+++ b/source/index.txt
@@ -231,7 +231,7 @@ run virtually any app or backend service on top of Atlas.
 
                   .. code-block:: bash
 
-                     curl -X POST https://realm.mongodb.com/api/client/v2.0/app/<Your App ID>/graphql \
+                     curl -X POST https://services.cloud.mongodb.com/api/client/v2.0/app/<Your App ID>/graphql \
                        -H 'apiKey: <YOUR API KEY>' \
                        -d {
                          "query": "query GetMeetingsInDateRange($start: DateTime!, $end: DateTime!) { meetings(query: { start_gte: $start, end_lte: $end }) { _id start end location } }"

--- a/source/mongodb/wire-protocol.txt
+++ b/source/mongodb/wire-protocol.txt
@@ -73,7 +73,7 @@ App Services connection strings have the following form:
 
 .. code-block:: shell
 
-   mongodb://<credentials>@<region>.realm.mongodb.com:27020/?<parameters>
+   mongodb://<credentials>@<region>.services.cloud.mongodb.com:27020/?<parameters>
 
 .. _wire-protocol-credentials:
 
@@ -186,7 +186,7 @@ Global Apps use the ``global`` region:
 
 .. code-block:: shell
 
-   mongodb://<credentials>@global.realm.mongodb.com:27020/?<parameters>
+   mongodb://<credentials>@global.services.cloud.mongodb.com:27020/?<parameters>
 
 Local Apps specify the cloud provider and region name using
 ``<region>.<cloud>`` format. For example, an app deployed to
@@ -194,7 +194,7 @@ Local Apps specify the cloud provider and region name using
 
 .. code-block:: shell
 
-   mongodb://<credentials>@us-east-1.aws.realm.mongodb.com:27020/?<parameters>
+   mongodb://<credentials>@us-east-1.aws.services.cloud.mongodb.com:27020/?<parameters>
 
 .. _wire-protocol-parameters:
 
@@ -364,14 +364,14 @@ with a regular :manual:`connection string
       
       .. code-block:: shell
      
-         $ mongo "mongodb://<user>:<password>@realm.mongodb.com:27020/?authMechanism=PLAIN&authSource=%24external&ssl=true&appName=realm-application-abcde:mongodb-atlas:local-userpass"
+         $ mongo "mongodb://<user>:<password>@services.cloud.mongodb.com:27020/?authMechanism=PLAIN&authSource=%24external&ssl=true&appName=realm-application-abcde:mongodb-atlas:local-userpass"
         
    .. tab::
       :tabid: python
       
       .. code-block:: python
      
-         client = pymongo.MongoClient("mongodb://<user>:<password>@realm.mongodb.com:27020/?authMechanism=PLAIN&authSource=%24external&ssl=true&appName=realm-application-abcde:mongodb-atlas:local-userpass")
+         client = pymongo.MongoClient("mongodb://<user>:<password>@services.cloud.mongodb.com:27020/?authMechanism=PLAIN&authSource=%24external&ssl=true&appName=realm-application-abcde:mongodb-atlas:local-userpass")
         
    .. tab::
       :tabid: cpp
@@ -379,7 +379,7 @@ with a regular :manual:`connection string
       .. code-block:: cpp
      
          mongocxx::instance instance{};
-         mongocxx::uri uri("mongodb://<user>:<password>@realm.mongodb.com:27020/?authMechanism=PLAIN&authSource=%24external&ssl=true&appName=realm-application-abcde:mongodb-atlas:local-userpass");
+         mongocxx::uri uri("mongodb://<user>:<password>@services.cloud.mongodb.com:27020/?authMechanism=PLAIN&authSource=%24external&ssl=true&appName=realm-application-abcde:mongodb-atlas:local-userpass");
          mongocxx::client client(uri);
 
 Read and Modify Data

--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -51,7 +51,7 @@ info:
     ```sh
     curl --request GET \
       --header 'Authorization: Bearer <access_token>' \
-      https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps
+      https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps
     ```
 
     This will return a list of objects describing each App Services App
@@ -95,7 +95,7 @@ info:
       --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
       --data '{"username": "<Public API Key>", "apiKey": "<Private API Key>"}' \
-      https://realm.mongodb.com/api/admin/v3.0/auth/providers/mongodb-cloud/login
+      https://services.cloud.mongodb.com/api/admin/v3.0/auth/providers/mongodb-cloud/login
     ```
 
     If authentication succeeds, App Services returns an access token as
@@ -136,7 +136,7 @@ info:
     ```shell
     curl --request POST \
       --header 'Authorization: Bearer <refresh_token>' \
-      https://realm.mongodb.com/api/admin/v3.0/auth/session
+      https://services.cloud.mongodb.com/api/admin/v3.0/auth/session
     ```
 
     If the refresh token is valid, the response body includes a new
@@ -151,7 +151,7 @@ info:
   version: "3.0"
   title: MongoDB Atlas App Services Admin API
 servers:
-  - url: https://realm.mongodb.com/api/admin/v3.0
+  - url: https://services.cloud.mongodb.com/api/admin/v3.0
     description: The root API resource and starting point for the App Services API.
 paths:
   "/auth/providers":
@@ -8216,7 +8216,7 @@ components:
           example: eps_baas-pl-prod_us-east-1_cloud
         dns:
           type: string
-          example: "*.aws.realm.mongodb.com"
+          example: "*.aws.services.cloud.mongodb.com"
         service_name:
           type: string
           example: com.amazonaws.vpce.us-east-1.vpce-svc-0f24fc6e6de007e5e
@@ -8294,7 +8294,7 @@ tags:
       curl --request POST \
         --header 'Content-Type: application/json' \
         --header 'Authorization: Bearer <access_token>' \
-        'https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/drafts'
+        'https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/drafts'
       ```
 
 
@@ -8308,7 +8308,7 @@ tags:
       ```shell
       curl --request DELETE \
         --header 'Authorization: Bearer <access_token>' \
-        'https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/drafts/{draftId}'
+        'https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/drafts/{draftId}'
       ```
 
       ### 2. Make Changes to Your Application
@@ -8327,7 +8327,7 @@ tags:
       curl --request POST \
         --header 'Content-Type: application/json' \
         --header 'Authorization: Bearer <access_token>' \
-        'https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/drafts/{draftId}/deployment'
+        'https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/drafts/{draftId}/deployment'
       ```
 
       #### Draft Conflicts
@@ -8365,7 +8365,7 @@ tags:
       [App Configuration](#tag/apps/operation/adminGetApplication):
 
       ```sh
-      curl -X GET https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId} \
+      curl -X GET https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId} \
         -h 'Authorization: Bearer <AccessToken>'
       ```
 
@@ -8374,7 +8374,7 @@ tags:
       Configuration](#tag/data-api/operation/adminGetDataApiConfig):
 
       ```sh
-      curl -X GET "https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/data_api/config" \
+      curl -X GET "https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/data_api/config" \
         -h 'Authorization: Bearer <AccessToken>'
       ```
 
@@ -8424,7 +8424,7 @@ tags:
       calling the [Get an App](#tag/apps/operation/adminGetApplication) endpoint:
 
       ```sh
-      curl -X GET https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId} \
+      curl -X GET https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId} \
         -h 'Authorization: Bearer <AccessToken>'
       ```
 
@@ -8506,7 +8506,7 @@ tags:
       ```sh
       curl --request GET \
         --header 'Authorization: Bearer <access_token>' \
-        'https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/logs'
+        'https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/logs'
       ```
 
       To request the next page of up to 100 log entries, pass the values of
@@ -8516,7 +8516,7 @@ tags:
       ```sh
       curl --request GET \
         --header 'Authorization: Bearer <access_token>' \
-        'https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/logs?end_date={nextEndDate of previous response}&skip={nextSkip of previous response}'
+        'https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/logs?end_date={nextEndDate of previous response}&skip={nextSkip of previous response}'
       ```
 
       Repeat this step to get more pages until the response does not have a

--- a/source/reference/partition-based-sync.txt
+++ b/source/reference/partition-based-sync.txt
@@ -543,7 +543,7 @@ Procedure
 
             .. code-block:: shell
 
-               curl https://realm.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services \
+               curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services \
                  -X GET \
                  -h 'Authorization: Bearer <Valid Access Token>'
 
@@ -557,7 +557,7 @@ Procedure
 
             .. code-block:: shell
 
-               curl https://realm.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services/{MongoDB_Service_ID}/config \
+               curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services/{MongoDB_Service_ID}/config \
                  -X GET \
                  -h 'Authorization: Bearer <Valid Access Token>'
 
@@ -601,7 +601,7 @@ Procedure
 
             .. code-block:: shell
 
-               curl https://realm.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/sync/data?service_id=<MongoDB Service ID> \
+               curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/sync/data?service_id=<MongoDB Service ID> \
                  -X GET \
                  -h 'Authorization: Bearer <Valid Access Token>'
 
@@ -745,7 +745,7 @@ Procedure
 
             .. code-block:: shell
 
-               curl https://realm.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services/{MongoDB_Service_ID}/config \
+               curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services/{MongoDB_Service_ID}/config \
                  -X PATCH \
                  -h 'Authorization: Bearer <Valid Access Token>' \
                  -d @/sync/config.json

--- a/source/reference/template-apps.txt
+++ b/source/reference/template-apps.txt
@@ -85,7 +85,7 @@ option is most convenient for you.
          :emphasize-lines: 6
 
          curl -X POST \
-           https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps \
+           https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps \
            -H 'Authorization: Bearer <access_token>' \
            -d '{
              "name": "<App Name>",

--- a/source/security/network.txt
+++ b/source/security/network.txt
@@ -210,7 +210,7 @@ DNS Filtering
 You can use DNS filtering to specifically allow connections from client
 applications, including Device Sync clients, to the server.
 
-Access ``*.realm.mongodb.com`` via HTTPS or port 443.
+Access ``*.services.cloud.mongodb.com`` via HTTPS or port 443.
 
 .. _security-allowed-request-origins:
 
@@ -294,7 +294,7 @@ View IP Access List Entries
 
          curl --request GET \
            --header 'Authorization: Bearer <access_token>' \
-           https://realm.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/security/access_list
+           https://services.cloud.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/security/access_list
 
       .. seealso::
       
@@ -350,7 +350,7 @@ Create an IP Access List Entry
          curl --request POST \
            --header 'Authorization: Bearer <access_token>' \
            --data '{ "address": "<IP Address>" }' \
-           https://realm.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/security/access_list
+           https://services.cloud.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/security/access_list
 
       .. seealso::
       
@@ -408,7 +408,7 @@ Edit an IP Access List Entry
          curl --request PATCH \
            --header 'Authorization: Bearer <access_token>' \
            --data '{ "address": "<IP Address>" }' \
-           https://realm.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/security/access_list/<ipID>
+           https://services.cloud.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/security/access_list/<ipID>
 
       .. seealso::
       
@@ -452,7 +452,7 @@ Delete an IP Access List Entry
 
          curl --request DELETE \
            --header 'Authorization: Bearer <access_token>' \
-           https://realm.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/security/access_list/<ipID>
+           https://services.cloud.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/security/access_list/<ipID>
 
       .. seealso::
       

--- a/source/security/private-endpoints.txt
+++ b/source/security/private-endpoints.txt
@@ -71,7 +71,7 @@ following information:
       .. input::
         :language: sh
 
-        curl https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/security/private_endpoint_service_infos \
+        curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/security/private_endpoint_service_infos \
           -H "Authorization: Bearer <access_token>"
 
       .. output::
@@ -82,7 +82,7 @@ following information:
           {
             "cloud_provider_region": "aws-us-east-1",
             "name": "eps_baas-pl-prod_us-east-1_cloud",
-            "dns": "*.aws.realm.mongodb.com",
+            "dns": "*.aws.services.cloud.mongodb.com",
             "service_name": "com.amazonaws.vpce.us-east-1.vpce-svc-0f12ab34cd56ef789"
           },
           ...
@@ -208,7 +208,7 @@ connection using either the App Services UI or the Admin API.
 
             .. code-block:: sh
 
-               curl https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/security/private_endpoints \
+               curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/security/private_endpoints \
                  -X POST \
                  -H "Authorization: Bearer <accessToken>" \
                  -H "Content-Type: application/json" \

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -161,7 +161,7 @@ Procedure
 
             .. code-block:: shell
 
-               curl https://realm.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services \
+               curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services \
                  -X GET \
                  -h 'Authorization: Bearer <Valid Access Token>'
 
@@ -175,7 +175,7 @@ Procedure
 
             .. code-block:: shell
 
-               curl https://realm.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services/{MongoDB_Service_ID}/config \
+               curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services/{MongoDB_Service_ID}/config \
                  -X GET \
                  -h 'Authorization: Bearer <Valid Access Token>'
 
@@ -216,7 +216,7 @@ Procedure
 
             .. code-block:: shell
 
-               curl https://realm.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services/{MongoDB_Service_ID}/config \
+               curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services/{MongoDB_Service_ID}/config \
                  -X PATCH \
                  -h 'Authorization: Bearer <Valid Access Token>' \
                  -h "Content-Type: application/json"

--- a/source/sync/configure/pause-or-terminate-sync.txt
+++ b/source/sync/configure/pause-or-terminate-sync.txt
@@ -100,7 +100,7 @@ all clients.
             
             The URL in your browser's toolbar should now resemble:
 
-            ``https://realm.mongodb.com/groups/$GROUP_ID/apps/$APP_ID/services/$SERVICE_ID/config``
+            ``https://services.cloud.mongodb.com/groups/$GROUP_ID/apps/$APP_ID/services/$SERVICE_ID/config``
 
          .. step:: Get the Sync Service Configuration
 
@@ -280,7 +280,7 @@ terminate and re-enable Device Sync under a few different circumstances:
             
             The URL in your browser's toolbar should now resemble:
 
-            ``https://realm.mongodb.com/groups/$GROUP_ID/apps/$APP_ID/services/$SERVICE_ID/config``
+            ``https://services.cloud.mongodb.com/groups/$GROUP_ID/apps/$APP_ID/services/$SERVICE_ID/config``
 
          .. step:: Get the Sync Service Configuration
 

--- a/source/users/create.txt
+++ b/source/users/create.txt
@@ -151,7 +151,7 @@ configured user confirmation flows.
          curl --request POST \
            --header 'Authorization: Bearer <access_token>' \
            --data '{ "email": "<string>", "password": "<string>" }' \
-           https://realm.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/users
+           https://services.cloud.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/users
 
       .. note::
          
@@ -230,7 +230,7 @@ users manually using the App Services UI or the Admin API:
 
          curl --request POST \
            --header 'Authorization: Bearer <access_token>' \
-           https://realm.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/user_registrations/by_email/<email>/confirm
+           https://services.cloud.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/user_registrations/by_email/<email>/confirm
 
       .. seealso::
        
@@ -309,7 +309,7 @@ the App Services UI or the :doc:`App Services Admin API </admin/api/v3>`:
 
          curl --request POST \
            --header 'Authorization: Bearer <access_token>' \
-           https://realm.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/user_registrations/by_email/<email>/run_confirm
+           https://services.cloud.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/user_registrations/by_email/<email>/run_confirm
 
       .. seealso::
        

--- a/source/users/custom-metadata.txt
+++ b/source/users/custom-metadata.txt
@@ -351,7 +351,7 @@ Enable Custom User Data
 
          .. code-block:: shell
 
-            curl --request PATCH 'https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/custom_user_data' \
+            curl --request PATCH 'https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/custom_user_data' \
               --header 'Authorization:  Bearer <access_token>' \
               --header 'Content-Type: application/json' \
               --data '{
@@ -613,7 +613,7 @@ Configure Authentication Provider Metadata
                .. code-block:: shell
                   :emphasize-lines: 15-25
 
-                  curl --request PATCH 'https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/auth_providers/{providerId}' \
+                  curl --request PATCH 'https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/auth_providers/{providerId}' \
                     --header 'Authorization:  Bearer <access_token>' \
                     --header 'Content-Type: application/json' \
                     --data '{
@@ -647,7 +647,7 @@ Configure Authentication Provider Metadata
                .. code-block:: shell
                   :emphasize-lines: 15-25
 
-                  curl --request PATCH 'https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/auth_providers/{providerId}' \
+                  curl --request PATCH 'https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/auth_providers/{providerId}' \
                     --header 'Authorization:  Bearer <access_token>' \
                     --header 'Content-Type: application/json' \
                     --data '{
@@ -681,7 +681,7 @@ Configure Authentication Provider Metadata
                .. code-block:: shell
                   :emphasize-lines: 8-14
 
-                  curl --request PATCH 'https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/auth_providers/{providerId}' \
+                  curl --request PATCH 'https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/auth_providers/{providerId}' \
                     --header 'Authorization:  Bearer <access_token>' \
                     --header 'Content-Type: application/json' \
                     --data '{

--- a/source/users/manage.txt
+++ b/source/users/manage.txt
@@ -88,7 +88,7 @@ You can use the App Services UI, CLI, or Admin API to manually remove a user acc
 
          curl --request DELETE \
            --header 'Authorization: Bearer <access_token>' \
-           https://realm.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/users/<userId>
+           https://services.cloud.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/users/<userId>
       
       If you want to delete a :ref:`pending <confirm-user>`
       email/password user, create a request in the following format: 
@@ -97,7 +97,7 @@ You can use the App Services UI, CLI, or Admin API to manually remove a user acc
 
          curl --request DELETE \
             --header 'Authorization: Bearer <access_token>' \
-            https://realm.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/user_registrations/by_email/<email>
+            https://services.cloud.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/user_registrations/by_email/<email>
 
       .. seealso::
       
@@ -150,7 +150,7 @@ take any arguments, and deletes the user who calls the function.
 
 .. code-block:: javascript
 
-   const apiUrl = "https://realm.mongodb.com/api/admin/v3.0/groups/{insert-your-project-id}/apps/{insert-your-app-id}";
+   const apiUrl = "https://services.cloud.mongodb.com/api/admin/v3.0/groups/{insert-your-project-id}/apps/{insert-your-app-id}";
 
    exports = async function(){
 
@@ -163,7 +163,7 @@ take any arguments, and deletes the user who calls the function.
       const username = context.values.get("adminApiPublicKey");
       const apiKey = context.values.get("adminApiPrivateKey");
       const response = await context.http.post({
-         url: "https://realm.mongodb.com/api/admin/v3.0/auth/providers/mongodb-cloud/login",
+         url: "https://services.cloud.mongodb.com/api/admin/v3.0/auth/providers/mongodb-cloud/login",
          body: {username, apiKey},
          encodeBodyAsJSON: true,
       });
@@ -246,7 +246,7 @@ invalidates any of the user's existing access and refresh tokens. You can
 
          curl --request PUT \
            --header 'Authorization: Bearer <access_token>' \
-           https://realm.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/users/<userId>/disable
+           https://services.cloud.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/users/<userId>/disable
 
       .. seealso::
       
@@ -311,7 +311,7 @@ You can enable a :ref:`disabled user <disable-user>` to let them log in again.
 
          curl --request PUT \
            --header 'Authorization: Bearer <access_token>' \
-           https://realm.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/users/<userId>/enable
+           https://services.cloud.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/users/<userId>/enable
 
       .. seealso::
       

--- a/source/users/read-metadata.txt
+++ b/source/users/read-metadata.txt
@@ -123,7 +123,7 @@ Find Users
 
          curl --request GET \
            --header 'Authorization: Bearer <access_token>' \
-           https://realm.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/users
+           https://services.cloud.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/users
 
       If you already know the ID of the user you want to find, you can append 
       the ID to the request URL:
@@ -133,7 +133,7 @@ Find Users
 
          curl --request GET \
            --header 'Authorization: Bearer <access_token>' \
-           https://realm.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/users/<userId>
+           https://services.cloud.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/users/<userId>
 
       .. seealso::
       
@@ -252,7 +252,7 @@ satisfy the filter conditions.
             
             curl --request GET \
               --header 'Authorization: Bearer <access_token>' \
-              https://realm.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/users?desc=true
+              https://services.cloud.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/users?desc=true
       
       You can also limit results to only :ref:`pending <confirm-user>` (unconfirmed) 
       email/password users. Create a ``GET`` request in the following format:
@@ -261,7 +261,7 @@ satisfy the filter conditions.
 
          curl --request GET \
            --header 'Authorization: Bearer <access_token>' \
-           https://realm.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/user_registrations/pending_users
+           https://services.cloud.mongodb.com/api/admin/v3.0/groups/<groupId>/apps/<appId>/user_registrations/pending_users
    
       .. seealso::
       

--- a/source/users/sessions.txt
+++ b/source/users/sessions.txt
@@ -56,7 +56,7 @@ access token.
 
             .. code-block:: text
 
-               https://realm.mongodb.com/api/client/v2.0/app/<App ID>
+               https://services.cloud.mongodb.com/api/client/v2.0/app/<App ID>
 
             Replace ``<AppID>`` with your client App ID. For example,
             ``myapp-abcde``.
@@ -66,7 +66,7 @@ access token.
 
             .. code-block:: text
 
-               https://<Region>.<Cloud>.realm.mongodb.com/api/client/v2.0/app/<AppID>/auth/providers/<ProviderType>/login
+               https://<Region>.<Cloud>.services.cloud.mongodb.com/api/client/v2.0/app/<AppID>/auth/providers/<ProviderType>/login
 
             - Replace ``<Region>`` with the region where your app is hosted. For example, ``us-east-1``.
 
@@ -83,7 +83,7 @@ access token.
          .. input::
             :language: shell
 
-            curl 'https://realm.mongodb.com/api/client/v2.0/app/<AppID>/location'
+            curl 'https://services.cloud.mongodb.com/api/client/v2.0/app/<AppID>/location'
 
          .. output::
             :language: json
@@ -92,8 +92,8 @@ access token.
             {
               "deployment_model": "LOCAL",
               "location": "US-VA",
-              "hostname": "https://us-east-1.aws.realm.mongodb.com",
-              "ws_hostname": "wss://ws.us-east-1.aws.realm.mongodb.com"
+              "hostname": "https://us-east-1.aws.services.cloud.mongodb.com",
+              "ws_hostname": "wss://ws.us-east-1.aws.services.cloud.mongodb.com"
             }
 
    .. step:: Authenticate a User
@@ -120,7 +120,7 @@ access token.
 
             .. code-block:: shell
 
-               curl -X POST 'https://realm.mongodb.com/api/client/v2.0/app/myapp-abcde/auth/providers/anon-user/login'
+               curl -X POST 'https://services.cloud.mongodb.com/api/client/v2.0/app/myapp-abcde/auth/providers/anon-user/login'
 
          .. tab::
             :tabid: local-userpass
@@ -128,7 +128,7 @@ access token.
             .. code-block:: shell
                :emphasize-lines: 4-5
 
-               curl -X POST 'https://realm.mongodb.com/api/client/v2.0/app/myapp-abcde/auth/providers/local-userpass/login' \
+               curl -X POST 'https://services.cloud.mongodb.com/api/client/v2.0/app/myapp-abcde/auth/providers/local-userpass/login' \
                  --header 'Content-Type: application/json' \
                  --data-raw '{
                    "username": "test@example.com",
@@ -141,7 +141,7 @@ access token.
             .. code-block:: shell
                :emphasize-lines: 4
 
-               curl -X POST 'https://realm.mongodb.com/api/client/v2.0/app/myapp-abcde/auth/providers/api-key/login' \
+               curl -X POST 'https://services.cloud.mongodb.com/api/client/v2.0/app/myapp-abcde/auth/providers/api-key/login' \
                  --header 'Content-Type: application/json' \
                  --data-raw '{
                    "key": "hScMWZyOKnjQMbfDPMJ1qHgtdGT2raQXdVDDvlC2SzKEBKlHKV8FK9SPCSTnODPg"
@@ -153,7 +153,7 @@ access token.
             .. code-block:: shell
                :emphasize-lines: 4
 
-               curl -X POST 'https://realm.mongodb.com/api/client/v2.0/app/myapp-abcde/auth/providers/custom-token/login' \
+               curl -X POST 'https://services.cloud.mongodb.com/api/client/v2.0/app/myapp-abcde/auth/providers/custom-token/login' \
                  --header 'Content-Type: application/json' \
                  --data-raw '{
                  	 "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0ZGV2LWJwcWVsIiwiZXhwIjoxNTE2MjM5MDIyLCJzdWIiOiIyNDYwMSIsInVzZXJfZGF0YSI6eyJuYW1lIjoiSmVhbiBWYWxqZWFuIiwiYWxpYXNlcyI6WyJNb25zaWV1ciBNYWRlbGVpbmUiLCJVbHRpbWUgRmF1Y2hlbGV2ZW50IiwiVXJiYWluIEZhYnJlIl19fQ.mVWr4yFf8nD1EhuhrJbgKfY7BEpMab38RflXzUxuaEI"
@@ -165,7 +165,7 @@ access token.
             .. code-block:: shell
                :emphasize-lines: 4
 
-               curl -X POST 'https://realm.mongodb.com/api/client/v2.0/app/myapp-abcde/auth/providers/custom-function/login' \
+               curl -X POST 'https://services.cloud.mongodb.com/api/client/v2.0/app/myapp-abcde/auth/providers/custom-function/login' \
                  --header 'Content-Type: application/json' \
                  --data-raw '{
                  	 "someCustomFunctionArg": "<Login Info>"
@@ -239,7 +239,7 @@ depends on your App's deployment model.
             :language: shell
             :emphasize-lines: 3
 
-            curl -X POST 'https://realm.mongodb.com/api/client/v2.0/auth/session' \
+            curl -X POST 'https://services.cloud.mongodb.com/api/client/v2.0/auth/session' \
               --header 'Content-Type: application/json' \
               --header 'Authorization: Bearer <RefreshToken>'
 
@@ -263,7 +263,7 @@ depends on your App's deployment model.
             :language: shell
             :emphasize-lines: 3
 
-            curl -X POST 'https://<Region>.<Cloud>.realm.mongodb.com/api/client/v2.0/auth/session' \
+            curl -X POST 'https://<Region>.<Cloud>.services.cloud.mongodb.com/api/client/v2.0/auth/session' \
               --header 'Content-Type: application/json' \
               --header 'Authorization: Bearer <RefreshToken>'
 
@@ -342,7 +342,7 @@ set to your desired expiration time.
 .. code-block:: bash
 
    curl -X PUT \
-     https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/security/refresh_token_expiration \
+     https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/security/refresh_token_expiration \
      --data-raw '{
        "expiration_time_seconds": 864000
      }'
@@ -367,7 +367,7 @@ token in the ``token`` field of the request body.
       :language: bash
 
       curl -X POST \
-        https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/users/verify_token \
+        https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/users/verify_token \
         --data-raw '{
           "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJiYWFzX2RldmljZV9pZCI6IjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMCIsImJhYXNfZG9tYWluX2lkIjoiNWNkYjEyNDA4ZTIzMmFjNGY5NTg3ZmU4IiwiZXhwIjoxNjc2NTExMjgyLCJpYXQiOjE2NzY1MDk0ODIsImlzcyI6IjYzZWQ4MTJhNDNiZTcyYzE3NmFhNWQyMyIsInN0aXRjaF9kZXZJZCI6IjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMCIsInN0aXRjaF9kb21haW5JZCI6IjVjZGIxMjQwOGUyMzJhYzRmOTU4N2ZlOCIsInN1YiI6IjYzZWQ4MTJhNDNiZTcyYzE3NmFhNWQyMSIsInR5cCI6ImFjY2VzcyJ9.7kHO9wjWvIaD3VewDyPhLyb-oRc7wTYZdD9-hroF-H4"
         }'
@@ -498,4 +498,4 @@ then all of the user's sessions are automatically revoked.
 
          curl -X PUT \
            -H 'Authorization: Bearer {access_token}' \
-           https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/users/{userId}/logout
+           https://services.cloud.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/users/{userId}/logout


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-35269

- [App Services Staging Site](https://preview-mongodbdacharyc.gatsbyjs.io/atlas-app-services/DOCSP-35269/): Update base URL throughout examples.

Note for reviewer: the Data API checks that are failing aren't related to this change - they're related to a missing environment variable when running the CI. Those failed checks shouldn't block this PR.

### Release Notes

- Throughout Docs
  - Update base URL (realm.mongodb.com) to new App Services base URL (services.cloud.mongodb.com).

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
