### PR TITLE
DOP-5694: Add GH workflow to deploy OpenAPI docs to Bump

### DIFF
--- a/.github/workflows/generate-bump-pages-openapi-admin-v3.yml
+++ b/.github/workflows/generate-bump-pages-openapi-admin-v3.yml
@@ -1,0 +1,50 @@
+name: Check & deploy Admin API documentation
+
+on:
+  # For deployments
+  workflow_dispatch: # Allow manual trigger in case of quick fix or retrigger
+  push:
+    branches:
+      - master
+    paths:
+      - 'source/openapi-admin-v3.yaml'
+
+  # For previews
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'source/openapi-admin-v3.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-doc:
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    name: Deploy API documentation on Bump.sh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Deploy API documentation
+        uses: bump-sh/github-action@59eaae922e81ac8d127bd2b2ac6dc4804bda8a4c
+        with:
+          doc: ${{vars.ADMIN_API_V3_DOC_ID}}
+          token: ${{secrets.BUMP_TOKEN}}
+          file: source/openapi-admin-v3.yaml
+  
+  api-preview:
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Create API preview on Bump.sh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Create API preview
+        uses: bump-sh/github-action@59eaae922e81ac8d127bd2b2ac6dc4804bda8a4c
+        with:
+          doc: ${{vars.ADMIN_API_V3_DOC_ID}}
+          token: ${{secrets.BUMP_TOKEN}}
+          file: source/openapi-admin-v3.yaml
+          command: preview

--- a/.github/workflows/generate-bump-pages-openapi-data-api.yml
+++ b/.github/workflows/generate-bump-pages-openapi-data-api.yml
@@ -1,0 +1,50 @@
+name: Check & deploy Data API documentation
+
+on:
+  # For deployments
+  workflow_dispatch: # Allow manual trigger in case of quick fix or retrigger
+  push:
+    branches:
+      - master
+    paths:
+      - 'source/openapi-data-api-v1.bundled.yaml'
+
+  # For previews
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'source/openapi-data-api-v1.bundled.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-doc:
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    name: Deploy API documentation on Bump.sh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Deploy API documentation
+        uses: bump-sh/github-action@59eaae922e81ac8d127bd2b2ac6dc4804bda8a4c
+        with:
+          doc: ${{vars.DATA_API_V1_DOC_ID}}
+          token: ${{secrets.BUMP_TOKEN}}
+          file: source/openapi-data-api-v1.bundled.yaml
+  
+  api-preview:
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Create API preview on Bump.sh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Create API preview
+        uses: bump-sh/github-action@59eaae922e81ac8d127bd2b2ac6dc4804bda8a4c
+        with:
+          doc: ${{vars.DATA_API_V1_DOC_ID}}
+          token: ${{secrets.BUMP_TOKEN}}
+          file: source/openapi-data-api-v1.bundled.yaml
+          command: preview


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOP-5694

This PR introduces a GitHub actions integration for Bump.sh, the new OpenAPI spec renderer that we'll be using in place of our fork of Redoc. The goal of this is to have a simple integration that we can use to start publishing the App Services Admin API v3 and the Atlas Data API v1 specs to Bump.

The workflow allows users to use Bump to create a preview when changes to the OpenAPI spec is found. When the change is merged to the master branch, it'll allow Bump to automatically publish the latest OpenAPI spec to prod.

Bump will also print out a link to previews in the GH action logs for pull requests.

We have a similar integration set up on the old `docs-relational-migrator` repo ([PR](https://github.com/mongodb/docs-relational-migrator/pull/253)) (we'll need to do this again for the monorepo when the time comes).