### PR TITLE
Fix OpenAPI ServiceResponse schema

### DIFF
--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -5669,11 +5669,11 @@ components:
     ServiceResponse:
       type: object
       properties:
-        _id: string;
-        name: string;
-        type: string;
-        version: number;
-        last_modified: number;
+        _id: { type: string }
+        name: { type: string }
+        type: { type: string }
+        version: { type: number }
+        last_modified: { type: number }
     ReadPreferencesTagSet:
       type: string
       enum:


### PR DESCRIPTION
## Pull Request Info
Swift Open API generator errors out on the ServiceResponse properties because they aren't parsable.

This PR fixes the syntax of ServiceResponse properties.

### Reminder Checklist

Before merging your PR, make sure to check a few things.
- [x] Describe your PR's changes in the Release Notes section

### Release Notes
- **Update ServiceResponse**
  - Fixed syntax of object properties

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
