### PR TITLE
DOCSP-37913 Enable development mode from API in Enable Sync Procedure

### DIFF
--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -155,7 +155,7 @@ Procedure
               :admin-api-endpoint:`API Authentication <section/Get-Authentication-Tokens>`
               documentation to learn how to acquire a valid access token.
 
-            You'll need the cluster's data source configuration file to configure sync. You
+            You'll need the cluster's service configuration file to configure sync. You
             can find the configuration file by :admin-api-endpoint:`listing all services 
             through the Admin API <operation/adminListServices>`:
 
@@ -231,4 +231,4 @@ Procedure
             For details on the sync configuration, refer to the :ref:`sync-configuration-reference`.
 
             You can confirm the configuration is updated by getting the service
-            configuration, as in Step 1. 
+            configuration again, as described in Step 1. 

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -155,27 +155,27 @@ Procedure
               :admin-api-endpoint:`API Authentication <section/Get-Authentication-Tokens>`
               documentation to learn how to acquire a valid access token.
 
-            You'll need the cluster's service configuration file to configure sync. You
+            You'll need the cluster's data source configuration file to configure sync. You
             can find the configuration file by :admin-api-endpoint:`listing all services 
             through the Admin API <operation/adminListServices>`:
 
             .. code-block:: shell
-               :caption: Find Your Service's Id
+               :caption: Find Your Cluster's Id
 
                curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services \
                  -X GET \
                  -h 'Authorization: Bearer <Valid Access Token>'
 
-            Identify the service whose configuration you need to update to enable
+            Identify the cluster whose configuration you need to update to enable
             Sync. If you have accepted the default names when configuring 
-            your App, this should be a service whose ``name`` is ``mongodb-atlas``
-            and ``type`` is ``mongodb-atlas``. You need this service's ``_id``.
+            your App, this should be a cluster whose ``name`` is ``mongodb-atlas``
+            and ``type`` is ``mongodb-atlas``. You need this cluster's ``_id``.
 
-            Now you can :admin-api-endpoint:`get the configuration file for 
-            this service <operation/adminGetServiceConfig>`:
+            Now you can :admin-api-endpoint:`get the sync configuration file for 
+            this cluster <operation/adminGetServiceConfig>`:
 
             .. code-block:: shell
-               :caption: Get the Service Configuration File
+               :caption: Get the Sync Configuration File for the Cluster
 
                curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services/{MongoDB_Service_ID}/config \
                  -X GET \

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -181,7 +181,7 @@ Procedure
                  -X GET \
                  -h 'Authorization: Bearer <Valid Access Token>'
 
-            To configure sync, we will add a ``flexible_sync`` object to this configuration in a following step.
+            To configure Sync, we will add a ``flexible_sync`` object to this configuration in a following step.
 
          .. step:: Enable Development Mode (optional)
 
@@ -202,7 +202,7 @@ Procedure
             To deploy your changes and start syncing data, send an
             Admin API request that :admin-api-endpoint:`updates the cluster
             configuration <operation/adminUpdateServiceConfig>` with a 
-            ``flexible_sync`` object with the following template configuration:
+            ``flexible_sync`` object using the following template configuration:
 
             .. code-block:: shell
                :caption: Update Sync Configuration
@@ -229,7 +229,7 @@ Procedure
                }
 
             
-            For details on the sync configuration, refer to the :ref:`sync-configuration-reference`.
+            For details on the Sync configuration, refer to the :ref:`sync-configuration-reference`.
 
-            You can confirm the configuration is updated by getting the service
+            You can confirm the Sync configuration is added by getting the service
             configuration again, as described in Step 1. 

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -229,3 +229,5 @@ Procedure
                    "collection_queryable_fields_names": <Map[String][]String>
                  }
                }
+
+            For details on the sync configuration, refer to the :ref:`sync-configuration-reference`.

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -171,17 +171,17 @@ Procedure
             your App, this should be a cluster whose ``name`` is ``mongodb-atlas``
             and ``type`` is ``mongodb-atlas``. You need this cluster's ``_id``.
 
-            Now you can :admin-api-endpoint:`get the sync configuration file for 
+            Now you can :admin-api-endpoint:`get the service configuration file for 
             this cluster <operation/adminGetServiceConfig>`:
 
             .. code-block:: shell
-               :caption: Get the Sync Configuration File for the Cluster
+               :caption: Get the Service Configuration File for the Cluster
 
                curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services/{MongoDB_Service_ID}/config \
                  -X GET \
                  -h 'Authorization: Bearer <Valid Access Token>'
 
-            For details on the sync configuration, refer to the :ref:`sync-configuration-reference`.
+            To configure sync, we will add a ``flexible_sync`` object to this configuration in a following step.
 
          .. step:: Enable Development Mode (optional)
 
@@ -201,7 +201,8 @@ Procedure
 
             To deploy your changes and start syncing data, send an
             Admin API request that :admin-api-endpoint:`updates the cluster
