### PR TITLE
Update OpenAPI adminLogin endpoint

### DIFF
--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -173,7 +173,7 @@ paths:
                 items:
                   "$ref": "#/components/schemas/BaseAuthProvider"
       security: []
-  "/auth/providers/{provider}/login":
+  "/auth/providers/mongodb-cloud/login":
     post:
       tags:
         - admin
@@ -220,13 +220,6 @@ paths:
                   device_id:
                     type: string
       security: []
-    parameters:
-      - name: provider
-        description: The authentication provider to use.
-        in: path
-        required: true
-        schema:
-          "$ref": "#/components/schemas/ProviderType"
   "/auth/profile":
     get:
       tags:

--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -6684,7 +6684,6 @@ components:
         - oauth2-facebook
         - custom-token
         - custom-function
-        - mongodb-cloud
     MessageState:
       type: string
       enum:

--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -6684,6 +6684,7 @@ components:
         - oauth2-facebook
         - custom-token
         - custom-function
+        - mongodb-cloud
     MessageState:
       type: string
       enum:


### PR DESCRIPTION
## Pull Request Info

Current OpenAPI spec doesn't account for `mongodb-cloud` as it should according to documentation in [Get an Admin API Session Access Token](https://www.mongodb.com/docs/atlas/app-services/admin/api/v3/#section/Get-an-Admin-API-Session-Access-Token)

The example specifies `mongodb-cloud` as the provider but it's not included in `ProviderType` in the spec file.

Example: https:// services.cloud.mongodb.com/api/admin/v3.0/auth/providers/`mongodb-cloud`/login

~~This PR adds the necessary provider so generated clients can access the Atlas App Services Admin API.~~
This PR hardcodes the provider into the path and removes the need for parameters.

### Reminder Checklist

Before merging your PR, make sure to check a few things.
- [x] Describe your PR's changes in the Release Notes section

### Release Notes

- **Update adminLogin operation**
  - /auth/providers/mongodb-cloud/login

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
