### PR TITLE
Update date in coll in mixed note

### DIFF
--- a/source/includes/note-collections-in-mixed-sync.rst
+++ b/source/includes/note-collections-in-mixed-sync.rst
@@ -1,13 +1,13 @@
-.. note:: Collections in Mixed fields supported in Apps created after May 22, 2024
+.. note:: Apps created after May 28, 2024
 
-    App Services Apps created *after* May 22, 2024 can store collections
+    App Services Apps created *after* May 28, 2024 can store collections
     (arrays and dictionaries) of mixed data within a mixed data property.
     You can nest collections within other collections, which lets you store
     complex data structures such as JSON or MongoDB documents without having to
     define a strict data model.
 
-    To use this feature with Atlas Device SDK, you must use the following
-    minimum SDK versions:
+    To use this feature with Atlas Device SDK, you must use one of the
+    following minimum SDK versions:
 
     - C++ SDK: version TBD
     - Flutter SDK: v2.0.0 or later


### PR DESCRIPTION
## Pull Request Info

Jira ticket: none

Update note to use `May 28, 2024`

- [Data Model Mapping](https://preview-mongodbcbullinger.gatsbyjs.io/atlas-app-services/no-jira-fix-date/sync/data-model/data-model-map/#collections-in-mixed-properties)

### Release Notes

- **Device Sync**: 
  - Configure and Update Your Data Model > Data Model Mapping: Update note for `Mixed Properties` to specify Collections in Mixed feature is only valid for App Services Apps created after `May 28, 2024`. 
  - Define a Data Model > Schemas > Schema Data Types: Update note for `Mixed` data type to specify Collections in Mixed feature is only valid for App Services Apps created after `May 28, 2024`.  

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
