### PR TITLE
(DOCSP-39173): Edge Server: Add info about Kubernetes deploys

### DIFF
--- a/source/edge-server/configure.txt
+++ b/source/edge-server/configure.txt
@@ -140,81 +140,33 @@ host.
 
 .. include:: /includes/important-stop-edge-server.rst
 
-.. procedure::
+.. tabs::
 
-   .. step:: Install the Edge Server Code
+   .. tab:: Docker Compose
+      :tabid: docker
 
-      Edge Server uses a command-line tool called ``edgectl`` to manage
-      the Edge Server instance on the host hardware. This includes an install
-      script to manage the installation and install required dependencies.
+      .. include:: /includes/edge/edge-docker-install-procedure.rst
 
-      Use this command to install the command-line tool and the Edge Server 
-      code on the device where you want to run the Edge Server instance:
+   .. tab:: Kubernetes
+      :tabid: kubernetes
 
-      .. code-block:: shell
+      We supply a Kubernetes operator which includes Custom Resource 
+      Definitions and a Controller to simplify running the Edge Server in your
+      own cluster. The Edge Server also uses a MongoDB container for its 
+      internal storage, which is managed by the official `MongoDB Kubernetes
+      Operator <https://www.mongodb.com/docs/kubernetes-operator/master/>`__.
 
-         curl -s https://services.cloud.mongodb.com/edge/install.sh | bash
+      Prerequisites
+      ~~~~~~~~~~~~~
 
-      Follow the prompts to download and install the Edge Server code.
+      For testing or development, we recommend using 
+      `minikube <https://minikube.sigs.k8s.io/docs/start/>`__ or 
+      `k3s <https://k3s.io/>`__.
 
-   .. step:: Initialize the Edge Server Instance
+      You need `Helm <https://helm.sh/docs/intro/install/>`__ to install the
+      operator.
 
-      Use ``edgectl`` to set up the Edge Server instance.
-
-      .. code-block:: shell
-
-         edgectl init --app-id="<INSERT-YOUR-APP-ID-HERE>" --platform=compose
-
-      The minimum required parameters are the ``app-id`` and the ``platform``.
-
-      - ``--app-id``: Provide your Edge Server App ID. For example, 
-        ``--app-id="edge-server-vtoyh"``. For more information, refer to 
-        :ref:`find-app-id`. 
-      - ``--platform``: You can use Docker Compose to install and manage your
-        Edge Server instance in a development environment, or Kubernetes to 
-        manage the instance in a production environment. Valid values are 
-        either ``compose`` or ``kubernetes``.
-
-      You can provide the following optional flags to specify additional
-      configuration details:
-
-      .. include:: /includes/edge/edgectl-init-flags.rst
-
-   .. step:: Supply the Edge Server Token
-
-      When first configuring the Edge Server instance, you're prompted to 
-      supply the Edge Server token. This is the token you got when you added 
-      the instance to your service.
-
-      If you no longer have the token, you can generate a new token from the
-      :ref:`edge-server-details` in your service.
-
-      The Edge Server instance exchanges this token for a secret. It uses the
-      secret to authenticate with Atlas when it syncs data.
-
-   .. step:: (Optional) Create a New User
-
-      If you'd like to connect to the Edge Server instance using a MongoDB
-      Driver or tool, you must have a username/password credential, or bypass
-      authentication. If you already have a username/password credential, or 
-      don't plan to connect to the Edge Server instance using a MongoDB Driver
-      or tool, you can skip this step.
-
-      For more information, refer to :ref:`edge-server-wireprotocol-connect`.
-
-      If you don't already have a username/password credential, you can create
-      one by following the prompts during ``edgectl init``.
-
-      Otherwise, you can manually :ref:`create-email-password-user` later
-      using the App Services UI, the App Services CLI, or the App Services
-      Admin API.
-
-      Alternately, if you plan to implement an authorization flow later, you
-      can bypass authorization with the following command and flag:
-
-      .. code-block:: console
-
-         edgectl config --insecure-disable-auth=true
+      .. include:: /includes/edge/edge-kube-install-procedure.rst
 
 .. _start-and-stop-edge-server:
 

--- a/source/edge-server/configure.txt
+++ b/source/edge-server/configure.txt
@@ -173,19 +173,48 @@ host.
 Start and Stop the Edge Server
 ------------------------------
 
