### PR TITLE
Fix incorrect Swift version number for coll-in-mixed feature

### DIFF
--- a/source/includes/note-collections-in-mixed-sync.rst
+++ b/source/includes/note-collections-in-mixed-sync.rst
@@ -15,7 +15,7 @@
     - .NET SDK: v12.2.0 or later
     - Node.js SDK: v12.9.0 or later
     - React Native SDK: v12.9.0 or later
-    - Swift SDK: version v10.15.0 or later
+    - Swift SDK: v10.51.0 or later
 
     This feature is *not* supported in the Java SDK.
 

--- a/source/sync/data-model/data-model-map.txt
+++ b/source/sync/data-model/data-model-map.txt
@@ -269,7 +269,7 @@ For SDK-specific details about mixed data types, refer to the following:
 
 - :ref:`Mixed - C++ SDK <cpp-supported-property-types>`
 - :ref:`RealmValue - Flutter SDK <flutter-realm-value>`
-- :ref:`RealmAny <java-realmany>`
+- :ref:`RealmAny - Java SDK <java-realmany>`
 - :ref:`RealmAny - Kotlin SDK <kotlin-realmany>`
 - :ref:`RealmValue - .NET SDK <realmvalue>`
 - :ref:`Mixed - Node.js SDK <node-data-types-mixed>`
@@ -278,9 +278,9 @@ For SDK-specific details about mixed data types, refer to the following:
 
 .. note:: New Java SDK Apps Cannot Use ``RealmAny``
 
-  New App Services Apps using Java SDK
-  will not be able to synchronize data models with properties of type
-  ``RealmAny``.
+  New App Services Apps using Java SDK cannot synchronize data models with
+  properties of type ``RealmAny``. To use mixed data types with Device Sync
+  in your app, use the Kotlin SDK.
 
 Embedded Objects
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Quick fix: 
Correct version number for Collections in Mixed feature release (should be `10.51.0` instead of `10.15.0`)

- [Data Model Mapping](https://preview-mongodbcbullinger.gatsbyjs.io/atlas-app-services/no-jira-fix-version-number/sync/data-model/data-model-map/#collections-in-mixed-properties)

### Release Notes

**Device Sync**
- Configure and Update Your Data Model > Data Model Mapping: Correct the minimum Swift SDK version number listed in the Collections in Mixed note.