### PR TITLE
(DOCSP-37744): Add JWT limit and clarify metadata field limit

### DIFF
--- a/source/authentication/custom-jwt.txt
+++ b/source/authentication/custom-jwt.txt
@@ -299,12 +299,13 @@ that field in the JWT as the user's display name.
   App Services refreshes a user's metadata whenever they log in and exposes the 
   fields in the ``data`` object of the :ref:`user metadata <user-objects>`.
 
-.. important:: 4096 Character Limit
+.. important:: JWT and Metadata Field Character Limits
 
    The length of a JWT token increases with the number of metadata fields in the 
    token and the size of each field. **App Services limits the length of a 
-   JWT token to 4096 characters.** If you exceed this limit, App Services 
-   logs an error and the ticket is not processed.
+   JWT token to 1 million characters, and the length of each metadata field to 
+   4096 characters.** If you exceed these limits, App Services logs an error 
+   and the ticket is not processed.
 
 There are three values that you need to specify for each metadata field:
 


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-37744

- [Custom JWT Authentication](https://preview-mongodbdacharyc.gatsbyjs.io/atlas-app-services/DOCSP-37744-2/authentication/custom-jwt/#metadata-fields): Clarify wording about JWT length and the 4096 character limit being _per_ metadata field.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [ ] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-realm work, if any

### Release Notes

Omitting release notes here since it's really just iteration on the prior PR. Same work, just refinements.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
