### PR TITLE
DOCSP-36194 Update CLI logs list with trigger_error_handler type

### DIFF
--- a/source/cli/appservices-logs-list.txt
+++ b/source/cli/appservices-logs-list.txt
@@ -50,7 +50,7 @@ Options
    * - --type
      - Set
      - false
-     - Specify the type(s) of logs to list (Default value: <none>; Allowed values: <none>, "auth", "function", "push", "service", "trigger", "graphql", "sync", "schema") This value defaults to [].
+     - Specify the type(s) of logs to list (Default value: <none>; Allowed values: <none>, "auth", "function", "push", "service", "trigger", "graphql", "sync", "schema", "trigger_error_handler", "log_forwarder", "endpoint") This value defaults to [].
    * - --errors
      - 
      - false


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-36194

- [appservices logs list](https://preview-mongodblindseymoore.gatsbyjs.io/atlas-app-services/DOCSP-36194/cli/appservices-logs-list/#options): Added ``trigger_error_handler`` as value for the ``--type`` flag in the Options table. 

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-realm work, if any

### Release Notes

<!--
- **Define Data Access Permissions**
  - Data Access Role Examples: Update CRUD Permissions example screenshots and
    copyable JSON
-->

**Reference**
- App Services CLI/logs/list: Add``trigger_error_handler`` as value for the ``--type`` flag in the Options table. 

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
