### PR TITLE
Add Neurelo as GraphQL migration option

### DIFF
--- a/source/graphql.txt
+++ b/source/graphql.txt
@@ -26,6 +26,7 @@ Atlas GraphQL API [Deprecated]
    Migrate to Hasura </graphql/migrate-hasura>
    Migrate to Apollo </graphql/migrate-apollo>
    Migrate to WunderGraph </graphql/migrate-wundergraph>
+   Migrate to Neurelo </graphql/migrate-neurelo>
 
 .. banner::
    :variant:  warning

--- a/source/graphql/migrate-neurelo.txt
+++ b/source/graphql/migrate-neurelo.txt
@@ -1,0 +1,32 @@
+.. _migrate-neurelo:
+
+==========================
+Migrate GraphQL to Neurelo
+==========================
+
+.. meta::
+  :description: Learn how to migrate your GraphQL host from Atlas App Services to Neurelo.
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Neurelo is a platform for developers designed to simplify the process of working
+with databases. It provides a powerful database abstraction with API-first
+approach, instantly transforming databases into REST and GraphQL APIs.
+
+Neurelo offers features such as building and managing schemas with
+Text-to-Schema support, fully-documented REST and GraphQL APIs (with SDKs)
+generated from your schema with an API  playground, custom API endpoints for
+complex queries with Text-to-MQL support, multiple CI/CD environments,
+schema-aware mock data generation, and more.
+
+This abstraction layer enables developers to program with databases through
+APIs, simplifying communication between the application and the database, and
+making it easier and faster to integrate databases into their applications.
+
+Refer to `Neurelo GraphQL API MongoDB Atlas Migration Guide 
+<https://docs.neurelo.com/guides/mongodb-atlas-migrate-graphql-to-neurelo>`__ to
+learn more.

--- a/source/graphql/migrate-neurelo.txt
+++ b/source/graphql/migrate-neurelo.txt
@@ -14,7 +14,7 @@ Migrate GraphQL to Neurelo
    :class: singlecol
 
 Neurelo is a platform for developers designed to simplify the process of working
-with databases. It provides a powerful database abstraction with API-first
+with databases. It provides a database abstraction with API-first
 approach, instantly transforming databases into REST and GraphQL APIs.
 
 Neurelo offers features such as building and managing schemas with

--- a/source/migrate-hosting-graphql.txt
+++ b/source/migrate-hosting-graphql.txt
@@ -72,6 +72,15 @@ Federation, take a look at WunderGraph Cosmo.
 
 Refer to :ref:`Migrate GraphQL to WunderGraph <migrate-wundergraph>` for details.
 
+Neurelo
+~~~~~~~
+
+Neurelo is a platform for developers designed to simplify the process of working
+with databases. It provides a powerful database abstraction with API-first
+approach, instantly transforming databases into REST and GraphQL APIs.
+
+Refer to :ref:`Migrate GraphQL to Neurelo <migrate-neurelo>` for details.
+
 Static Hosting Providers
 ------------------------
 


### PR DESCRIPTION
This PR adds info about migrating GraphQL services to Neurelo.

### Staging Links
<!-- start insert-links -->
<li><a href=https://deploy-preview-839--app-services.netlify.app/graphql/migrate-neurelo>graphql/migrate-neurelo</a></li><li><a href=https://deploy-preview-839--app-services.netlify.app/graphql>graphql</a></li><li><a href=https://deploy-preview-839--app-services.netlify.app/migrate-hosting-graphql>migrate-hosting-graphql</a></li>
<!-- end insert-links -->

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
