### PR TITLE
Remove guidance on migrating to http endpoints and data api

### DIFF
--- a/source/data-api/custom-endpoints.txt
+++ b/source/data-api/custom-endpoints.txt
@@ -18,6 +18,11 @@ or webhooks that integrate with external services. A custom endpoint
 uses a serverless function that you write to handle incoming requests
 for a specific URL and HTTP method.
 
+.. note:: 
+
+   Custom HTTPS Endpoints are not supported in 
+   :ref:`private endpoints <private-endpoints>`.
+
 Endpoints use standard, encrypted HTTPS requests, which means that you
 don't need to install any database drivers or opinionated libraries to
 call them. Instead, you send requests like this from any HTTP client:

--- a/source/data-api/generated-endpoints.txt
+++ b/source/data-api/generated-endpoints.txt
@@ -33,6 +33,10 @@ document in a linked cluster by calling the ``insertOne`` endpoint:
 For a detailed API reference of all available endpoints, see the
 :ref:`Data API OpenAPI Reference <data-api-v1>`.
 
+.. note:: 
+
+   Data API Endpoints are not supported in :ref:`private endpoints <private-endpoints>`.
+
 When to Use the Data API
 ------------------------
 

--- a/source/security/private-endpoints.txt
+++ b/source/security/private-endpoints.txt
@@ -69,11 +69,6 @@ Add a Private Endpoint
 You can add a new General Endpoint or Sync Endpoint with the App Services UI or
 the Admin API.
 
-.. note:: 
-   
-   Endpoints that use the ``realm.mongodb.com`` domain must migrate to use the new
-   ``services.cloud.mongodb.com`` domain.
-
 Add a General Endpoint
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/security/private-endpoints.txt
+++ b/source/security/private-endpoints.txt
@@ -66,15 +66,8 @@ You must also install and authenticate the AWS CLI.
 Add a Private Endpoint
 ----------------------
 
-You can add a new Private Endpoint with the App Services UI or the Admin API.
-
-You can add a new General Endpoint or a new Sync Endpoint. You can also
-migrate a Legacy Endpoint to either a new General or Sync Endpoint.
-
-.. note:: 
-   
-   Endpoints that use the ``realm.mongodb.com`` domain must migrate to use the new
-   ``services.cloud.mongodb.com`` domain.
+You can add a new General Endpoint or Sync Endpoint with the App Services UI or
+the Admin API.
 
 Add a General Endpoint
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/source/security/private-endpoints.txt
+++ b/source/security/private-endpoints.txt
@@ -32,8 +32,12 @@ There are two kinds of App Services Private Endpoints:
 - Sync: Endpoints that use ``services.cloud.mongodb.com`` for Sync WebSocket
   connections.
 
-Endpoints that use the ``realm.mongodb.com`` domain must migrate to use the new
-``services.cloud.mongodb.com`` domain.
+.. important:: 
+
+   :ref:`Custom HTTPS Endpoints <custom-endpoints>` and 
+   :ref:`Data API endpoints <data-api-endpoints>` are not supported 
+   in private endpoints.
+
 
 Before You Begin
 ----------------
@@ -66,6 +70,11 @@ You can add a new Private Endpoint with the App Services UI or the Admin API.
 
 You can add a new General Endpoint or a new Sync Endpoint. You can also
 migrate a Legacy Endpoint to either a new General or Sync Endpoint.
+
+.. note:: 
+   
+   Endpoints that use the ``realm.mongodb.com`` domain must migrate to use the new
+   ``services.cloud.mongodb.com`` domain.
 
 Add a General Endpoint
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -333,21 +342,6 @@ Every Sync Endpoint must be paired with a General Endpoint.
                   }'
             #. You must also create a General Private Endpoint by following the
                steps for creating a General Private Endpoint on this page.
-
-Migrate a Legacy Endpoint
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you have an endpoint that uses the legacy ``realm.mongodb.com`` domain, you
-must migrate it to use the ``services.cloud.mongodb.com`` domain. You can't
-create new legacy endpoints.
-
-**To migrate a Legacy Endpoint:** 
-
-#. Following the procedures on this page, create new VPC endpoints to replace
-   existing VPC endpoints
-#. Update Atlas Device SDK to a :ref:`version that supports the new domain 
-   <domain-migration-sdk-versions>`
-#. Update client API calls to use new services domain
 
 .. _change_access_restrictions:
 


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-41041

- [Use a VPC Private Endpoint (Preview)](https://preview-mongodbmongocaleb.gatsbyjs.io/atlas-app-services/DOCSP-41041/security/private-endpoints/#migrate-a-legacy-endpoint): Remove guidance on migrating to http endpoints and data api
- [Custom HTTPS Endpoints](https://preview-mongodbmongocaleb.gatsbyjs.io/atlas-app-services/DOCSP-41041/data-api/custom-endpoints/#std-label-custom-endpoints): add note.
- [Data API Endpoints](https://preview-mongodbmongocaleb.gatsbyjs.io/atlas-app-services/DOCSP-41041/data-api/generated-endpoints/#std-label-data-api-endpoints): add note.

### Release Notes
- **Private Endpoints**
  - Private endpoints do not support HTTPS Endpoints or the Data API. 