### PR TITLE
added $setIsSubset as unsupported.

### DIFF
--- a/source/mongodb/crud-and-aggregation-apis.txt
+++ b/source/mongodb/crud-and-aggregation-apis.txt
@@ -4,6 +4,14 @@
 CRUD & Aggregation APIs
 =======================
 
+.. facet::
+   :name: genre 
+   :values: reference
+
+.. meta:: 
+   :description: CRUD and Aggregation APIs.
+   :keywords: aggregation, mongo data source
+
 .. default-domain:: mongodb
 
 .. contents:: On this page

--- a/source/mongodb/crud-and-aggregation-apis.txt
+++ b/source/mongodb/crud-and-aggregation-apis.txt
@@ -599,20 +599,11 @@ App Services supports all :manual:`aggregation pipeline operators
 </reference/operator/aggregation/>` when you :ref:`run an aggregation pipeline
 <mongodb-aggregate>` in the :ref:`system user
 <system-functions>` context. App Services supports all pipeline operators
-in an :ref:`application user <user-accounts>` context with the following
-exceptions:
+in an :ref:`application user <user-accounts>` context except for the following
+operators:
 
-.. list-table::
-   :header-rows: 1
-   :widths: 25 10 10
-
-   * - Operator
-     - User Context
-     - System Context
-
-   * - :manual:`$function </reference/operator/aggregation/function/>`
-     - No
-     - Yes
+- :manual:`$function </reference/operator/aggregation/function/>`
+- :manual:`$setIsSubset </reference/operator/aggregation/setIsSubset/>`
 
 .. _mongodb-crud-and-aggregation-apis-database-commands:
 

--- a/source/mongodb/crud-and-aggregation-apis.txt
+++ b/source/mongodb/crud-and-aggregation-apis.txt
@@ -9,10 +9,8 @@ CRUD & Aggregation APIs
    :values: reference
 
 .. meta:: 
-   :description: CRUD and Aggregation APIs.
-   :keywords: aggregation, mongo data source
+   :description: Use supported MongoDB CRUD operations, aggregation methods, and limited database commands with your Atlas data source.
 
-.. default-domain:: mongodb
 
 .. contents:: On this page
    :local:
@@ -606,7 +604,9 @@ Aggregation Pipeline Operator Availability
 App Services supports all :manual:`aggregation pipeline operators
 </reference/operator/aggregation/>` when you :ref:`run an aggregation pipeline
 <mongodb-aggregate>` in the :ref:`system user
-<system-functions>` context. App Services supports all pipeline operators
+<system-functions>` context. 
+
+App Services supports all pipeline operators
 in an :ref:`application user <user-accounts>` context except for the following
 operators:
 


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-38453

- [CRUD & Aggregation APIs](https://preview-mongodbmongocaleb.gatsbyjs.io/atlas-app-services/DOCSP-38453/mongodb/crud-and-aggregation-apis/#aggregation-pipeline-operator-availability): Added `$setIsSubset`. Did not add `distinct` because it is a command, and we [explicitly state commands are not supported](https://www.mongodb.com/docs/atlas/app-services/mongodb/crud-and-aggregation-apis/#database-commands) (with some exceptions). 

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-realm work, if any

### Release Notes

- Add $setisSubset to list of unsupported pipeline operators

