### PR TITLE
Fix OpenAPI duplicate operation names

### DIFF
--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -916,7 +916,7 @@ paths:
     patch:
       tags:
         - services
-      operationId: adminUpdateServiceConfig
+      operationId: adminUpdateServicesConfig
       summary: Update configuration settings of sources and third-party services
       description: >-
         Update the [data

--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -896,7 +896,7 @@ paths:
     get:
       tags:
         - services
-      operationId: adminGetServiceConfig
+      operationId: adminGetServicesConfig
       summary: Get configuration of sources and third-party services
       description: >-
         Get configuration of [data


### PR DESCRIPTION
## Pull Request Info
OpenAPI operation names must be unique.
This PR resolves 2 operation name collisions.

line #899 `operationId: adminGetServiceConfig` -> `operationId: adminGetServicesConfig`
line #1111 `operationId: adminGetServiceConfig` keep the same

line #919 `operationId: adminUpdateServiceConfig` -> `operationId: adminUpdateServicesConfig`
line #1122 `operationId: adminUpdateServiceConfig` keep the same

### Reminder Checklist

Before merging your PR, make sure to check a few things.
- [x] Describe your PR's changes in the Release Notes section

### Release Notes

- **Fix operation name collisions**
  - adminGetServicesConfig
  - adminUpdateServicesConfig

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
