### PR TITLE
Fix CLI profile config path for macOS

### DIFF
--- a/source/includes/app-services-cli-overview.rst
+++ b/source/includes/app-services-cli-overview.rst
@@ -220,7 +220,7 @@ depends on your system:
      - ``$XDG_CONFIG_HOME/<profile>.yaml`` or ``$HOME/.config/<profile>.yaml``
 
    * - macOS
-     - ``Library/Application Support/appservices-cli/<profile>.yaml``
+     - ``$HOME/Library/Application\ Support/appservices-cli/<profile>.yaml``
 
    * - Windows
      - ``%AppData%/<profile>.yaml``


### PR DESCRIPTION
## Pull Request Info

- [CLI Profiles](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/macos-cli-profile-path/cli/#cli-profiles)

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-realm work, if any

### Release Notes

- **CLI Profiles**
  - Updated the profile configuration file path to be nested under `$HOME` on macOS

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
