### PR TITLE
DOCSP-35929 Move x509 security note to more appropriate spot

### DIFF
--- a/source/includes/x509-encryption.rst
+++ b/source/includes/x509-encryption.rst
@@ -1,0 +1,5 @@
+.. note:: Backend Encryption
+
+   All internal communication between App Services and Atlas is encrypted with 
+   x509 certificates.
+   

--- a/source/mongodb.txt
+++ b/source/mongodb.txt
@@ -6,6 +6,13 @@ Connect to MongoDB Data Sources
 
 .. default-domain:: mongodb
 
+.. meta::
+   :description: Learn how to connect your Atlas App Services App to an MongoDB Atlas data source.
+
+.. facet::
+   :name: genre
+   :values: tutorial
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -39,6 +46,11 @@ use the name to refer to the data source throughout your app.
 Requests to data sources are routed through Atlas App Services. Because of this,
 App Services automatically opens and closes database connections. This means you
 don't need to worry about calling ``db.close()`` when using a data source.
+
+.. note:: Backend Encryption
+
+   All internal communication between App Services and Atlas is encrypted with 
+   x509 certificates.
 
 Read, Write, and Aggregate Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/mongodb.txt
+++ b/source/mongodb.txt
@@ -45,6 +45,7 @@ Requests to data sources are routed through Atlas App Services. Because of this,
 App Services automatically opens and closes database connections. This means you
 don't need to worry about calling ``db.close()`` when using a data source.
 
+
 .. include:: /includes/x509-encryption.rst
 
 Read, Write, and Aggregate Data

--- a/source/mongodb.txt
+++ b/source/mongodb.txt
@@ -4,10 +4,8 @@
 Connect to MongoDB Data Sources
 ===============================
 
-.. default-domain:: mongodb
-
 .. meta::
-   :description: Learn how to connect your Atlas App Services App to an MongoDB Atlas data source.
+   :description: Learn how to connect your Atlas App Services App to a MongoDB Atlas data source.
 
 .. facet::
    :name: genre
@@ -47,10 +45,7 @@ Requests to data sources are routed through Atlas App Services. Because of this,
 App Services automatically opens and closes database connections. This means you
 don't need to worry about calling ``db.close()`` when using a data source.
 
-.. note:: Backend Encryption
-
-   All internal communication between App Services and Atlas is encrypted with 
-   x509 certificates.
+.. include:: /includes/x509-encryption.rst
 
 Read, Write, and Aggregate Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/mongodb.txt
+++ b/source/mongodb.txt
@@ -45,7 +45,6 @@ Requests to data sources are routed through Atlas App Services. Because of this,
 App Services automatically opens and closes database connections. This means you
 don't need to worry about calling ``db.close()`` when using a data source.
 
-
 .. include:: /includes/x509-encryption.rst
 
 Read, Write, and Aggregate Data

--- a/source/security/network.txt
+++ b/source/security/network.txt
@@ -6,6 +6,13 @@ Configure Network Security
 
 .. default-domain:: mongodb
 
+.. meta::
+   :description: Learn about the network security protocols used by Atlas App Services.
+
+.. facet::
+   :name: genre
+   :values: reference 
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -35,6 +42,11 @@ to secure all network requests to and from your application, including:
 - Queries and operations on a linked MongoDB Atlas data source.
 
 The TLS certificate is pre-defined and cannot be customized or disabled.
+
+.. note:: Backend Encryption
+
+   All internal communication between App Services and Atlas is encrypted with 
+   x509 certificates.
 
 .. _realm-public-ips:
 .. _firewall-configuration:
@@ -468,8 +480,3 @@ for project or organization access from the Realm CLI or the App Services
 Admin API, you can specify IP addresses that can use this API key. If you specify 
 an IP address, App Services blocks any request originating from an IP address that 
 is not on the access list.
-
-.. note:: Backend Encryption
-
-   All internal communication between App Services and Atlas is encrypted with 
-   x509 certificates.

--- a/source/security/network.txt
+++ b/source/security/network.txt
@@ -4,8 +4,6 @@
 Configure Network Security
 ==========================
 
-.. default-domain:: mongodb
-
 .. meta::
    :description: Learn about the network security protocols used by Atlas App Services.
 
@@ -43,10 +41,7 @@ to secure all network requests to and from your application, including:
 
 The TLS certificate is pre-defined and cannot be customized or disabled.
 
-.. note:: Backend Encryption
-
-   All internal communication between App Services and Atlas is encrypted with 
-   x509 certificates.
+.. include:: /includes/x509-encryption.rst
 
 .. _realm-public-ips:
 .. _firewall-configuration:


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-35929

- [Configure Network Security](https://preview-mongodblindseymoore.gatsbyjs.io/atlas-app-services/DOCSP-35929/security/network/#transport-layer-security--tls-): Moved note about x509 security certificate between Atlas App Services and Atlas data sources to a more appropriate spot higher up on the page.
- [Connect to MongoDB Data Sources](https://preview-mongodblindseymoore.gatsbyjs.io/atlas-app-services/DOCSP-35929/mongodb/): Added note about x509 security certificate between Atlas App Services and Atlas data sources.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-realm work, if any

### Release Notes

<!--
- **Define Data Access Permissions**
  - Data Access Role Examples: Update CRUD Permissions example screenshots and
    copyable JSON
-->
**Connect to a MongoDB Data Sources**
- Landing Page: Added note about x509 security certificate between Atlas App Services and Atlas data sources.

**Secure Your App**
- Configure Network Security: Moved note about x509 security certificate between Atlas App Services and Atlas data sources to a more appropriate spot higher up on the page.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
