### PR TITLE
DOCS-16807 fixed typo and added metadata

### DIFF
--- a/source/sync/app-builder/device-sync-permissions-guide.txt
+++ b/source/sync/app-builder/device-sync-permissions-guide.txt
@@ -6,6 +6,13 @@ Device Sync Permissions Guide
 
 .. default-domain:: mongodb
 
+.. meta:: 
+  :description: Learn how to configure the different permissions available to your users using Device Sync.
+
+.. facet::
+  :name: genre
+  :values: tutorial
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -432,7 +439,7 @@ Note that this function will run under System authentication and writes to the
 custom user data. When using custom user data for permissions, clients must
 never be allowed to directly edit custom user data. Otherwise, any user could
 grant themselves any permissions. Instead, modify user data on the backend with
-a System function. The function should do whatever checks necessary to ensure
+a System function. The function should do whatever checks are necessary to ensure
 the user's request for permissions is valid.
 
 To create the function, follow these steps:

--- a/source/sync/app-builder/device-sync-permissions-guide.txt
+++ b/source/sync/app-builder/device-sync-permissions-guide.txt
@@ -4,12 +4,14 @@
 Device Sync Permissions Guide
 =============================
 
-.. default-domain:: mongodb
-
 .. meta:: 
   :description: Learn how to configure the different permissions available to your users using Device Sync.
   :keywords: code example
 
+.. facet::
+   :name: programming_language
+   :values: javascript/typescript
+   
 .. facet::
   :name: genre
   :values: tutorial

--- a/source/sync/app-builder/device-sync-permissions-guide.txt
+++ b/source/sync/app-builder/device-sync-permissions-guide.txt
@@ -8,6 +8,7 @@ Device Sync Permissions Guide
 
 .. meta:: 
   :description: Learn how to configure the different permissions available to your users using Device Sync.
+  :keywords: code example
 
 .. facet::
   :name: genre


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCS-16807

- [Device Sync Permissions Guide](https://preview-mongodbosharafmdb.gatsbyjs.io/atlas-app-services/DOCSP-16807-typo-create-subscribetouser/sync/app-builder/device-sync-permissions-guide/#create-subscribetouser-function): fixed a typo and added metadata

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [N/A] Create a Jira ticket for related docs-realm work, if any

### Release Notes

- **Device Sync**
  - App Builder's Resources/Device Sync Permissions Guide: Fix a typo under "Create subscribeToUser Function" and add metadata to the page.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
