### PR TITLE
(DOCSP-37204): Remove 'frontend' from template app tutorial instructions

### DIFF
--- a/source/tutorial/kotlin.txt
+++ b/source/tutorial/kotlin.txt
@@ -140,8 +140,7 @@ Set up the Template App
 
    .. step:: Open the App
 
-      In Android Studio, open the ``kotlin.todo.flex`` folder located in the
-      ``frontend`` folder of the template app. 
+      In Android Studio, open the ``kotlin.todo.flex`` folder. 
 
       If you downloaded the client as a ``.zip`` file or cloned the client 
       GitHub repository, you must manually insert the App Services App ID 

--- a/source/tutorial/react-native.txt
+++ b/source/tutorial/react-native.txt
@@ -151,7 +151,7 @@ computer:
 
       In your terminal, go to the directory that contains the client code. If you
       created the app with the App Services CLI, go to 
-      ``MyTutorialApp/frontend/react-native.todo.flex``.
+      ``MyTutorialApp/react-native.todo.flex``.
       Otherwise, go to the root of your downloaded or cloned project. Then 
       run following commands to navigate to install the app's dependencies:
 


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-37204

### Staging Links
<!-- start insert-links -->
<li><a href=https://deploy-preview-830--app-services.netlify.app/tutorial/kotlin>tutorial/kotlin</a></li><li><a href=https://deploy-preview-830--app-services.netlify.app/tutorial/react-native>tutorial/react-native</a></li>
<!-- end insert-links -->

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [ ] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-realm work, if any

### Release Notes

- **Tutorials**
  - Kotlin & React Native: Remove `frontend` from instructions about finding the client code, as the path no longer includes a `frontend` directory.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
