### PR TITLE
(DOCSP-37744): Increase JWT token character limit to 4096

### DIFF
--- a/source/authentication/custom-jwt.txt
+++ b/source/authentication/custom-jwt.txt
@@ -299,11 +299,11 @@ that field in the JWT as the user's display name.
   App Services refreshes a user's metadata whenever they log in and exposes the 
   fields in the ``data`` object of the :ref:`user metadata <user-objects>`.
 
-.. important:: 2048 Character Limit
+.. important:: 4096 Character Limit
 
    The length of a JWT token increases with the number of metadata fields in the 
    token and the size of each field. **App Services limits the length of a 
-   JWT token to 2048 characters.** If you exceed this limit, App Services 
+   JWT token to 4096 characters.** If you exceed this limit, App Services 
    logs an error and the ticket is not processed.
 
 There are three values that you need to specify for each metadata field:

--- a/source/release-notes/backend.txt
+++ b/source/release-notes/backend.txt
@@ -28,7 +28,7 @@ Atlas App Services Changelog
 20 March 2024 Release
 ~~~~~~~~~~~~~~~~~~~~~
 
-- Increased limit for length of a JWT token from 2048 to 4066 characters.
+- Increased limit for length of a JWT token from 2048 to 4096 characters.
   
 - Created a new CLI command,``users count``, to display the total number of users for an app.
   


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-37744

- [Custom JWT Authentication](https://preview-mongodbdacharyc.gatsbyjs.io/atlas-app-services/DOCSP-37744/authentication/custom-jwt/#metadata-fields): Increase token character limit from 2048 to 4096.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-realm work, if any

### Release Notes

- **Authenticate & Manage Users**
  - Authentication Providers/Custom JWT: Increase token character limit from 2048 to 4096.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
