### PR TITLE
Correct Base URL, spacing tweaks

### DIFF
--- a/source/users/sessions.txt
+++ b/source/users/sessions.txt
@@ -66,7 +66,7 @@ access token.
 
                https://services.cloud.mongodb.com/api/client/v2.0/app/<App ID>
 
-            Replace ``<AppID>`` with your client App ID. For example,
+            Replace ``<App ID>`` with your client App ID. For example,
             ``myapp-abcde``.
 
          .. tab:: Local Deployment
@@ -74,13 +74,13 @@ access token.
 
             .. code-block:: text
 
-               https://<Region>.<Cloud>.services.cloud.mongodb.com/api/client/v2.0/app/<AppID>/auth/providers/<ProviderType>/login
+               https://<Region>.<Cloud>.services.cloud.mongodb.com/api/client/v2.0/app/<App ID>
 
             - Replace ``<Region>`` with the region where your app is hosted. For example, ``us-east-1``.
 
             - Replace ``<Cloud>`` with the cloud where your app is hosted. For example, ``aws``, ``azure``, or ``gcp``.
 
-            - Replace ``<AppID>`` with your client app ID. For example, ``myapp-abcde``.
+            - Replace ``<App ID>`` with your client app ID. For example, ``myapp-abcde``.
 
       You can find the base URL programmatically with the App
       location endpoint. The response body includes the base URL as
@@ -91,7 +91,7 @@ access token.
          .. input::
             :language: shell
 
-            curl 'https://services.cloud.mongodb.com/api/client/v2.0/app/<AppID>/location'
+            curl 'https://services.cloud.mongodb.com/api/client/v2.0/app/<App ID>/location'
 
          .. output::
             :language: json
@@ -164,7 +164,7 @@ access token.
                curl -X POST 'https://services.cloud.mongodb.com/api/client/v2.0/app/myapp-abcde/auth/providers/custom-token/login' \
                  --header 'Content-Type: application/json' \
                  --data-raw '{
-                 	 "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0ZGV2LWJwcWVsIiwiZXhwIjoxNTE2MjM5MDIyLCJzdWIiOiIyNDYwMSIsInVzZXJfZGF0YSI6eyJuYW1lIjoiSmVhbiBWYWxqZWFuIiwiYWxpYXNlcyI6WyJNb25zaWV1ciBNYWRlbGVpbmUiLCJVbHRpbWUgRmF1Y2hlbGV2ZW50IiwiVXJiYWluIEZhYnJlIl19fQ.mVWr4yFf8nD1EhuhrJbgKfY7BEpMab38RflXzUxuaEI"
+                   "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0ZGV2LWJwcWVsIiwiZXhwIjoxNTE2MjM5MDIyLCJzdWIiOiIyNDYwMSIsInVzZXJfZGF0YSI6eyJuYW1lIjoiSmVhbiBWYWxqZWFuIiwiYWxpYXNlcyI6WyJNb25zaWV1ciBNYWRlbGVpbmUiLCJVbHRpbWUgRmF1Y2hlbGV2ZW50IiwiVXJiYWluIEZhYnJlIl19fQ.mVWr4yFf8nD1EhuhrJbgKfY7BEpMab38RflXzUxuaEI"
                  }'
 
          .. tab::
@@ -176,7 +176,7 @@ access token.
                curl -X POST 'https://services.cloud.mongodb.com/api/client/v2.0/app/myapp-abcde/auth/providers/custom-function/login' \
                  --header 'Content-Type: application/json' \
                  --data-raw '{
-                 	 "someCustomFunctionArg": "<Login Info>"
+                   "someCustomFunctionArg": "<Login Info>"
                  }'
 
       If the authentication request succeeds, the response body includes


### PR DESCRIPTION
## Pull Request Info

- [Manage User Sessions](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/sessions-url/users/sessions/)
  - Fix the base URL to not include auth provider information (specified in the next step)
  - Tweak placeholder spacing to be consistent
  - Convert tab to space for correct spacing on some curl request examples

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [ ] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-realm work, if any

### Release Notes

<!--
- **Define Data Access Permissions**
  - Data Access Role Examples: Update CRUD Permissions example screenshots and
    copyable JSON
-->

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