-Use ``edgectl`` to start and stop the Edge Server instance.
+.. tabs::
 
-To start all Edge Server instance containers, use the ``start`` command:
+   .. tab:: Docker Compose
+      :tabid: docker
 
-.. code-block:: shell
+      Use ``edgectl`` to start and stop the Edge Server instance.
 
-   edgectl start
+      To start all Edge Server instance containers, use the ``start`` command:
 
-To stop all Edge Server instance containers, use the ``stop`` command:
+      .. code-block:: shell
 
-.. code-block:: shell
+         edgectl start
 
-   edgectl stop
+      To stop all Edge Server instance containers, use the ``stop`` command:
+
+      .. code-block:: shell
+
+         edgectl stop
+
+   .. tab:: Kubernetes
+      :tabid: kubernetes
+
+      Kubernetes deployments do not have a direct analog to ``start`` and
+      ``stop``.
+
+      Instead, you can scale your deployment to effectively stop and start it,
+      or delete the deployment and apply the configuration again later to 
+      recreate it.
+
+      To scale a deployment to effectively stop it:
+
+      .. code-block:: shell
+
+         kubectl scale deployments mongodb-kubernetes-operator --replicas=0
+         kubectl scale deployments mongodb-atlas-edge-operator-controller-manager --replicas=0
+
+      To start the deployment again:
+
+      .. code-block:: shell
+
+         kubectl scale deployments mongodb-kubernetes-operator --replicas=1
+         kubectl scale deployments mongodb-atlas-edge-operator-controller-manager --replicas=1
 
 .. include:: /includes/important-stop-edge-server.rst
 
@@ -194,7 +223,21 @@ To stop all Edge Server instance containers, use the ``stop`` command:
 Check the Edge Server Status
 ----------------------------
 
-.. include:: /includes/edge/edgectl-status.rst
+.. tabs::
+
+   .. tab:: Docker Compose
+      :tabid: docker
+
+      .. include:: /includes/edge/edgectl-status.rst
+
+   .. tab:: Kubernetes
+      :tabid: kubernetes
+
+      Use ``kubectl`` to check the status of running pods:
+
+      .. code-block:: shell
+
+         kubectl get pods
 
 .. _update-edge-server-instance-config:
 
@@ -202,11 +245,16 @@ Update the Edge Server Instance Configuration
 ---------------------------------------------
 
 You can make changes to an existing Edge Server instance using ``edgectl``.
-After you change the configuration, restart the instance to apply the updates.
 
-.. procedure::
+.. tabs::
 
-   .. step:: Update the Edge Server Configuration
+   .. tab:: Docker Compose
+      :tabid: docker
+
+      .. include:: /includes/edge/edge-docker-update-config-procedure.rst
+
+   .. tab:: Kubernetes
+      :tabid: kubernetes
 
       Use the ``edgectl config`` command with the appropriate flags to update
       the instance:
@@ -215,21 +263,10 @@ After you change the configuration, restart the instance to apply the updates.
 
          edgectl config --YOUR-FLAG-HERE
 
+      When you issue the ``config`` command, the Edge Server operator updates
+      the resource.
+
       .. include:: includes/edge/edgectl-config-flags.rst
-
-   .. step:: Restart the Edge Server Instance
-
-      After you update the configuration, stop the instance:
-
-      .. code-block:: console
-
-         edgectl stop
-
-      And start it again to apply the updates:
-
-      .. code-block:: console
-
-         edgectl start
 
 .. _upgrade-edge-server-version:
 
@@ -255,12 +292,12 @@ or it enters a ``FAILED`` state and cannot connect to Atlas.
 
       .. code-block:: shell
 
-         edgectl update
+         edgectl upgrade --YOUR-FLAG-HERE
 
       Depending on your hardware and network connection, the upgrade 
       process may take seconds to minutes.
 
-      You can optionally specify arguments to upgrade to a specific version:
+      You can specify any of these arguments to perform the upgrade:
 
       .. list-table::
          :header-rows: 1
@@ -270,10 +307,11 @@ or it enters a ``FAILED`` state and cannot connect to Atlas.
            - Type
            - Value
 
-         * - ``--config-path``
+         * - ``--edge-root-dir``
            - String
