### PR TITLE
Adds github action to generate preview links in PR description

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,8 @@
 
 Jira ticket: https://jira.mongodb.org/browse/DOCSP-NNNNN
 
-- [PAGE_NAME](https://docs-atlas-staging.mongodb.com/atlas-app-services/docsworker-xlarge/BRANCH_NAME/): description of changes
+### Staging Links
+<!-- start insert-links --><!-- end insert-links -->
 
 ### Reminder Checklist
 

--- a/.github/workflows/add-netlify-links.yml
+++ b/.github/workflows/add-netlify-links.yml
@@ -1,0 +1,62 @@
+name: Add Netlify Links To Changed Pages
+on:
+    workflow_call:
+    pull_request:
+jobs:
+    get-pr-changes:
+        name: Get Changed Files
+        runs-on: ubuntu-latest
+        permissions:
+            issues: write
+            contents: write
+            pull-requests: write
+            repository-projects: write
+        outputs:
+            staging_links: ${{ steps.build_page_links.outputs.staging_links }}
+        steps:
+          - uses: actions/checkout@v4
+          - name: Get changed files
+            id: changed-files
+            uses: tj-actions/changed-files@v44
+            with:
+              separator: ","
+              files: source/**
+          - name: Build Netlify Links for Changed Pages
+            id: build_page_links
+            run: |
+              new_links=""
+              base_link='https://deploy-preview-${{ github.event.number }}--app-services.netlify.app'
+              changed_files=${{ steps.changed-files.outputs.all_changed_files }}
+              files=$(echo $changed_files | tr "," "\n")
+              for file in $files; do
+                echo "processing ${file}"
+                if (! grep -s "includes/"  <<< $file) && 
+                    (! grep -s "images/"  <<< $file) && 
+                    (! grep -s "examples/"  <<< $file); then
+                  file="${file#source}"
+                  file="${file%.txt}"
+                  echo "${base_link}${file}"
+                  new_links+="<br/> - ${base_link}${file}"
+                else
+                  echo "(file skipped)"
+                fi
+              done
+              echo "Final new_links string: "
+              echo "${new_links}"
+              echo "staging_links=${new_links}" >> "$GITHUB_OUTPUT"
+    update-pr-description:
+        name: Update the PR Description
+        needs: get-pr-changes
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Debug
+              id: parser
+              run: |
+                echo "${{ needs.get-pr-changes.outputs.staging_links }}"
+            - name: Update PR Description
+              uses: nefrob/pr-description@v1.1.2
+              with:
+                  regex: "<!-- start insert-links -->.*?<!-- end insert-links -->"
+                  content: ${{ needs.get-pr-changes.outputs.staging_links }}
+                  token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-netlify-links.yml
+++ b/.github/workflows/add-netlify-links.yml
@@ -41,6 +41,9 @@ jobs:
                   echo "(file skipped)"
                 fi
               done
+              if (${new_links} == ""); then
+                new_links = " - "
+              fi
               echo "Final new_links string: "
               echo "${new_links}"
               echo "staging_links=${new_links}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/add-netlify-links.yml
+++ b/.github/workflows/add-netlify-links.yml
@@ -42,7 +42,7 @@ jobs:
                 fi
               done
               if [ "$new_links" == "" ]; then
-                new_links = " - "
+                $new_links = " - "
               fi
               echo "Final new_links string: "
               echo "${new_links}"

--- a/.github/workflows/add-netlify-links.yml
+++ b/.github/workflows/add-netlify-links.yml
@@ -41,7 +41,7 @@ jobs:
                   echo "(file skipped)"
                 fi
               done
-              if (${new_links} == ""); then
+              if [ "$new_links" == "" ]; then
                 new_links = " - "
               fi
               echo "Final new_links string: "

--- a/.github/workflows/add-netlify-links.yml
+++ b/.github/workflows/add-netlify-links.yml
@@ -42,7 +42,7 @@ jobs:
                 fi
               done
               if [ "$new_links" == "" ]; then
-                new_links=" - "
+                new_links="No pages to preview"
               fi
               echo "Final new_links string: "
               echo "${new_links}"

--- a/.github/workflows/add-netlify-links.yml
+++ b/.github/workflows/add-netlify-links.yml
@@ -42,7 +42,7 @@ jobs:
                 fi
               done
               if [ "$new_links" == "" ]; then
-                $new_links = " - "
+                new_links=" - "
               fi
               echo "Final new_links string: "
               echo "${new_links}"


### PR DESCRIPTION
## Pull Request Info

Adds github action to generate preview links in PR description. Updated the template to provide a placeholder for regex to match again (and know where to insert links).
This Action does **not** build links for files in /source/examples, /source/includes, or /source/images.

### Future work:
- If there is an include, provide links to pages that contain that include
- same with an image

 - No pages to preview