### PR TITLE
(DOCSP-44484) Update 3rd party service deprecation date

### DIFF
--- a/source/data-api.txt
+++ b/source/data-api.txt
@@ -3,9 +3,9 @@
 
 .. _data-api:
 
-==============
-Atlas Data API
-==============
+===========================
+Atlas Data API [Deprecated]
+===========================
 
 .. facet::
    :name: programming_language
@@ -24,8 +24,8 @@ Atlas Data API
    :hidden:
    
    Data API and HTTPS Endpoints Deprecation </data-api/data-api-deprecation>
-   Data API Endpoints </data-api/generated-endpoints>
-   Custom HTTPS Endpoints </data-api/custom-endpoints>
+   Data API Endpoints [Deprecated] </data-api/generated-endpoints>
+   Custom HTTPS Endpoints [Deprecated] </data-api/custom-endpoints>
    Authenticate Data API Requests </data-api/authenticate>
    Data API Examples </data-api/examples>
    Data Formats </data-api/data-formats>

--- a/source/data-api/custom-endpoints.txt
+++ b/source/data-api/custom-endpoints.txt
@@ -4,9 +4,9 @@
 .. _https-endpoints:
 .. _custom-endpoints:
 
-======================
-Custom HTTPS Endpoints
-======================
+===================================
+Custom HTTPS Endpoints [Deprecated]
+===================================
 
 .. default-domain:: mongodb
 

--- a/source/data-api/generated-endpoints.txt
+++ b/source/data-api/generated-endpoints.txt
@@ -3,9 +3,9 @@
 
 .. _data-api-endpoints:
 
-==================
-Data API Endpoints
-==================
+===============================
+Data API Endpoints [Deprecated]
+===============================
 
 .. default-domain:: mongodb
 

--- a/source/includes/note-third-party-services-deprecation.rst
+++ b/source/includes/note-third-party-services-deprecation.rst
@@ -8,7 +8,7 @@
    <https-endpoints>` with no change in behavior. You should
    :ref:`migrate <convert-webhooks-to-endpoints>` existing Webhooks.
 
-   Existing services will continue to work until **November 1, 2024**.
+   Existing services will continue to work until **September 30, 2025**.
 
    Because third party services and push notifications are now deprecated, they have
    been removed by default from the App Services UI. If you need to manage an existing third party

--- a/source/index.txt
+++ b/source/index.txt
@@ -22,8 +22,6 @@ What are the Atlas Application Services?
    
    Introduction </introduction>
    Feature Deprecations </deprecation>
-   Device Sync </sync>
-   Data API </data-api>
    Functions </functions>
    Triggers </triggers>
    Develop & Deploy Apps </apps>
@@ -33,6 +31,8 @@ What are the Atlas Application Services?
    Define Data Access Permissions </rules>
    Secure Your App </security>
    Monitor App Activity </activity>
+   Device Sync [Deprecated] </sync>
+   Data API [Deprecated] </data-api>
    Reference </reference>
    Release Notes </release-notes/backend>
    Atlas Device SDK <https://mongodb.com/docs/atlas/device-sdks/>

--- a/source/sync.txt
+++ b/source/sync.txt
@@ -7,9 +7,9 @@
 
 .. _sync:
 
-=================
-Atlas Device Sync
-=================
+==============================
+Atlas Device Sync [Deprecated]
+==============================
 
 .. meta::
    :description: Atlas Device Sync is a cloud service that syncs data seamlessly between local devices and Atlas.


### PR DESCRIPTION
## Pull Request Info

Update third-party service deprecation date to match HTTPS Endpoints deprecation date. Also, add some deprecation labels to top-level pages to help make it clearer at a glance what is deprecated.

Jira ticket: https://jira.mongodb.org/browse/DOCSP-44484

### Staging Links
<!-- start insert-links -->
<li><a href=https://deploy-preview-867--app-services.netlify.app/data-api>data-api</a></li><li><a href=https://deploy-preview-867--app-services.netlify.app/data-api/custom-endpoints>data-api/custom-endpoints</a></li><li><a href=https://deploy-preview-867--app-services.netlify.app/data-api/generated-endpoints>data-api/generated-endpoints</a></li><li><a href=https://deploy-preview-867--app-services.netlify.app/index>index</a></li><li><a href=https://deploy-preview-867--app-services.netlify.app/sync>sync</a></li>
<!-- end insert-links -->

- [Third-party service](https://deploy-preview-867--app-services.netlify.app/services/call-a-service-action/). Each of the pages in this section have an important note about the deprecation. The date in the deprecation note has been updated.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-app-services/blob/master/REVIEWING.md)
