### PR TITLE
(DOCSP-38548) Standardize tutorial page names

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -35,7 +35,6 @@ raw: ${prefix}/triggers/examples -> ${base}/triggers/
 # get-started refresh
 raw: ${prefix}/tutorial/jwt -> ${base}/authentication/custom-jwt/
 raw: ${prefix}/template-apps -> ${base}/reference/template-apps/
-raw: ${prefix}/tutorials -> ${base}/get-started/
 
 raw: ${prefix}/sync/learn/conflict-resolution -> ${base}/sync/details/conflict-resolution/
 raw: ${prefix}/sync/learn/protocol -> ${base}/sync/details/protocol/
@@ -305,3 +304,6 @@ raw: ${prefix}/cli/realm-cli-users-list -> ${base}/realm-cli/realm-cli-users-lis
 raw: ${prefix}/cli/realm-cli-users-revoke -> ${base}/realm-cli/realm-cli-users-revoke/
 raw: ${prefix}/cli/realm-cli-users -> ${base}/realm-cli/realm-cli-users/
 raw: ${prefix}/cli/realm-cli-whoami -> ${base}/realm-cli/realm-cli-whoami/
+
+# Return to using tutorials instead of get started
+raw: ${prefix}/get-started -> ${base}/tutorials/

--- a/source/index.txt
+++ b/source/index.txt
@@ -15,7 +15,7 @@ What are the Atlas Application Services?
    :hidden:
    
    Introduction </introduction>
-   Get Started </get-started>
+   Tutorials </tutorials>
    Device Sync </sync>
    Edge Server </edge-server>
    Data API </data-api>

--- a/source/tutorial/backend.txt
+++ b/source/tutorial/backend.txt
@@ -1,10 +1,12 @@
 .. _backend-tutorial:
 
-==============================================
-Write a Serverless GitHub Contribution Tracker
-==============================================
+========================================================
+Tutorial: Write a Serverless GitHub Contribution Tracker
+========================================================
 
-.. default-domain:: mongodb
+.. meta::
+   :keywords: code example
+   :description: Learn how to use Atlas App Services Triggers, Functions, and Values by building a severless GitHub contribution tracker.
 
 .. contents:: On this page
    :local:

--- a/source/tutorial/backend.txt
+++ b/source/tutorial/backend.txt
@@ -1,8 +1,8 @@
 .. _backend-tutorial:
 
-========================================================
-Tutorial: Write a Serverless GitHub Contribution Tracker
-========================================================
+==============================================================================================
+Tutorial: Build a Serverless GitHub Contribution Tracker using Triggers, Functions, and Values
+==============================================================================================
 
 .. meta::
    :keywords: code example

--- a/source/tutorial/backend.txt
+++ b/source/tutorial/backend.txt
@@ -14,9 +14,6 @@ Tutorial: Build a Serverless GitHub Contribution Tracker using Triggers, Functio
    :depth: 2
    :class: singlecol
 
-Overview
---------
-
 *Estimated time to complete: 30 minutes*
 
 In this tutorial, you will use Atlas App Services to build a serverless

--- a/source/tutorial/dotnet.txt
+++ b/source/tutorial/dotnet.txt
@@ -1,8 +1,12 @@
 .. _dotnet-tutorial:
 
-=============
-MAUI Tutorial
-=============
+==============================================
+Tutorial: Atlas Device Sync for .NET with MAUI
+==============================================
+
+.. meta::
+   :keywords: code example
+   :description: Learn how to build, modify, and run a demo .NET MAUI application using Atlas Device SDK for .NET and Atlas Device Sync.
 
 .. contents:: On this page
    :local:

--- a/source/tutorial/dotnet.txt
+++ b/source/tutorial/dotnet.txt
@@ -14,8 +14,7 @@ Tutorial: Atlas Device Sync for .NET with MAUI
    :depth: 3
    :class: singlecol
 
-Overview
---------
+*Estimated time to complete: 30 minutes, depending on your experience with MAUI*
 
 Realm provides a .NET SDK for creating multi-platform applications in C# with 
 MAUI. This tutorial is based on the 
@@ -30,9 +29,6 @@ In this tutorial, you will add a new ``Priority`` field
 to the existing ``Item`` model and update the 
 :ref:`Flexible Sync subscription <queryable-fields>` to only show items within 
 a range of priorities. 
-
-Depending on your experience with MAUI, this tutorial should take 
-around 30 minutes.
 
 .. note:: Check Out the Quick Start
    

--- a/source/tutorial/flutter.txt
+++ b/source/tutorial/flutter.txt
@@ -18,6 +18,8 @@ Tutorial: Atlas Device Sync for Flutter
    :depth: 3
    :class: singlecol
 
+*Estimated time to complete: 30 minutes, depending on your experience with Flutter*
+
 The Atlas Device SDK for Flutter allows you to create a multi-platform
 applications with Dart and Flutter. This tutorial is based on the
 Flutter Flexible Sync Template App, named ``flutter.todo.flex``, which illustrates
