### PR TITLE
(DOCSP-38678): Fix deployment labels for GCP

### DIFF
--- a/source/apps/deployment-models-and-regions.txt
+++ b/source/apps/deployment-models-and-regions.txt
@@ -204,35 +204,35 @@ App Services supports the following regions:
    
    * - GCP
      - ``us-central1``
-     - Ohio (US-VA)
+     - Iowa
      - ``gcp-us-central1``
      - ✓
      - 
    
    * - GCP
      - ``us-east4``
-     - Virginia (US-VA)
+     - Virginia
      - ``gcp-us-east4``
      - ✓
      - 
    
    * - GCP
      - ``us-west1``
-     - Oregon (US-OR)
+     - Oregon
      - ``gcp-us-west1``
      - ✓
      - 
    
    * - GCP
      - ``europe-west1``
-     - Belgium (DE-FF)
+     - Belgium
      - ``gcp-europe-west1``
      - ✓
      - 
    
    * - GCP
      - ``asia-south1``
-     - Mumbai (IN-MB)
+     - Mumbai
      - ``gcp-asia-south1``
      - ✓
      - 


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-38678

- [Deployment Models & Regions](https://preview-mongodbdacharyc.gatsbyjs.io/atlas-app-services/DOCSP-38678/apps/deployment-models-and-regions/): Correct GCP deployment region "Ohio" to "Iowa" per engineering updates. Remove AWS-style abbreviations.

DO NOT MERGE until this week's BAAS release.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-realm work, if any

### Release Notes

- **Develop & Deploy Apps**
  - Deployment Models & Regions: Correct GCP deployment region "Ohio" to "Iowa" per engineering updates. Remove AWS-style abbreviations.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
