### PR TITLE
(DOCSP-36901): Fix incorrect operation for redeploy

### DIFF
--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -3495,7 +3495,7 @@ paths:
       - "$ref": "#/components/parameters/GroupId"
       - "$ref": "#/components/parameters/AppId"
       - "$ref": "#/components/parameters/DeploymentId"
-    get:
+    post:
       tags:
         - deploy
       operationId: adminRedeployDeployment


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-36901

- [App Services Admin API](https://preview-mongodbdacharyc.gatsbyjs.io/atlas-app-services/DOCSP-36901/admin/api/v3/#tag/deploy/operation/adminRedeployDeployment): Correct `/redeploy` operation type from `Get` to `Post`.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-realm work, if any

### Release Notes

- **App Services Admin API**
  - Correct `/redeploy` operation type from `Get` to `Post`.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
