### PR TITLE
add note about UI-downloaded zip not working (always) on windows

### DIFF
--- a/source/includes/note-windows-zip.rst
+++ b/source/includes/note-windows-zip.rst
@@ -1,0 +1,5 @@
+.. note::
+
+   The default Windows ZIP utility may show the .zip file as empty. If you 
+   encounter this, use one of the third-party zip programs that are 
+   available. 

--- a/source/tutorial/dotnet.txt
+++ b/source/tutorial/dotnet.txt
@@ -101,6 +101,8 @@ on it.
       instructions to get the client code. For this tutorial, select the 
       :guilabel:`C# (.NET MAUI)` client code.
 
+      .. include:: /includes/note-windows-zip.rst
+
    .. tab:: App Services CLI
       :tabid: cli
 

--- a/source/tutorial/flutter.txt
+++ b/source/tutorial/flutter.txt
@@ -109,6 +109,8 @@ on it.
 
       Unzip the downloaded app, and you will see the Flutter app.
 
+      .. include:: /includes/note-windows-zip.rst
+
    .. tab:: App Services CLI
       :tabid: cli
 

--- a/source/tutorial/kotlin.txt
+++ b/source/tutorial/kotlin.txt
@@ -96,6 +96,8 @@ on it.
       instructions to get the client code. For this tutorial, select the 
       :guilabel:`Kotlin (Android)` client code.
 
+      .. include:: /includes/note-windows-zip.rst
+
    .. tab:: App Services CLI
       :tabid: cli
 

--- a/source/tutorial/react-native.txt
+++ b/source/tutorial/react-native.txt
@@ -100,6 +100,8 @@ on it.
       instructions to get the client code. For this tutorial, select the 
       :guilabel:`JavaScript (React Native)` client code.
 
+      .. include:: /includes/note-windows-zip.rst
+
    .. tab:: App Services CLI
       :tabid: cli
 

--- a/source/tutorial/swiftui.txt
+++ b/source/tutorial/swiftui.txt
@@ -97,6 +97,8 @@ on it.
       instructions to get the client code. For this tutorial, select the 
       :guilabel:`SwiftUI (iOS + SwiftUI)` client code.
 
+      .. include:: /includes/note-windows-zip.rst
+
    .. tab:: App Services CLI
       :tabid: cli
 


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-36897

- [.Net Tutorial](https://deploy-preview-794--app-services.netlify.app/tutorial/dotnet/): Add note
- [Flutter Tutorial](https://deploy-preview-794--app-services.netlify.app/tutorial/flutter/): Add note
- [Kotlin Tutorial](https://deploy-preview-794--app-services.netlify.app/tutorial/kotlin/): Add note
- [React Native Tutorial](https://deploy-preview-794--app-services.netlify.app/tutorial/react-native/): Add note
- [Swift Tutorial](https://deploy-preview-794--app-services.netlify.app/tutorial/swiftui/): Add note

### Release Notes

- **Downloaded ZIP might not open in Windows**
  - When downloading the .zip file for a tutorial from the UI, the default Windows zip utility might not work. Use a third-party tool to unzip the file. 