### PR TITLE
DOCSP-49656: Add Eden to Data API Deprecation page

### DIFF
--- a/source/data-api/data-api-deprecation.txt
+++ b/source/data-api/data-api-deprecation.txt
@@ -185,6 +185,25 @@ products and features.
 Refer to Hasura's `MongoDB GraphQL API Migration Guide
 <https://hasura.io/graphql/database/mongodb>`__ to learn more.
 
+Eden
+~~~~
+
+Eden provides a unified API layer that enables applications to interact
+seamlessly with MongoDB and diverse backend systems through a single, universal
+interface. 
+By handling the underlying complexity of data infrastructure while supporting 
+distributed transactions and prepared requests across various data stores, Eden 
+empowers development teams to focus on what matters most.
+
+Unlike traditional solutions that impose restrictive abstraction layers, Eden 
+maintains native query support, allowing teams to continue leveraging their 
+existing MongoDB queries and optimizations. The platform expertly coordinates 
+multi-endpoint workflows and manages infrastructure concerns, freeing 
+engineering resources to concentrate on core application development.
+
+Refer to the official `Eden Documentation <https://www.eden.dev/mongodb>`__ to 
+learn more.
+
 Snaplogic
 ~~~~~~~~~
 

--- a/source/deprecation.txt
+++ b/source/deprecation.txt
@@ -86,13 +86,13 @@ Functions
 ~~~~~~~~~
 
 Functions will continue to be available within the context of Triggers. Use
-cases where a function was being directly accessed through a Realm SDK are
+cases where a function was being directly accessed through a Device SDK are
 impacted and must migrate to a different solution. 
 
 Wire Protocol
 ~~~~~~~~~~~~~
 
-App Services Wire Protocol is also deprecated alongside the Realm SDKs.
+App Services Wire Protocol is also deprecated alongside the Device SDKs.
 
 Data Access Permissions
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -112,4 +112,3 @@ Get Help
 
 Please contact our support team through the `MongoDB Support Portal <https://support.mongodb.com/?_ga=2.106517189.77142833.1725890426-453336878.1698066040>`__
 or your Account Executive.
-


### PR DESCRIPTION
Add Eden as listed partner solution for data api migration
- [Data API and HTTPS Endpoints Deprecation](https://deploy-preview-883--docs-app-services.netlify.app/data-api/data-api-deprecation/#eden) page

## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-49656