-           - The location on disk to store configuration files. Defaults to
-             ``~/.mongodb-edge/``.
+           - The location on disk where configuration files are stored. 
+             Defaults to ``~/.mongodb-edge/``. If you have not customized the
+             root directory, you can omit this flag.
 
          * - ``--minor``
            - Boolean
@@ -284,9 +322,18 @@ or it enters a ``FAILED`` state and cannot connect to Atlas.
            - Boolean
            - Upgrade to the next major version. Defaults to ``false``.
 
-         * - ``--to``
+         * - ``--latest``
+           - Boolean
+           - Upgrade to the latest version. Defaults to ``false``.
+
+         * - ``--profile``
            - String
-           - Upgrade (or downgrade) to an exact version. Default ``""``.
+           - The name of the profile to use when executing a given ``edgectl``
+             command. If you do not provide a name, the profile name defaults to
+             the ``app-id``, with an incrementing number appended, starting with
+             ``-01``. When you do not provide a profile flag, ``edgectl`` uses the
+             default profile when executing a command. For more information, refer
+             to :ref:`multiple-edge-servers-on-host`.
 
    .. step:: Configure the Edge Server
 

--- a/source/edge-server/configure.txt
+++ b/source/edge-server/configure.txt
@@ -195,26 +195,11 @@ Start and Stop the Edge Server
    .. tab:: Kubernetes
       :tabid: kubernetes
 
-      Kubernetes deployments do not have a direct analog to ``start`` and
-      ``stop``.
+      Kubernetes deployments do not have a direct analog to ``edgectl start``
+      and ``edgectl stop``.
 
-      Instead, you can scale your deployment to effectively stop and start it,
-      or delete the deployment and apply the configuration again later to 
-      recreate it.
-
-      To scale a deployment to effectively stop it:
-
-      .. code-block:: shell
-
-         kubectl scale deployments mongodb-kubernetes-operator --replicas=0
-         kubectl scale deployments mongodb-atlas-edge-operator-controller-manager --replicas=0
-
-      To start the deployment again:
-
-      .. code-block:: shell
-
-         kubectl scale deployments mongodb-kubernetes-operator --replicas=1
-         kubectl scale deployments mongodb-atlas-edge-operator-controller-manager --replicas=1
+      Instead, use your deployment tool to appropriately stop or delete
+      the containers.
 
 .. include:: /includes/important-stop-edge-server.rst
 

--- a/source/edge-server/connect.txt
+++ b/source/edge-server/connect.txt
@@ -274,6 +274,7 @@ this form:
    * - ``<port>``
      - The Edge Server Wire Protocol listen port. The default port is ``27021``.
        For more details, refer to :ref:`edge-server-install-and-configure`.
+       If using Kubernetes, you must expose a port to accept client connections.
 
    * - ``authMechanism=PLAIN``
      - The auth mechanism. Currently, the only supported value is ``PLAIN``.

--- a/source/includes/edge/edge-docker-install-procedure.rst
+++ b/source/includes/edge/edge-docker-install-procedure.rst
@@ -1,0 +1,56 @@
+.. procedure::
+
+   .. step:: Install the Edge Server Code
+
+      .. include:: /includes/edge/install-edgectl.rst
+
+   .. step:: Initialize the Edge Server Instance
+
+      Use ``edgectl`` to set up the Edge Server instance.
+
+      .. code-block:: shell
+
+         edgectl init --app-id="<INSERT-YOUR-APP-ID-HERE>" --platform=compose
+
+      The minimum required parameters are the ``app-id`` and the ``platform``.
+
+      - ``--app-id``: Provide your Edge Server App ID. For example, 
+        ``--app-id="edge-server-vtoyh"``. For more information, refer to 
+        :ref:`find-app-id`. 
+      - ``--platform``: You can use Docker Compose to install and manage your
+        Edge Server instance in a development environment, or Kubernetes to 
+        manage the instance in a production environment. Valid values are 
+        either ``compose`` or ``kubernetes``.
+
+      You can provide the following optional flags to specify additional
+      configuration details:
+
+      .. include:: /includes/edge/edgectl-init-flags.rst
+
+   .. step:: Supply the Edge Server Token
+
+      .. include:: /includes/edge/init-registration-token.rst
+
+   .. step:: (Optional) Create a New User
+
+      If you'd like to connect to the Edge Server instance using a MongoDB
+      Driver or tool, you must have a username/password credential, or bypass
+      authentication. If you already have a username/password credential, or 
+      don't plan to connect to the Edge Server instance using a MongoDB Driver
+      or tool, you can skip this step.
+
+      For more information, refer to :ref:`edge-server-wireprotocol-connect`.
+
+      If you don't already have a username/password credential, you can create
+      one by following the prompts during ``edgectl init``.
+
+      Otherwise, you can manually :ref:`create-email-password-user` later
+      using the App Services UI, the App Services CLI, or the App Services
+      Admin API.
+
+      Alternately, if you plan to implement an authorization flow later, you
+      can bypass authorization with the following command and flag:
+
+      .. code-block:: console
+
+         edgectl config --insecure-disable-auth=true

