### PR TITLE
GitHub action to lint Admin API spec

### DIFF
--- a/.github/workflows/check-openapi-admin-v3.yml
+++ b/.github/workflows/check-openapi-admin-v3.yml
@@ -1,0 +1,19 @@
+name: Check OpenAPI Spec > Admin API v3
+
+on:
+  pull_request:
+    paths:
+      - "source/openapi-admin-v3.yaml"
+      - "source/admin/api/v3.txt"
+
+jobs:
+  check-openapi-spec-admin-api-v3:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - name: Lint OpenAPI Spec
+        run: |
+          npx -y @redocly/cli@latest lint source/openapi-admin-v3.yaml --config redocly.yaml


### PR DESCRIPTION
This will run the OpenAPI linter on changes to the Admin API spec. This will let us block PRs that introduce errors.