@@ -36,9 +38,6 @@ However, you would likely remove this toggle in a production application.
 This tutorial adds on to the template app. You will add a new ``priority`` field
 to the existing ``Item`` model and update the :ref:`Flexible Sync subscription
 <queryable-fields>` to only show items within a range of priorities.
-
-Depending on your experience with Flutter, this tutorial should take
-around 30 minutes.
 
 Learning Objectives
 -------------------

--- a/source/tutorial/flutter.txt
+++ b/source/tutorial/flutter.txt
@@ -1,8 +1,8 @@
 .. _flutter-tutorial:
 
-================
-Flutter Tutorial
-================
+=======================================
+Tutorial: Atlas Device Sync for Flutter
+=======================================
 
 .. meta::
    :keywords: code example

--- a/source/tutorial/kotlin.txt
+++ b/source/tutorial/kotlin.txt
@@ -14,8 +14,7 @@ Tutorial: Atlas Device Sync for Kotlin
    :depth: 3
    :class: singlecol
 
-Overview
---------
+*Estimated time to complete: 30 minutes, depending on your experience with Kotlin*
 
 Realm provides a Kotlin SDK that allows you to create an Android mobile
 application with Kotlin using :android:`Jetpack Compose </jetpack/compose/documentation>`. 
@@ -38,9 +37,6 @@ to the existing ``Item`` model and update the
 :ref:`Flexible Sync subscription <queryable-fields>` to only show items within 
 a range of priorities. This example illustrates how you might adapt the 
 template app for your own needs. 
-
-Depending on your experience with Kotlin, this tutorial should take 
-around 30 minutes.
 
 Learning Objectives
 -------------------

--- a/source/tutorial/kotlin.txt
+++ b/source/tutorial/kotlin.txt
@@ -1,8 +1,12 @@
 .. _kotlin-tutorial:
 
-============================
-Android With Kotlin Tutorial
-============================
+======================================
+Tutorial: Atlas Device Sync for Kotlin
+======================================
+
+.. meta::
+   :keywords: code example
+   :description: Learn how to build, modify, and run a demo Kotlin application using Atlas Device SDK for Kotlin and Atlas Device Sync.
 
 .. contents:: On this page
    :local:

--- a/source/tutorial/react-native.txt
+++ b/source/tutorial/react-native.txt
@@ -18,7 +18,7 @@ Tutorial: Atlas Device Sync for React Native
    :keywords: realm/react, code example
    :description: Learn how to build, modify, and run a demo React Native application using Atlas Device SDK for React Native and Atlas Device Sync.
 
-Overview
+*Estimated time to complete: 30 minutes*
 --------
 
 You can use the Realm React Native SDK and :npm:`@realm/react`

--- a/source/tutorial/react-native.txt
+++ b/source/tutorial/react-native.txt
@@ -18,8 +18,7 @@ Tutorial: Atlas Device Sync for React Native
    :keywords: realm/react, code example
    :description: Learn how to build, modify, and run a demo React Native application using Atlas Device SDK for React Native and Atlas Device Sync.
 
-*Estimated time to complete: 30 minutes*
---------
+*Estimated time to complete: 30 minutes, depending on your experience with React Native*
 
 You can use the Realm React Native SDK and :npm:`@realm/react`
 to build a mobile application with React Native. This tutorial
@@ -50,8 +49,6 @@ The template app provides a toggle that simulates the device being in
 an offline mode. This toggle lets you quickly test Device Sync functionality,
 emulating the user having no internet connection. However,
 you would likely remove this toggle in a production application.
-
-This tutorial should take around 30 minutes.
 
 .. note:: Check Out the Quick Start
    

--- a/source/tutorial/react-native.txt
+++ b/source/tutorial/react-native.txt
@@ -1,8 +1,8 @@
 .. _react-native-tutorial:
 
-=====================
-React Native Tutorial
-=====================
+============================================
+Tutorial: Atlas Device Sync for React Native
+============================================
 
 .. contents:: On this page
    :local:
@@ -15,7 +15,8 @@ React Native Tutorial
    :values: javascript/typescript
  
 .. meta::
-   :keywords: realm/react
+   :keywords: realm/react, code example
+   :description: Learn how to build, modify, and run a demo React Native application using Atlas Device SDK for React Native and Atlas Device Sync.
 
 Overview
 --------

--- a/source/tutorial/swiftui.txt
+++ b/source/tutorial/swiftui.txt
@@ -1,9 +1,13 @@
 .. _ios-swift-tutorial:
 .. _swift-swiftui-tutorial:
 
-====================
-SwiftUI iOS Tutorial
-====================
+===================================================
+Tutorial: Atlas Device Sync for Swift with Swift UI
+===================================================
+
+.. meta::
+   :keywords: code example
+   :description: Learn how to build, modify, and run a demo SwiftUI application using Atlas Device SDK for Swift and Atlas Device Sync.
 
 .. contents:: On this page
    :local:

--- a/source/tutorial/swiftui.txt
+++ b/source/tutorial/swiftui.txt
@@ -15,8 +15,7 @@ Tutorial: Atlas Device Sync for Swift with Swift UI
    :depth: 3
    :class: singlecol
 
