### PR TITLE
DOCSP-46649: Update EOL date for GraphQL and Static Hosting

### DIFF
--- a/source/deprecation.txt
+++ b/source/deprecation.txt
@@ -27,8 +27,8 @@ Previously Deprecated Services
 ------------------------------
 
 As of March 12, 2024, GraphQL and Static Hosting are deprecated for Atlas App
-Services. GraphQL and Static Hosting services will be discontinued on
-**March 12, 2025**.
+Services. GraphQL and Static Hosting services will be discontinued and removed on
+**September 30, 2025**.
 
 To learn more about these deprecations, refer to the :ref:`Migrate Static
 Hosting and GraphQL From App Services page <migrate-hosting-graphql>`.

--- a/source/graphql/migrate-apollo.txt
+++ b/source/graphql/migrate-apollo.txt
@@ -62,7 +62,7 @@ following steps:
       Once you have verified that your GraphQL API endpoints are fully migrated
       and operational on Apollo Server, you can delete your MongoDB Atlas App
       Services app to avoid unnecessary costs. As a reminder, Atlas GraphQL
-      endpoints will no longer be supported beginning March 12, 2025.
+      endpoints will no longer be supported beginning September 30, 2025.
 
 Next Steps
 ----------

--- a/source/graphql/migrate-hasura.txt
+++ b/source/graphql/migrate-hasura.txt
@@ -191,4 +191,4 @@ Shut down MongoDB Atlas App Services Endpoints
 Once you have verified that your GraphQL API endpoints are fully migrated
 and operational on Hasura, you can delete your MongoDB Atlas App
 Services app to avoid unnecessary costs. As a reminder, Atlas GraphQL
-endpoints will no longer be supported beginning March 12, 2025.
+endpoints will no longer be supported beginning September 30, 2025.

--- a/source/graphql/migrate-wundergraph.txt
+++ b/source/graphql/migrate-wundergraph.txt
@@ -186,7 +186,7 @@ your project and the technologies used.
       Once you have verified that your GraphQL API endpoints are fully migrated
       and operational on WunderGraph, you can delete your MongoDB Atlas App
       Services app to avoid unnecessary costs. As a reminder, Atlas GraphQL
-      endpoints will no longer be supported beginning **March 12, 2025**.
+      endpoints will no longer be supported beginning **September 30, 2025**.
 
 Next Steps
 ----------

--- a/source/hosting/migrate-blob.txt
+++ b/source/hosting/migrate-blob.txt
@@ -59,7 +59,7 @@ below to migrate from using Atlas Hosting to using your own S3 bucket.
       Once you have verified that your files deploy successfully to your S3
       bucket, delete your hosted files from your Atlas App Services app.
       As a reminder, hosting domains on Atlas App Services will no longer run
-      starting on March 12, 2025.
+      starting on September 30, 2025.
 
 Access S3 Bucket from Atlas Functions
 -------------------------------------

--- a/source/hosting/migrate-netlify.txt
+++ b/source/hosting/migrate-netlify.txt
@@ -160,7 +160,7 @@ your site manually <https://docs.netlify.com/cli/get-started/#manual-deploys>`__
       Once you have verified that your application deploys successfully to
       Netlify, delete your hosted files from your Atlas App Services app.
       As a reminder, hosting domains on Atlas App Services will no longer run
-      starting on March 12, 2025.
+      starting on September 30, 2025.
 
 Next Steps
 ----------

--- a/source/hosting/migrate-vercel.txt
+++ b/source/hosting/migrate-vercel.txt
@@ -102,7 +102,7 @@ Vercel documentation: `Deploy from CLI <https://vercel.com/docs/cli/deploying-fr
       Once you have verified that your application deploys successfully to
       Vercel, delete your hosted files from your Atlas App Services app.
       As a reminder, hosting domains on Atlas App Services will no longer run
-      starting on March 12, 2025.
+      starting on September 30, 2025.
 
 When you create a deployment, Vercel automatically adds a new and unique
 generated URL. You can visit this URL to preview your changes in a live

--- a/source/migrate-hosting-graphql.txt
+++ b/source/migrate-hosting-graphql.txt
@@ -21,11 +21,12 @@ Migrate Static Hosting and GraphQL From App Services
 .. banner::
    :variant:  warning
 
-   GraphQL and Static Hosting are deprecated.
+   GraphQL and Static Hosting are deprecated and will be discontinued
+   on **September 30, 2025**.
 
-As of **March 12, 2024** , GraphQL and Static Hosting are deprecated for Atlas App
-Services. GraphQL and Static Hosting services will be discontinued after one
-year on March 12, 2025.
+As of March 12, 2024, GraphQL and Static Hosting are deprecated for Atlas App
+Services. GraphQL and Static Hosting services will be discontinued on September
+30, 2025.
 
 If you use GraphQL or Static Hosting, you should migrate to other providers
 before the services are discontinued. Below, you can find migration guides


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-46649

Update EOL date listed for GraphQL and Static Hosting from `March 12, 2025` to the extended date of `September 30, 2025`.

See https://github.com/10gen/baas-ui/pull/4795 for corresponding UI update.