-            configuration <operation/adminUpdateServiceConfig>` with the following template sync configuration:
+            configuration <operation/adminUpdateServiceConfig>` with a 
+            ``flexible_sync`` object with the following template configuration:
 
             .. code-block:: shell
                :caption: Update Sync Configuration

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -198,8 +198,6 @@ Procedure
                  ...
                }
 
-            For details, refer to the :ref:`sync-configuration-reference`.
-
             You may want to enable :ref:`Development Mode <development-mode>` before deploying your changes. 
             You can use the following command to enable Development Mode:
             
@@ -210,6 +208,8 @@ Procedure
                  -h 'Authorization: Bearer <Valid Access Token>'
                  -h "Content-Type: application/json"
                  -d '{"development_mode_enabled": true}'
+
+            For details, refer to the :ref:`sync-configuration-reference`.
               
          .. step:: Deploy the Sync Configuration
 

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -179,28 +179,11 @@ Procedure
                  -X GET \
                  -h 'Authorization: Bearer <Valid Access Token>'
 
-            Once you have the configuration, add the ``flexible_sync`` object with the
-            following template configuration:
+         .. step:: Enable Development Mode (optional)
 
-            .. code-block:: json
-
-               {
-                 ...
-                 "flexible_sync": {
-                   "state": "enabled",
-                   "database_name": "<Name of Database>",
-                   "client_max_offline_days": <Number>,
-                   "is_recovery_mode_disabled": <Boolean>,
-                   "indexed_queryable_fields_names": <Array of String Field Names>,
-                   "queryable_fields_names": <Array of String Field Names>,
-                   "collection_queryable_fields_names": <Map[String][]String>
-                 }
-                 ...
-               }
-
-            You may want to enable :ref:`Development Mode <development-mode>` before deploying your changes. 
+            You may need to enable :ref:`Development Mode <development-mode>` before deploying your changes. 
             You can use the following command to enable Development Mode:
-            
+
             .. code-block:: shell
 
                curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/sync/config \
@@ -209,14 +192,12 @@ Procedure
                  -h "Content-Type: application/json"
                  -d '{"development_mode_enabled": true}'
 
-            For details, refer to the :ref:`sync-configuration-reference`.
-              
-         .. step:: Deploy the Sync Configuration
+         .. step:: Update and Deploy the Sync Configuration
 
             To deploy your changes and start syncing data, send an
             :admin-api-endpoint:`Admin API request
-            <operation/adminGetServiceConfig>` that updates the cluster
-            configuration with your sync configuration:
+            <operation/adminUpdateServiceConfig>` that updates the cluster
+            configuration with the following template sync configuration:
 
             .. note:: Authenticating Your Request with an Access Token
 
@@ -230,5 +211,21 @@ Procedure
                curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services/{MongoDB_Service_ID}/config \
                  -X PATCH \
                  -h 'Authorization: Bearer <Valid Access Token>' \
-                 -h "Content-Type: application/json"
-                 -d @/sync/config.json
+                 -h "Content-Type: application/json" \
+                 -d '<Flexible Sync Configuration>'
+
+            .. code-block:: json
+
+               {
+                 "flexible_sync": {
+                   "state": "enabled",
+                   "database_name": "<Name of Database>",
+                   "client_max_offline_days": <Number>,
+                   "is_recovery_mode_disabled": <Boolean>,
+                   "indexed_queryable_fields_names": <Array of String Field Names>,
+                   "queryable_fields_names": <Array of String Field Names>,
+                   "collection_queryable_fields_names": <Map[String][]String>
+                 }
+               }
+
+            For details on the sync configuration, refer to the :ref:`sync-configuration-reference`.

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -206,10 +206,10 @@ Procedure
             .. code-block:: shell
 
                curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/sync/config \
-               -X PUT \
-               -h 'Authorization: Bearer <Valid Access Token>'
-               -h "Content-Type: application/json"
-               -d '{"development_mode_enabled": true}'
+                 -X PUT \
+                 -h 'Authorization: Bearer <Valid Access Token>'
+                 -h "Content-Type: application/json"
+                 -d '{"development_mode_enabled": true}'
               
          .. step:: Deploy the Sync Configuration
 

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -200,6 +200,17 @@ Procedure
 
             For details, refer to the :ref:`sync-configuration-reference`.
 
+            You may want to enable :ref:`Development Mode <development-mode>` before deploying your changes. 
+            You can use the following command to enable Development Mode:
+            
+            .. code-block:: shell
+
+               curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/sync/config \
+               -X PUT \
+               -h 'Authorization: Bearer <Valid Access Token>'
+               -h "Content-Type: application/json"
+               -d '{"development_mode_enabled": true}'
+              
          .. step:: Deploy the Sync Configuration
 
             To deploy your changes and start syncing data, send an

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -160,6 +160,7 @@ Procedure
             through the Admin API <operation/adminListServices>`:
 
             .. code-block:: shell