--- a/source/includes/edge/edge-docker-update-config-procedure.rst
+++ b/source/includes/edge/edge-docker-update-config-procedure.rst
@@ -1,0 +1,26 @@
+.. procedure::
+
+   .. step:: Update the Edge Server Configuration
+
+      Use the ``edgectl config`` command with the appropriate flags to update
+      the instance:
+
+      .. code-block:: console
+
+         edgectl config --YOUR-FLAG-HERE
+
+      .. include:: includes/edge/edgectl-config-flags.rst
+
+   .. step:: Restart the Edge Server Instance
+
+      After you update the configuration, stop the instance:
+
+      .. code-block:: console
+
+         edgectl stop
+
+      And start it again to apply the updates:
+
+      .. code-block:: console
+
+         edgectl start

--- a/source/includes/edge/edge-kube-install-procedure.rst
+++ b/source/includes/edge/edge-kube-install-procedure.rst
@@ -61,9 +61,6 @@
 
       Use ``kubectl`` to apply the configuration to your cluster. The prior
       step provided the configuration path as part of the ``edgectl`` output.
-      It should look similar to:
-
-      ``'/Users/YOUR-USERNAME/.mongodb-edge/profiles/YOUR-PROFILE-NAME/kube-resource.yml'``
 
       .. code-block:: console
 

--- a/source/includes/edge/edge-kube-install-procedure.rst
+++ b/source/includes/edge/edge-kube-install-procedure.rst
@@ -1,0 +1,86 @@
+.. procedure::
+
+   .. step:: Add the MongoDB Helm Charts repository to Helm
+
+      Add the `MongoDB Helm Charts for Kubernetes <https://mongodb.github.io/helm-charts>`__ 
+      repository to Helm.
+
+      .. code-block:: console
+
+         helm repo add mongodb https://mongodb.github.io/helm-charts
+
+   .. step:: Install the Community Operator
+
+      .. code-block:: console
+
+         helm upgrade --install community-operator mongodb/community-operator --set mongodb.name=mongodb-enterprise-server --set mongodb.repo=quay.io/mongodb
+
+   .. step:: Fetch the Edge Server Operator resource and `kubectl apply` it
+
+      .. code-block:: console
+
+         curl "https://raw.githubusercontent.com/mongodb/edge-kubernetes-operator/main/release.yaml" | kubectl apply -f -
+
+   .. step:: Install `edgectl`
+
+      .. include:: /includes/edge/install-edgectl.rst
+
+   .. step:: Initialize the Edge Server Instance
+
+      Use ``edgectl`` to set up the Edge Server instance. This generates a
+      configuration file which you can apply to your cluster with ``kubectl``.
+
+      .. code-block:: shell
+
+         edgectl init --app-id="<INSERT-YOUR-APP-ID-HERE>" --platform=kubernetes
+
+      The minimum required parameters are the ``app-id`` and the ``platform``.
+
+      - ``--app-id``: Provide your Edge Server App ID. For example, 
+        ``--app-id="edge-server-vtoyh"``. For more information, refer to 
+        :ref:`find-app-id`. 
+      - ``--platform``: You can use Docker Compose to install and manage your
+        Edge Server instance in a development environment, or Kubernetes to 
+        manage the instance in a production environment. Valid values are 
+        either ``compose`` or ``kubernetes``.
+
+      You can provide the following optional flags to specify additional
+      configuration details:
+
+      .. include:: /includes/edge/edgectl-init-flags.rst
+
+   .. step:: Supply the Edge Server Token
+
+      .. include:: /includes/edge/init-registration-token.rst
+
+      After you supply the registration token, ``edgectl`` outputs the path
+      where it has written the Kubernetes resource file. Note this
+      information for the next step.
+
+   .. step:: Apply the Configuration to Your Cluster
+
+      Use ``kubectl`` to apply the configuration to your cluster. The prior
+      step provided the configuration path as part of the ``edgectl`` output.
+      It should look similar to:
+
+      ``'/Users/YOUR-USERNAME/.mongodb-edge/profiles/YOUR-PROFILE-NAME/kube-resource.yml'``
+
+      .. code-block:: console
+
+         kubectl apply -f /Users/YOUR-USERNAME/.mongodb-edge/profiles/YOUR-PROFILE-NAME/kube-resource.yml
+
+      Use ``kuebctl get pods`` to get the status of the deployment. A completed
+      deployment resembles:
+
+      .. code-block:: console
+
+         $ kubectl get pods
+         NAME                                                              READY   STATUS    RESTARTS      AGE
+         mongodb-atlas-edge-operator-controller-manager-565b79476d-4t248   2/2     Running   0             11m
+         mongodb-kubernetes-operator-f6f956684-rbtz4                       1/1     Running   0             62m
+         stores-NY-42-0                                                    2/2     Running   0             58m
+         stores-NY-42-backing-db-0                                         2/2     Running   0             58m
+
+      It may take a few moments to configure and get everything running. You 
+      may see transient errors during initial setup, which should resolve
+      as all the containers get to a ``Running`` state.

