### PR TITLE
(DOCSP-038798): Domain Migration: Add SDK versions that use the new baseURL by default

### DIFF
--- a/source/domain-migration.txt
+++ b/source/domain-migration.txt
@@ -17,17 +17,18 @@ API requests through the Atlas Device SDKs.
 Relevant SDK Versions
 ---------------------
 
-Starting in the following versions, the SDKs will use the new base URL by
+Starting in the following versions, the SDKs use the new base URL by
 default:
 
-- C++ SDK: version TBD
-- Flutter SDK: version TBD
+- C++ SDK: v1.1.1
+- Flutter SDK: v2.1.0
 - Java SDK: version TBD
-- Kotlin SDK: version TBD
-- .NET SDK: version TBD
-- Node.js SDK: version TBD
-- React Native SDK: version TBD
-- Swift SDK: version TBD
+- Kotlin SDK: v1.15.0
+- .NET SDK: v12.0.0
+- Node.js SDK: v12.7.0
+- React Native SDK: v12.7.0
+- Swift SDK: v10.49.2
+- Web SDK: version TBD
 
 Begin Migration Now
 -------------------


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-38798

- [Domain Migration](https://preview-mongodbdacharyc.gatsbyjs.io/atlas-app-services/DOCSP-38798/domain-migration/): Add SDK versions that use the new baseURL by default.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-realm work, if any

### Release Notes

- **Other**
  - Domain Migration: Add SDK versions that use the new baseURL by default.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