+               :caption: Find Your Service's Id
 
                curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services \
                  -X GET \
@@ -174,6 +175,7 @@ Procedure
             this service <operation/adminGetServiceConfig>`:
 
             .. code-block:: shell
+               :caption: Get the Service Configuration File
 
                curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services/{MongoDB_Service_ID}/config \
                  -X GET \
@@ -183,32 +185,26 @@ Procedure
 
          .. step:: Enable Development Mode (optional)
 
-            You may need to enable :ref:`Development Mode <development-mode>` before deploying your changes. 
-            You can use the following command to enable Development Mode:
+            If you would like to enable :ref:`Development Mode <development-mode>` to streamline production, 
+            use the following command:
 
             .. code-block:: shell
+               :caption: Enable Development Mode
 
                curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/sync/config \
                  -X PUT \
-                 -h 'Authorization: Bearer <Valid Access Token>'
-                 -h "Content-Type: application/json"
+                 -h 'Authorization: Bearer <Valid Access Token>' \
+                 -h "Content-Type: application/json" \
                  -d '{"development_mode_enabled": true}'
 
-         .. step:: Update and Deploy the Sync Configuration
+         .. step:: Add and Deploy the Sync Configuration
 
             To deploy your changes and start syncing data, send an
-            :admin-api-endpoint:`Admin API request
-            <operation/adminUpdateServiceConfig>` that updates the cluster
-            configuration with the following template sync configuration:
-
-            .. note:: Authenticating Your Request with an Access Token
-
-              To authenticate your request to the App Services Admin API, you need a valid and
-              current authorization token from the MongoDB Cloud API. Read the
-              :admin-api-endpoint:`API Authentication <section/Get-Authentication-Tokens>`
-              documentation to learn how to acquire a valid access token.
+            Admin API request that :admin-api-endpoint:`updates the cluster
+            configuration <operation/adminUpdateServiceConfig>` with the following template sync configuration:
 
             .. code-block:: shell
+               :caption: Update Sync Configuration
 
                curl https://services.cloud.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/services/{MongoDB_Service_ID}/config \
                  -X PATCH \
@@ -217,6 +213,7 @@ Procedure
                  -d '<Flexible Sync Configuration>'
 
             .. code-block:: json
+               :caption: Flexible Sync Configuration
 
                {
                  "flexible_sync": {
@@ -230,4 +227,8 @@ Procedure
                  }
                }
 
+            
             For details on the sync configuration, refer to the :ref:`sync-configuration-reference`.
+
+            You can confirm the configuration is updated by getting the service
+            configuration, as in Step 1. 

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -179,6 +179,8 @@ Procedure
                  -X GET \
                  -h 'Authorization: Bearer <Valid Access Token>'
 
+            For details on the sync configuration, refer to the :ref:`sync-configuration-reference`.
+
          .. step:: Enable Development Mode (optional)
 
             You may need to enable :ref:`Development Mode <development-mode>` before deploying your changes. 
@@ -227,5 +229,3 @@ Procedure
                    "collection_queryable_fields_names": <Map[String][]String>
                  }
                }
-
-            For details on the sync configuration, refer to the :ref:`sync-configuration-reference`.


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-37913

- [Enable Atlas Device Sync](https://preview-mongodblindseymoore.gatsbyjs.io/atlas-app-services/DOCSP-37913/sync/configure/enable-sync/#select-a-cluster-to-sync): For Admin API, added info on enabling development mode and edited steps for clarity. 

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-realm work, if any

### Release Notes

<!--
- **Define Data Access Permissions**
  - Data Access Role Examples: Update CRUD Permissions example screenshots and
    copyable JSON
-->

**Device Sync**
- Configure Sync/Enable Atlas Device Sync: For Admin API, added a step on enabling development mode and clarified procedure steps for updating and enabling sync.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