--- a/source/includes/edge/edge-kube-install-procedure.rst
+++ b/source/includes/edge/edge-kube-install-procedure.rst
@@ -15,13 +15,13 @@
 
          helm upgrade --install community-operator mongodb/community-operator --set mongodb.name=mongodb-enterprise-server --set mongodb.repo=quay.io/mongodb
 
-   .. step:: Fetch the Edge Server Operator resource and `kubectl apply` it
+   .. step:: Fetch the Edge Server Operator resource and ``kubectl apply`` it
 
       .. code-block:: console
 
          curl "https://raw.githubusercontent.com/mongodb/edge-kubernetes-operator/main/release.yaml" | kubectl apply -f -
 
-   .. step:: Install `edgectl`
+   .. step:: Install ``edgectl``
 
       .. include:: /includes/edge/install-edgectl.rst
 
@@ -70,6 +70,7 @@
       deployment resembles:
 
       .. code-block:: console
+         :copyable: false
 
          $ kubectl get pods
          NAME                                                              READY   STATUS    RESTARTS      AGE

--- a/source/includes/edge/init-registration-token.rst
+++ b/source/includes/edge/init-registration-token.rst
@@ -1,0 +1,9 @@
+When first configuring the Edge Server instance, you're prompted to 
+supply the Edge Server token. This is the token you got when you added 
+the instance to your service.
+
+If you no longer have the token, you can generate a new token from the
+:ref:`edge-server-details` in your service.
+
+The Edge Server instance exchanges this token for a secret. It uses the
+secret to authenticate with Atlas when it syncs data.

--- a/source/includes/edge/install-edgectl.rst
+++ b/source/includes/edge/install-edgectl.rst
@@ -1,0 +1,12 @@
+Edge Server uses a command-line tool called ``edgectl`` to manage
+the Edge Server instance on the host hardware. This includes an install
+script to manage the installation and install required dependencies.
+
+Use this command to install the command-line tool and the Edge Server 
+code on the device where you want to run the Edge Server instance:
+
+.. code-block:: shell
+
+   curl -s https://services.cloud.mongodb.com/edge/install.sh | bash
+
+Follow the prompts to download and install the Edge Server code.


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-39173

- [Configure an Edge Server Instance](https://preview-mongodbdacharyc.gatsbyjs.io/atlas-app-services/DOCSP-39173/edge-server/configure/#install-and-configure-the-edge-server-instance): Add tabs for Docker Compose and Kubernetes instructions where they diverge.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-realm work, if any

### Release Notes

- **Edge Server**
  - Configure an Edge Server Instance: Add tabs for Docker Compose and Kubernetes instructions where they diverge.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
