### PR TITLE
DOCSP-42889 CLI v2.0.0 updates w/ GraphQL deprecation

### DIFF
--- a/source/cli/appservices-logs-list.txt
+++ b/source/cli/appservices-logs-list.txt
@@ -14,7 +14,7 @@ appservices logs list
 
 Lists the Logs in your app (alias: ls)
 
-Displays a list of your app’s Logs sorted by recentness, with most recent Logs
+Displays a list of your app's Logs sorted by recentness, with most recent Logs
 appearing towards the bottom. You can specify a "--tail" flag to monitor your
 Logs and follow any newly created Logs in real-time.
 
@@ -50,7 +50,7 @@ Options
    * - --type
      - Set
      - false
-     - Specify the type(s) of logs to list (Default value: <none>; Allowed values: <none>, "auth", "function", "push", "service", "trigger", "graphql", "sync", "schema", "trigger_error_handler", "log_forwarder", "endpoint") This value defaults to [].
+     - Specify the type(s) of logs to list (Default value: <none>; Allowed values: <none>, "auth", "function", "push", "service", "trigger", [DEPRECATED] "graphql", "sync", "schema", "trigger_error_handler", "log_forwarder", "endpoint") This value defaults to [].
    * - --errors
      - 
      - false
@@ -58,11 +58,11 @@ Options
    * - --start
      - Date
      - false
