### PR TITLE
DOCSP-33924: Add MaxIntegrationAttempts to Sync Errors page

### DIFF
--- a/source/sync/error-handling/errors.txt
+++ b/source/sync/error-handling/errors.txt
@@ -210,19 +210,21 @@ and MongoDB Atlas.
      - Description
 
    * - MaxIntegrationAttempts
-     - This error occurs when a transaction fails to commit after the 
-       translator reaches the maximum number of tries to integrate the 
-       changeset. This is usually caused by insufficient cluster size. 
-       This can be due to an exceptionally large transaction that 
-       exceeds the current cluster's available resources (for example, a 
-       device that was offline for a long period of time attempts to 
-       sync an abnormal amount of batched transactions), or that the 
-       current cluster size is simply not sufficient for the app. The 
-       error can be resolved by upgrading the cluster tier.   
-      
+     - When the MongoDB translator cannot integrate a changeset, it 
+       retries for a fixed number of times. This error occurs when the 
+       translator reaches the maximum number of retries and could not 
+       commit changes. This is usually caused by insufficient cluster 
+       size. This can be due to a very large transaction that exceeds 
+       the cluster's available resources. For example, a device is 
+       offline for a long time and tries to sync an atypical quantity of 
+       batched transactions. Or the cluster resources are generally
+       insufficient for the app's needs.
+       
+       You can resolve this error by upgrading the cluster tier.
+
        To avoid this error, ensure the linked MongoDB cluster meets the 
-       needs of your app and that your app uses best practices for 
-       reading and writing data. Refer to 
+       needs of your app. Also, make sure your app uses best practices 
+       for reading and writing data. Refer to 
        `Atlas Cluster Sizing and Tier Selection <https://www.mongodb.com/docs/atlas/sizing-tier-selection>`__ 
        for more information.
 

--- a/source/sync/error-handling/errors.txt
+++ b/source/sync/error-handling/errors.txt
@@ -4,11 +4,12 @@
 Sync Errors
 ===========
 
+.. meta:: 
+   :description: Common errors encountered when using Atlas Device Sync and how to handle them. 
+
 .. facet::
    :name: genre 
    :values: reference
-
-.. default-domain:: mongodb
 
 .. contents:: On this page
    :local:
@@ -20,7 +21,7 @@ Overview
 --------
 
 While you develop applications using Atlas Device Sync, you may run into errors. This
-section lists common errors and describes how to and handle them.
+section lists common Sync errors and describes how to handle them.
 
 .. note::
    
@@ -207,6 +208,23 @@ and MongoDB Atlas.
 
    * - Error Name
      - Description
+
+   * - MaxIntegrationAttempts
+     - This error occurs when a transaction fails to commit after the 
+       translator reaches the maximum number of tries to integrate the 
+       changeset. This is usually caused by insufficient cluster size. 
+       This can be due to an exceptionally large transaction that 
+       exceeds the current cluster's available resources (for example, a 
+       device that was offline for a long period of time attempts to 
+       sync an abnormal amount of batched transactions), or that the 
+       current cluster size is simply not sufficient for the app. The 
+       error can be resolved by upgrading the cluster tier.   
+      
+       To avoid this error, ensure the linked MongoDB cluster meets the 
+       needs of your app and that your app uses best practices for 
+       reading and writing data. Refer to 
+       `Atlas Cluster Sizing and Tier Selection <https://www.mongodb.com/docs/atlas/sizing-tier-selection>`__ 
+       for more information.
 
    * - MongoEncodingError
      - This error occurs when a MongoDB Atlas write (i.e. not a Sync client)


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-33924

- [Sync Errors](https://preview-mongodbcbullinger.gatsbyjs.io/atlas-app-services/docsp-33924-maxIntegrationAttempts/sync/error-handling/errors/#mongodb-translator-errors): Add `MaxIntegrationAttempts` error to MongoDB Translator Errors section table.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-realm work, if any

### Release Notes

- **Device Sync**
  - Handle Errors > Sync Errors: Update MongoDB Translator Errors section table to include 'MaxIntegrationAttempts' error description and typical resolution.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
