### PR TITLE
DOP-5861: Create redirects for OpenAPI Redoc pages

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -312,3 +312,7 @@ raw: ${prefix}/get-started -> ${base}/tutorials/
 
 # Redirect Data API exmaples to Data API root to hide the examples page
 raw: ${prefix}/data-api/examples/ -> ${base}/data-api/
+
+# OpenAPI redirects from Redoc pages to Bump
+raw: ${prefix}/admin/api/v3 -> https://www.mongodb.com/docs/api/doc/atlas-app-services-admin-api-v3/
+raw: ${prefix}/data-api/openapi -> https://www.mongodb.com/docs/api/doc/atlas-data-api-v1/


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOP-5861

This PR creates the new redirects from the current OpenAPI pages built with Redoc to the new pages built with Bump. Ideally, this PR is merged and then re-deployed after 11am ET today to consolidate traffic to the new Bump pages. Please double-check URLs look correct.