-     - Specify when to begin listing logs (Allowed format: 2006-01-02[T15:04:05.000-0700]) [`Learn more <https://www.mongodb.com/docs/atlas/app-services/logs/cli/#view-logs-for-a-date-range>`__]
+     - Specify when to begin listing logs (Allowed format: 2006-01-02[T15:04:05.000-0700]) [Learn more: https://www.mongodb.com/docs/atlas/app-services/logs/cli/#view-logs-for-a-date-range]
    * - --end
      - Date
      - false
-     - Specify when to finish listing logs (Allowed format: 2006-01-02[T15:04:05.000-0700]) [`Learn more <https://www.mongodb.com/docs/atlas/app-services/logs/cli/#view-logs-for-a-date-range>`__]
+     - Specify when to finish listing logs (Allowed format: 2006-01-02[T15:04:05.000-0700]) [Learn more: https://www.mongodb.com/docs/atlas/app-services/logs/cli/#view-logs-for-a-date-range]
    * - --tail
      - 
      - false
@@ -86,7 +86,7 @@ Inherited Options
    * - --profile
      - string
      - false
-     - Specify your profile (Default value: "default") [`Learn more <https://www.mongodb.com/docs/atlas/app-services/cli/#cli-profiles>`__]
+     - Specify your profile (Default value: "default") [Learn more: https://www.mongodb.com/docs/atlas/app-services/cli/#cli-profiles]
    * - --telemetry
      - string
      - false

--- a/source/cli/appservices-logs-list.txt
+++ b/source/cli/appservices-logs-list.txt
@@ -58,11 +58,11 @@ Options
    * - --start
      - Date
      - false
-     - Specify when to begin listing logs (Allowed format: 2006-01-02[T15:04:05.000-0700]) [Learn more: https://www.mongodb.com/docs/atlas/app-services/logs/cli/#view-logs-for-a-date-range]
+     - Specify when to begin listing logs (Allowed format: 2006-01-02[T15:04:05.000-0700]) [`Learn more <https://www.mongodb.com/docs/atlas/app-services/logs/cli/#view-logs-for-a-date-range>`__]
    * - --end
      - Date
      - false
-     - Specify when to finish listing logs (Allowed format: 2006-01-02[T15:04:05.000-0700]) [Learn more: https://www.mongodb.com/docs/atlas/app-services/logs/cli/#view-logs-for-a-date-range]
+     - Specify when to finish listing logs (Allowed format: 2006-01-02[T15:04:05.000-0700]) [`Learn more <https://www.mongodb.com/docs/atlas/app-services/logs/cli/#view-logs-for-a-date-range>`__]
    * - --tail
      - 
      - false

--- a/source/cli/appservices-logs-list.txt
+++ b/source/cli/appservices-logs-list.txt
@@ -86,7 +86,7 @@ Inherited Options
    * - --profile
      - string
      - false
-     - Specify your profile (Default value: "default") [Learn more: https://www.mongodb.com/docs/atlas/app-services/cli/#cli-profiles]
+     - Specify your profile (Default value: "default") [`Learn more <https://www.mongodb.com/docs/atlas/app-services/cli/#cli-profiles>`__]
    * - --telemetry
      - string
      - false

--- a/source/cli/appservices-logs-list.txt
+++ b/source/cli/appservices-logs-list.txt
@@ -50,7 +50,7 @@ Options
    * - --type
      - Set
      - false
-     - Specify the type(s) of logs to list (Default value: <none>; Allowed values: <none>, "auth", "function", "push", "service", "trigger", [DEPRECATED] "graphql", "sync", "schema", "trigger_error_handler", "log_forwarder", "endpoint") This value defaults to [].
+     - Specify the type(s) of logs to list (Default value: <none>; Allowed values: <none>, "auth", "function", "push", "service", "trigger", "graphql" [DEPRECATED], "sync", "schema", "trigger_error_handler", "log_forwarder", "endpoint") This value defaults to [].
    * - --errors
      - 
      - false

--- a/source/cli/appservices-pull.txt
+++ b/source/cli/appservices-pull.txt
@@ -66,7 +66,7 @@ Options
    * - -t, --template
      - strings
      - false
-     - Specify the frontend Template ID(s) to pull. (Note: Specified templates must be compatible with the remote app) [Learn more: https://www.mongodb.com/docs/atlas/app-services/reference/template-apps/#template-apps-available]
+     - Specify the frontend Template ID(s) to pull. (Note: Specified templates must be compatible with the remote app) [`Learn more <https://www.mongodb.com/docs/atlas/app-services/reference/template-apps/#template-apps-available>`__]
    * - --project
      - string
      - false
@@ -90,7 +90,7 @@ Inherited Options
    * - --profile
      - string
      - false
-     - Specify your profile (Default value: "default") [Learn more: https://www.mongodb.com/docs/atlas/app-services/cli/#cli-profiles]
+     - Specify your profile (Default value: "default") [`Learn more <https://www.mongodb.com/docs/atlas/app-services/cli/#cli-profiles>`__]
    * - --telemetry
      - string
      - false

--- a/source/cli/appservices-pull.txt
+++ b/source/cli/appservices-pull.txt
@@ -55,7 +55,7 @@ Options
      - 
      - false
      - Pull and include app dependencies from a package.json file
-   * - -s, --include-hosting
+   * - -s, --include-hosting [DEPRECATED]
      - 
      - false
      - Pull and include app hosting files
@@ -66,7 +66,7 @@ Options
    * - -t, --template
      - strings
      - false
-     - Specify the frontend Template ID(s) to pull. (Note: Specified templates must be compatible with the remote app) [`Learn more <https://www.mongodb.com/docs/atlas/app-services/reference/template-apps/#template-apps-available>`__]
+     - Specify the frontend Template ID(s) to pull. (Note: Specified templates must be compatible with the remote app) [Learn more: https://www.mongodb.com/docs/atlas/app-services/reference/template-apps/#template-apps-available]
    * - --project
      - string
      - false
@@ -90,7 +90,7 @@ Inherited Options
    * - --profile
      - string
      - false
-     - Specify your profile (Default value: "default") [`Learn more <https://www.mongodb.com/docs/atlas/app-services/cli/#cli-profiles>`__]
+     - Specify your profile (Default value: "default") [Learn more: https://www.mongodb.com/docs/atlas/app-services/cli/#cli-profiles]
    * - --telemetry
      - string
      - false

--- a/source/cli/appservices-push.txt
+++ b/source/cli/appservices-push.txt
@@ -57,11 +57,11 @@ Options
      - 
      - false
      - Push and include app dependencies from a package.json file
-   * - -s, --include-hosting
+   * - -s, --include-hosting [DEPRECATED]
      - 
      - false
      - Push and include app hosting files
-   * - -c, --reset-cdn-cache
+   * - -c, --reset-cdn-cache [DEPRECATED]
      - 
      - false
      - Reset the hosting CDN cache of an app
@@ -96,7 +96,7 @@ Inherited Options
    * - --profile
      - string
      - false
-     - Specify your profile (Default value: "default") [`Learn more <https://www.mongodb.com/docs/atlas/app-services/cli/#cli-profiles>`__]
+     - Specify your profile (Default value: "default") [Learn more: https://www.mongodb.com/docs/atlas/app-services/cli/#cli-profiles]
    * - --telemetry
      - string
      - false

--- a/source/cli/appservices-push.txt
+++ b/source/cli/appservices-push.txt
@@ -96,7 +96,7 @@ Inherited Options
    * - --profile
      - string
      - false
-     - Specify your profile (Default value: "default") [Learn more: https://www.mongodb.com/docs/atlas/app-services/cli/#cli-profiles]
+     - Specify your profile (Default value: "default") [`Learn more <https://www.mongodb.com/docs/atlas/app-services/cli/#cli-profiles>`__]
    * - --telemetry
      - string
      - false


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-42889

### Staging Links
<!-- start insert-links -->
<li><a href=https://deploy-preview-834--app-services.netlify.app/cli/appservices-logs-list>cli/appservices-logs-list</a></li><li><a href=https://deploy-preview-834--app-services.netlify.app/cli/appservices-pull>cli/appservices-pull</a></li><li><a href=https://deploy-preview-834--app-services.netlify.app/cli/appservices-push>cli/appservices-push</a></li>
<!-- end insert-links -->

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - programming_language
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-realm work, if any

### Release Notes

<!--
- **Define Data Access Permissions**
  - Data Access Role Examples: Update CRUD Permissions example screenshots and
    copyable JSON
-->

- Reference
  - App Services CLI: Update cli references for v2.0.0. Includes deprecation notes on the following flags for commands affected by GraphQL and Static Hosting deprecation:
    - `logs list`: `--type`
    - `pull`: `-s, --include-hosting`
    - `push`: `-s, --include-hosting`, `-c, --reset-cdn-cache`

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
