### PR TITLE
Add links to new C++ GA content

### DIFF
--- a/source/sync/data-model/data-model-map.txt
+++ b/source/sync/data-model/data-model-map.txt
@@ -4,6 +4,14 @@
 Data Model Mapping
 ==================
 
+.. meta:: 
+   :keywords: code example
+   :description: Learn about how data types in the Atlas App Services Schema map to objects used by Atlas Device SDK.
+
+.. facet::
+  :name: genre
+  :values: reference
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -257,7 +265,7 @@ A set is a collection of unique values.
 
 Realm SDK Set documentation:
 
-- :ref:`C++ SDK: Set <cpp-set-collections>`
+- :ref:`Set - C++ SDK <cpp-set-collections>`
 - :ref:`RealmSet - Flutter SDK <flutter-realm-set>`
 - :ref:`java-realmset`
 - :ref:`RealmSet - Kotlin SDK <kotlin-realm-set>`

--- a/source/sync/data-model/data-model-map.txt
+++ b/source/sync/data-model/data-model-map.txt
@@ -257,6 +257,7 @@ A set is a collection of unique values.
 
 Realm SDK Set documentation:
 
+- :ref:`C++ SDK: Set <cpp-set-collections>`
 - :ref:`RealmSet - Flutter SDK <flutter-realm-set>`
 - :ref:`java-realmset`
 - :ref:`RealmSet - Kotlin SDK <kotlin-realm-set>`

--- a/source/sync/error-handling/client-resets.txt
+++ b/source/sync/error-handling/client-resets.txt
@@ -213,13 +213,14 @@ Examples
 For more information on performing a client reset, check out the client
 reset examples for your SDK:
 
-- :ref:`Handle Sync Errors - Client Reset - Flutter SDK <flutter-client-reset>`
-- :ref:`Reset a Client Realm - Java SDK <java-client-resets>`
-- :ref:`Handle Sync Errors - Client Reset - Kotlin SDK <kotlin-client-reset>`
-- :ref:`Client Resets - .NET SDK <dotnet-client-resets>`
-- :ref:`Reset a Client Realm - Node.js SDK <node-client-resets>`
-- :ref:`Reset a Client Realm - React Native SDK <react-native-client-resets>`
-- :ref:`Handle Sync Errors - Client Reset - Swift SDK <ios-client-resets>`
+- :ref:`C++ SDK: Handle Sync Errors - Client Reset <cpp-client-reset>`
+- :ref:`Flutter SDK: Handle Sync Errors - Client Reset <flutter-client-reset>`
+- :ref:`Java SDK: Reset a Client Realm <java-client-resets>`
+- :ref:`Kotlin SDK: Handle Sync Errors - Client Reset <kotlin-client-reset>`
+- :ref:`.NET SDK: Client Resets <dotnet-client-resets>`
+- :ref:`Node.js SDK: Reset a Client Realm <node-client-resets>`
+- :ref:`React Native SDK: Reset a Client Realm <react-native-client-resets>`
+- :ref:`Swift SDK: Handle Sync Errors - Client Reset <ios-client-resets>`
 
 .. _enable-or-disable-recovery-mode:
 

--- a/source/sync/error-handling/client-resets.txt
+++ b/source/sync/error-handling/client-resets.txt
@@ -4,7 +4,12 @@
 Client Resets
 =============
 
-.. default-domain:: mongodb
+.. meta:: 
+   :description: When device databases can no longer sync with Atlas, you must perform a client reset. Learn what can cause this condition, and how to resolve it.
+
+.. facet::
+  :name: genre
+  :values: reference
 
 .. contents:: On this page
    :local:


### PR DESCRIPTION
## Pull Request Info

- [Data Model Mapping/Sets](https://preview-mongodbdacharyc.gatsbyjs.io/atlas-app-services/cpp-ga-link-updates/sync/data-model/data-model-map/#sets): Add C++ SDK's new Set data type to the list.
- [Client Reset](https://preview-mongodbdacharyc.gatsbyjs.io/atlas-app-services/cpp-ga-link-updates/sync/error-handling/client-resets/): Add C++ client reset documentation to the list. Start list items with SDK name to make it easier for users to quickly identify the correct link.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-realm work, if any

### Release Notes

- **Device Sync**
  - Configure & Update Your Data Model/Data Model Mapping: Add C++ Set to the list of SDK Set documentation links.
  - Handle Errors/Client Reset: Add the new C++ Client Reset page to the list of SDK pages for handling client resets.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