-Overview
---------
+*Estimated time to complete: 30 minutes, depending on your experience with SwiftUI*
 
 Realm provides a Swift SDK that allows you to create a native iOS 
 mobile application with Swift or Objective-C. This tutorial is based on the 
@@ -37,9 +36,6 @@ This tutorial builds on the Template App. You will add a new ``priority`` field
 to the existing ``Item`` model and update the 
 :ref:`Flexible Sync subscription <queryable-fields>` to only show items within 
 a range of priorities.
-
-Depending on your experience with SwiftUI, this tutorial should take 
-around 30 minutes.
 
 Learning Objectives
 -------------------

--- a/source/tutorial/triggers-fts.txt
+++ b/source/tutorial/triggers-fts.txt
@@ -1,8 +1,12 @@
 .. _triggers-fts-tutorial:
 
-==========================================
-Build Reverse Search Into Your Application
-==========================================
+====================================================
+Tutorial: Build Reverse Search Into Your Application
+====================================================
+
+.. meta::
+   :keywords: code example
+   :description: Learn how to use Atlas App Services Triggers and Atlas Search in your application.
 
 .. contents:: On this page
    :local:

--- a/source/tutorial/triggers-fts.txt
+++ b/source/tutorial/triggers-fts.txt
@@ -1,8 +1,8 @@
 .. _triggers-fts-tutorial:
 
-====================================================
-Tutorial: Build Reverse Search Into Your Application
-====================================================
+====================================================================================
+Tutorial: Build Reverse Search Into Your Application using Triggers and Atlas Search
+====================================================================================
 
 .. meta::
    :keywords: code example

--- a/source/tutorial/triggers-fts.txt
+++ b/source/tutorial/triggers-fts.txt
@@ -14,8 +14,7 @@ Tutorial: Build Reverse Search Into Your Application using Triggers and Atlas Se
    :depth: 2
    :class: singlecol
 
-Overview
---------
+*Estimated time to complete: 30 minutes*
 
 You can use Atlas App Services with :ref:`Atlas Triggers <triggers>` and 
 :ref:`Atlas Search <fts-top-ref>` to build features, such as reverse search,
@@ -53,8 +52,6 @@ For example, if you want to know when users submit a time-sensitive task,
 you might enter a term such as ``urgent``. Then, when a user adds a task that 
 contains the term, such as ``Urgent: complete this task``, you'll be alerted 
 right away.
-
-This tutorial should take around 30 minutes.
 
 Prerequisites
 -------------

--- a/source/tutorials.txt
+++ b/source/tutorials.txt
@@ -1,20 +1,20 @@
 .. _app-services-get-started:
 
-===========
-Get Started
-===========
+============================================
+Get Started with Template Apps and Tutorials
+============================================
 
 .. toctree::
    :titlesonly:
    :hidden:
 
-   Device Sync Tutorial - .NET MAUI </tutorial/dotnet>
-   Device Sync Tutorial - Flutter </tutorial/flutter>
-   Device Sync Tutorial - Kotlin </tutorial/kotlin>
-   Device Sync Tutorial - React Native </tutorial/react-native> 
-   Device Sync Tutorial - SwiftUI </tutorial/swiftui>
-   Triggers, Functions & Values Tutorial </tutorial/backend>
-   Triggers and Atlas Search Tutorial </tutorial/triggers-fts>
+   .NET MAUI - Device Sync </tutorial/dotnet>
+   Flutter - Device Sync </tutorial/flutter>
+   Kotlin - Device Sync </tutorial/kotlin>
+   React Native - Device Sync </tutorial/react-native> 
+   SwiftUI - Device Sync </tutorial/swiftui>
+   Triggers, Functions & Values </tutorial/backend>
+   Triggers & Atlas Search </tutorial/triggers-fts>
 
 .. contents:: On this page
    :local:


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-38548

- [Home page](https://preview-mongodbkrollinsmdb.gatsbyjs.io/atlas-app-services/DOCSP-38548/):
  - Changed "Get Started" TOC entry to "Tutorials"
  - Flipped the TOC construction for tutorial pages from "Device Sync Tutorial - <LANGUAGE>" to "<LANGUAGE> - Device Sync"
- Individual tutorial pages:
  - Updated page titles to clearly indicate they're tutorials and include product names
  - Added meta descriptions and keywords to those that didn't have them 

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-realm work, if any

### Release Notes

- **Tutorials**
  - Changed "Get Started" TOC entry to "Tutorials"
  - Flipped the TOC construction for tutorial pages from "Device Sync Tutorial - <LANGUAGE>" to "<LANGUAGE> - Device Sync"
  - Individual tutorial pages:
    - Updated page titles to clearly indicate they're tutorials and include product names
    - Added meta descriptions and keywords to those that didn't have them 

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)

### Animal Wearing a Hat

<img src="https://i.chzbgr.com/full/9218227456/hC4EC0F99/cowboy-hat-vertebrate">
